### PR TITLE
fix: add hardbreak leafText

### DIFF
--- a/packages/preset-commonmark/src/node/hardbreak.ts
+++ b/packages/preset-commonmark/src/node/hardbreak.ts
@@ -31,6 +31,7 @@ export const hardbreakSchema = $nodeSchema('hardbreak', ctx => ({
       state.addNode(type, { isInline: Boolean(node.data?.isInline) })
     },
   },
+  leafText: () => '\n',
   toMarkdown: {
     match: node => node.type.name === 'hardbreak',
     runner: (state, node) => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Add leafText for `hardbreak` node, to make `nodeContainingHardbreak.textContent` work correctly.


## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Pass all tests
