### PR TITLE
feat(plugin-slash): expose trigger key

### DIFF
--- a/packages/plugin-slash/src/slash-provider.ts
+++ b/packages/plugin-slash/src/slash-provider.ts
@@ -18,6 +18,8 @@ export type SlashProviderOptions = {
   debounce?: number
   /// The function to determine whether the tooltip should be shown.
   shouldShow?: (view: EditorView, prevState?: EditorState) => boolean
+  /// The key trigger for show
+  trigger: string | string[]
 }
 
 /// A provider for creating slash.
@@ -35,6 +37,9 @@ export class SlashProvider {
   #debounce: number
 
   /// @internal
+  #trigger: string | string[]
+
+  /// @internal
   #shouldShow: (view: EditorView, prevState?: EditorState) => boolean
 
   constructor(options: SlashProviderOptions) {
@@ -42,6 +47,7 @@ export class SlashProvider {
     this.#tippyOptions = options.tippyOptions ?? {}
     this.#debounce = options.debounce ?? 200
     this.#shouldShow = options.shouldShow ?? this.#_shouldShow
+    this.#trigger = options.trigger ?? '/'
   }
 
   /// @internal
@@ -83,7 +89,12 @@ export class SlashProvider {
     if (!currentTextBlockContent)
       return false
 
-    return currentTextBlockContent.at(-1) === '/'
+    const target = currentTextBlockContent.at(-1)
+
+    if (!target)
+      return false
+
+    return Array.isArray(this.#trigger) ? this.#trigger.includes(target) : this.#trigger === target
   }
 
   /// Update provider state by editor view.

--- a/packages/plugin-slash/src/slash-provider.ts
+++ b/packages/plugin-slash/src/slash-provider.ts
@@ -18,8 +18,8 @@ export type SlashProviderOptions = {
   debounce?: number
   /// The function to determine whether the tooltip should be shown.
   shouldShow?: (view: EditorView, prevState?: EditorState) => boolean
-  /// The key trigger for show
-  trigger: string | string[]
+  /// The key trigger for shouldShow, '/' by default.
+  trigger?: string | string[]
 }
 
 /// A provider for creating slash.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

This pull request expose trigger of plugin-slash for show content not only by the '/' key. It's possible to override `shouldShow` to do this approach, but you'd end up having to rewrite other functions like `getContent()`, and this change doesn't bring any breaking changes.

## How did you test this change?

I implemented the same idea in a project by wrapping this plugin and it worked properly:

![image](https://github.com/Milkdown/milkdown/assets/41403842/ed8db073-5fa9-4c22-a1d7-80f283e2516e)

