### PR TITLE
fix: 🐛 expose styles from prosemirror packages

### DIFF
--- a/.github/workflows/ci-for-pr.yml
+++ b/.github/workflows/ci-for-pr.yml
@@ -2,6 +2,7 @@ name: On Pull Request
 
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
     branches: main
 

--- a/packages/prose/package.json
+++ b/packages/prose/package.json
@@ -61,7 +61,9 @@
     "./tables": {
       "types": "./lib/tables.d.ts",
       "import": "./lib/tables.js"
-    }
+    },
+    "./view/style/prosemirror.css": "./lib/style/prosemirror.css",
+    "./tables/style/tables.css": "./lib/style/tables.css"
   },
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/prose/rollup.config.js
+++ b/packages/prose/rollup.config.js
@@ -7,6 +7,7 @@ import json from '@rollup/plugin-json'
 import resolve from '@rollup/plugin-node-resolve'
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
+import copy from 'rollup-plugin-copy'
 
 import pkg from './package.json' assert { type: 'json' }
 
@@ -39,6 +40,18 @@ const proseModule = (name) => {
         commonjs(),
         esbuild({
           target: 'es6',
+        }),
+        copy({
+          targets: [
+            {
+              src: 'node_modules/prosemirror-view/style/prosemirror.css',
+              dest: 'lib/style',
+            },
+            {
+              src: 'node_modules/prosemirror-tables/style/tables.css',
+              dest: 'lib/style',
+            },
+          ],
         }),
       ],
     },

--- a/packages/theme-nord/package.json
+++ b/packages/theme-nord/package.json
@@ -39,8 +39,6 @@
     "@milkdown/core": "workspace:*",
     "@milkdown/ctx": "workspace:*",
     "@milkdown/prose": "workspace:*",
