### PR TITLE
feat: undo inputrule when backspace

### DIFF
--- a/e2e/cypress/e2e/preset-commonmark/input.cy.ts
+++ b/e2e/cypress/e2e/preset-commonmark/input.cy.ts
@@ -152,5 +152,12 @@ describe('input:', () => {
         cy.isMarkdown('The lunatic is `on the grass`\n')
       })
     })
+
+    it('undo input rule when press backspace', () => {
+      cy.get('.editor').type('The lunatic is *on the grass*')
+      cy.get('.editor').get('em').should('have.text', 'on the grass')
+      cy.get('.editor').type('{backspace}')
+      cy.isMarkdown('The lunatic is \\*on the grass\\*\n')
+    })
   })
 })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Undo inputrule when press `Backspace`.

## How did you test this change?

E2E