### PR TITLE
fix: 🐛 theme-nord th tag fix

### DIFF
--- a/packages/theme-nord/src/style.css
+++ b/packages/theme-nord/src/style.css
@@ -42,7 +42,8 @@
   @apply text-sm shadow-md sm:rounded-lg !overflow-visible !m-4;
 }
 
-.milkdown-theme-nord.prose td, th {
+.milkdown-theme-nord.prose td,
+.milkdown-theme-nord.prose th {
   @apply !py-3 !px-6;
 }
 


### PR DESCRIPTION
-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

`th` tag was out of `.milkdown-theme-nord.prose` scope, generating unwanted side effects.

## How did you test this change?

`pnpm test` run passed

![image](https://github.com/Milkdown/milkdown/assets/1547211/1eb0e2f5-d480-48df-aabb-b8fd3e03c62f)