-    "prosemirror-tables": "^1.2.5",
-    "prosemirror-view": "^1.28.0",
     "tailwind-nord": "^1.2.0"
   },
   "nx": {

--- a/packages/theme-nord/src/index.ts
+++ b/packages/theme-nord/src/index.ts
@@ -3,8 +3,8 @@ import type { Ctx } from '@milkdown/ctx'
 import { editorViewOptionsCtx } from '@milkdown/core'
 import clsx from 'clsx'
 
-import 'prosemirror-tables/style/tables.css'
-import 'prosemirror-view/style/prosemirror.css'
+import '@milkdown/prose/view/style/prosemirror.css'
+import '@milkdown/prose/tables/style/tables.css'
 import './style.css'
 
 export const nord = (ctx: Ctx): void => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
       '@commitlint/config-conventional': 17.0.3
       '@nrwl/cli': 15.7.2
       '@nrwl/cypress': 15.7.2_fpsqvd6667tk4r5owg54wtenry
-      '@nrwl/nx-cloud': 15.0.3
+      '@nrwl/nx-cloud': 15.1.1
       '@nrwl/tao': 15.7.2
       '@nrwl/workspace': 15.7.2_s5ps7njkmjlaqajutnox5ntcla
       '@rollup/plugin-commonjs': 24.0.0_rollup@3.7.3
@@ -566,8 +566,6 @@ importers:
       '@milkdown/ctx': workspace:*
       '@milkdown/prose': workspace:*
       clsx: ^1.2.1
-      prosemirror-tables: ^1.2.5
-      prosemirror-view: ^1.28.0
       tailwind-nord: ^1.2.0
       tslib: ^2.4.0
     dependencies:
@@ -577,8 +575,6 @@ importers:
       '@milkdown/core': link:../core
       '@milkdown/ctx': link:../ctx
       '@milkdown/prose': link:../prose
-      prosemirror-tables: 1.3.2
-      prosemirror-view: 1.30.1
       tailwind-nord: 1.2.0
 
   packages/transformer:
@@ -2094,8 +2090,8 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/nx-cloud/15.0.3:
-    resolution: {integrity: sha512-KvwM8/IbCOlbWIzi+Tm14tJkEdQK3ruN6TPUmeKnkeFZsJyoFw4GCyKJMOLs8y4MQokHgskg3nbF822JLR9xJg==}
+  /@nrwl/nx-cloud/15.1.1:
+    resolution: {integrity: sha512-aIVb87PQpAjwdEaFksQ3rYgFq9MDaBG2KvYZcj/k+z2uWeWH84ha/opO37aCFLf5VXNiyJZGRb/+7vW7BFpNOw==}
     hasBin: true
     dependencies:
       axios: 0.21.4
@@ -7895,6 +7891,7 @@ packages:
 
   /orderedmap/2.0.0:
     resolution: {integrity: sha512-buf4PoAMlh45b8a8gsGy/X6w279TSqkyAS0C0wdTSJwFSU+ljQFJON5I8NfjLHoCXwpSROIo2wr0g33T+kQshQ==}
+    dev: false
 
   /os-homedir/1.0.2:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
@@ -8316,11 +8313,13 @@ packages:
     dependencies:
       prosemirror-state: 1.4.2
       w3c-keyname: 2.2.4
+    dev: false
 
   /prosemirror-model/1.19.0:
     resolution: {integrity: sha512-/CvFGJnwc41EJSfDkQLly1cAJJJmBpZwwUJtwZPTjY2RqZJfM8HVbCreOY/jti8wTRbVyjagcylyGoeJH/g/3w==}
     dependencies:
       orderedmap: 2.0.0
+    dev: false
 
   /prosemirror-schema-list/1.2.2:
     resolution: {integrity: sha512-rd0pqSDp86p0MUMKG903g3I9VmElFkQpkZ2iOd3EOVg1vo5Cst51rAsoE+5IPy0LPXq64eGcCYlW1+JPNxOj2w==}
@@ -8336,6 +8335,7 @@ packages:
       prosemirror-model: 1.19.0
       prosemirror-transform: 1.7.1
       prosemirror-view: 1.30.1
+    dev: false
 
   /prosemirror-tables/1.3.2:
     resolution: {integrity: sha512-/9JTeN6s58Zq66HXaxP6uf8PAmc7XXKZFPlOGVtLvxEd6xBP6WtzaJB9wBjiGUzwbdhdMEy7V62yuHqk/3VrnQ==}
@@ -8345,11 +8345,13 @@ packages:
       prosemirror-state: 1.4.2
       prosemirror-transform: 1.7.1
       prosemirror-view: 1.30.1
+    dev: false
 
   /prosemirror-transform/1.7.1:
     resolution: {integrity: sha512-VteoifAfpt46z0yEt6Fc73A5OID9t/y2QIeR5MgxEwTuitadEunD/V0c9jQW8ziT8pbFM54uTzRLJ/nLuQjMxg==}
     dependencies:
       prosemirror-model: 1.19.0
+    dev: false
 
   /prosemirror-view/1.30.1:
     resolution: {integrity: sha512-pZUfr7lICJkEY7XwzldAKrkflZDeIvnbfuu2RIS01N5NwJmR/dfZzDzJRzhb3SM2QtT/bM8b4Nnib8X3MGpAhA==}
@@ -8357,6 +8359,7 @@ packages:
       prosemirror-model: 1.19.0
       prosemirror-state: 1.4.2
       prosemirror-transform: 1.7.1
+    dev: false
 
   /proto-list/1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -9997,6 +10000,7 @@ packages:
 
   /w3c-keyname/2.2.4:
     resolution: {integrity: sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==}
+    dev: false
 
   /w3c-xmlserializer/4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}


### PR DESCRIPTION
✅ Closes: #911

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Expose styles for:

- `prosemirror-view/style/prosemirror.css` -> `@milkdown/prose/view/style/prosemirror.css`
- `prosemirror-tables/style/tables.css` -> `@milkdown/prose/tables/style/tables.css`

## How did you test this change?

Tested manually.