### PR TITLE
fix: marks won't be extended when pasting pure text

### DIFF
--- a/e2e/cypress/e2e/plugin-clipboard/plugin.cy.ts
+++ b/e2e/cypress/e2e/plugin-clipboard/plugin.cy.ts
@@ -32,12 +32,22 @@ it('paste code from vscode', () => {
   cy.get('.editor pre code').should('have.text', 'const a = 1;')
 })
 
-it('past html', () => {
+it('paste html', () => {
   cy.get('.editor').paste({ 'text/html': '<h1>The Place Where He Inserted the <strong>Blade</strong></h1>' })
   cy.get('.editor h1').should('have.text', 'The Place Where He Inserted the Blade')
   cy.get('.editor strong').should('have.text', 'Blade')
   cy.window().then((win) => {
     cy.wrap(win.__getMarkdown__())
       .should('equal', '# The Place Where He Inserted the **Blade**\n')
+  })
+})
+
+it('paste inline text only html should extend mark', () => {
+  cy.get('.editor').type('[milkdown repo](https://github.com)')
+  cy.get('.editor').type('{leftArrow}{leftArrow}{leftArrow}{leftArrow}')
+  cy.get('.editor').paste({ 'text/html': '<meta charset=\'utf-8\'><span style="color: rgb(36, 41, 47);">mono</span>' })
+  cy.window().then((win) => {
+    cy.wrap(win.__getMarkdown__())
+      .should('equal', '[milkdown monorepo](https://github.com)\n')
   })
 })

--- a/packages/plugin-clipboard/src/index.ts
+++ b/packages/plugin-clipboard/src/index.ts
@@ -26,11 +26,14 @@ const isPureText = (content: UnknownRecord | UnknownRecord[] | undefined | null)
 const isTextOnlySlice = (slice: Slice): Node | false => {
   if (slice.content.childCount === 1) {
     const node = slice.content.firstChild
-    if (node?.type.name === 'text')
+    if (node?.type.name === 'text' && node.marks.length === 0)
       return node
 
-    if (node?.type.name === 'paragraph' && node.childCount === 1 && node.firstChild?.type.name === 'text')
-      return node.firstChild
+    if (node?.type.name === 'paragraph' && node.childCount === 1) {
+      const _node = node.firstChild
+      if (_node?.type.name === 'text' && _node.marks.length === 0)
+        return _node
+    }
   }
 
   return false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Closes: https://github.com/Milkdown/milkdown/issues/1023

## How did you test this change?

E2E
