### PR TITLE
fix: 🐛 missing twemoji type

### DIFF
--- a/packages/plugin-emoji/package.json
+++ b/packages/plugin-emoji/package.json
@@ -39,7 +39,7 @@
     "node-emoji": "^2.0.0",
     "remark-emoji": "^4.0.0",
     "tslib": "^2.5.0",
-    "twemoji": "^14.0.1",
+    "twemoji": "^14.0.2",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/plugin-emoji/src/__internal__/parse.ts
+++ b/packages/plugin-emoji/src/__internal__/parse.ts
@@ -3,6 +3,8 @@ import twemoji from 'twemoji'
 
 const setAttr = (text: string) => ({ title: text })
 
+export type TwemojiOptions = Parameters<typeof twemoji.parse>[1]
+
 export function parse(emoji: string, twemojiOptions?: TwemojiOptions): string {
   return twemoji.parse(emoji, { attributes: setAttr, base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji/assets/', ...twemojiOptions }) as unknown as string
 }

--- a/packages/plugin-emoji/src/__internal__/remark-twemoji.ts
+++ b/packages/plugin-emoji/src/__internal__/remark-twemoji.ts
@@ -2,7 +2,7 @@
 import type { Node, RemarkPluginRaw } from '@milkdown/transformer'
 import emojiRegex from 'emoji-regex'
 
-import { parse } from './parse'
+import { type TwemojiOptions, parse } from './parse'
 
 const regex = emojiRegex()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,7 +529,7 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       twemoji:
-        specifier: ^14.0.1
+        specifier: ^14.0.2
         version: 14.0.2
       unist-util-visit:
         specifier: ^5.0.0


### PR DESCRIPTION
✅ Closes: #1177

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Fix missing `TwemojiOptions` type in emoji plugin.

## How did you test this change?

CI
