### PR TITLE
feat: 🎸 add a command to lift first list item

### DIFF
--- a/e2e/cypress/e2e/preset-gfm/input.cy.ts
+++ b/e2e/cypress/e2e/preset-gfm/input.cy.ts
@@ -11,6 +11,7 @@ it('has editor', () => {
 })
 
 describe('input:', () => {
+  const isMac = Cypress.platform === 'darwin'
   describe('task list', () => {
     it('unchecked', () => {
       cy.get('.editor').type('- [ ] task list')
@@ -54,5 +55,15 @@ describe('input:', () => {
       cy.get('.editor').get('th').should('have.length', 4)
       cy.get('.editor').get('td').should('have.length', 16)
     })
+  })
+
+  it('remove list item after table', () => {
+    cy.get('.editor').type('|1x1| ')
+    cy.get('.editor table').should('exist')
+    cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+enter}`)
+    cy.get('.editor').type('- ')
+    cy.get('.editor ul').should('exist')
+    cy.get('.editor').type('{backspace}')
+    cy.get('.editor > ul').should('not.exist')
   })
 })

--- a/packages/preset-commonmark/src/composed/commands.ts
+++ b/packages/preset-commonmark/src/composed/commands.ts
@@ -1,7 +1,23 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import type { MilkdownPlugin } from '@milkdown/ctx'
 import { toggleEmphasisCommand, toggleInlineCodeCommand, toggleLinkCommand, toggleStrongCommand, updateLinkCommand } from '../mark'
-import { createCodeBlockCommand, downgradeHeadingCommand, insertHardbreakCommand, insertHrCommand, insertImageCommand, liftListItemCommand, sinkListItemCommand, splitListItemCommand, turnIntoTextCommand, updateImageCommand, wrapInBlockquoteCommand, wrapInBulletListCommand, wrapInHeadingCommand, wrapInOrderedListCommand } from '../node'
+import {
+  createCodeBlockCommand,
+  downgradeHeadingCommand,
+  insertHardbreakCommand,
+  insertHrCommand,
+  insertImageCommand,
+  liftFirstListItemCommand,
+  liftListItemCommand,
+  sinkListItemCommand,
+  splitListItemCommand,
+  turnIntoTextCommand,
+  updateImageCommand,
+  wrapInBlockquoteCommand,
+  wrapInBulletListCommand,
+  wrapInHeadingCommand,
+  wrapInOrderedListCommand,
+} from '../node'
 
 /// @internal
 export const commands: MilkdownPlugin[] = [
@@ -21,6 +37,7 @@ export const commands: MilkdownPlugin[] = [
   sinkListItemCommand,
   splitListItemCommand,
   liftListItemCommand,
+  liftFirstListItemCommand,
 
   toggleEmphasisCommand,
   toggleInlineCodeCommand,


### PR DESCRIPTION
✅ Closes: #997

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Bind the new `liftFirstListItem` command to `Backspace` and `Delete` to avoid list items cannot be deleted in some cases.

## How did you test this change?

E2E
