### PR TITLE
fix: set keys of heading shortcuts correctly

### DIFF
--- a/packages/preset-commonmark/src/node/heading.ts
+++ b/packages/preset-commonmark/src/node/heading.ts
@@ -198,21 +198,21 @@ export const headingKeymap = $useKeymap('headingKeymap', {
     shortcuts: 'Mod-Alt-4',
     command: (ctx) => {
       const commands = ctx.get(commandsCtx)
-      return () => commands.call(wrapInHeadingCommand.key, 3)
+      return () => commands.call(wrapInHeadingCommand.key, 4)
     },
   },
   TurnIntoH5: {
     shortcuts: 'Mod-Alt-5',
     command: (ctx) => {
       const commands = ctx.get(commandsCtx)
-      return () => commands.call(wrapInHeadingCommand.key, 3)
+      return () => commands.call(wrapInHeadingCommand.key, 5)
     },
   },
   TurnIntoH6: {
     shortcuts: 'Mod-Alt-6',
     command: (ctx) => {
       const commands = ctx.get(commandsCtx)
-      return () => commands.call(wrapInHeadingCommand.key, 3)
+      return () => commands.call(wrapInHeadingCommand.key, 6)
     },
   },
   DowngradeHeading: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

The keys of the heading shortcuts are not set correctly.

## How did you test this change?

Automated tests.
