### PR TITLE
fix: 🐛 string slice type for ctx

### DIFF
--- a/packages/ctx/src/plugin/ctx.spec.ts
+++ b/packages/ctx/src/plugin/ctx.spec.ts
@@ -1,5 +1,6 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { describe, expect, it } from 'vitest'
+import type { SliceType } from '../context'
 import { Container, createSlice } from '../context'
 import { Clock, createTimer } from '../timer'
 import { Ctx } from './ctx'
@@ -20,8 +21,14 @@ describe('ctx', () => {
     ctx.update(sliceType, x => x + 1)
     expect(ctx.get(sliceType)).toBe(1)
 
+    ctx.update<number, 'counter'>('counter', x => x + 1)
+    expect(ctx.get(sliceType)).toBe(2)
+
     ctx.set(sliceType, 100)
     expect(ctx.get(sliceType)).toBe(100)
+
+    ctx.set<number, 'counter'>(sliceType, 200)
+    expect(ctx.get(sliceType)).toBe(200)
 
     ctx.remove(sliceType)
     expect(ctx.isInjected(sliceType)).toBeFalsy()

--- a/packages/ctx/src/plugin/ctx.ts
+++ b/packages/ctx/src/plugin/ctx.ts
@@ -53,13 +53,13 @@ export class Ctx {
     this.#container.get(sliceType)
 
   /// Get a slice value from the ctx.
-  readonly get = <T, N extends string>(sliceType: SliceType<T, N>) => this.use(sliceType).get()
+  readonly get = <T, N extends string>(sliceType: SliceType<T, N> | N) => this.use(sliceType).get()
 
   /// Get a slice value from the ctx.
-  readonly set = <T, N extends string>(sliceType: SliceType<T, N>, value: T) => this.use(sliceType).set(value)
+  readonly set = <T, N extends string>(sliceType: SliceType<T, N> | N, value: T) => this.use(sliceType).set(value)
 
   /// Update a slice value from the ctx by a callback.
-  readonly update = <T, N extends string>(sliceType: SliceType<T, N>, updater: (prev: T) => T) =>
+  readonly update = <T, N extends string>(sliceType: SliceType<T, N> | N, updater: (prev: T) => T) =>
     this.use(sliceType).update(updater)
 
   /// Get a timer from the ctx.


### PR DESCRIPTION
✅ Closes: #906

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Fix the issue that ctx won't accept string as slice type.

## How did you test this change?

Unit Test