### PR TITLE
fix: 🐛 missing type error in theme-nord

### DIFF
--- a/packages/theme-nord/package.json
+++ b/packages/theme-nord/package.json
@@ -11,6 +11,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.es.js"
     },
     "./style.css": "./lib/style.css"


### PR DESCRIPTION
✅ Closes: #1075

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Fix the issue that import theme-nord will throw error in typescript.

## How did you test this change?

Manully
