### PR TITLE
fix: 🐛 silent tippy warnings

### DIFF
--- a/packages/components/src/link-tooltip/edit/edit-view.ts
+++ b/packages/components/src/link-tooltip/edit/edit-view.ts
@@ -5,7 +5,7 @@ import type { PluginView } from '@milkdown/prose/state'
 import type { Mark } from '@milkdown/prose/model'
 import type { EditorView } from '@milkdown/prose/view'
 import { TooltipProvider } from '@milkdown/plugin-tooltip'
-import { editorViewCtx } from '@milkdown/core'
+import { editorViewCtx, rootDOMCtx } from '@milkdown/core'
 import { posToDOMRect } from '@milkdown/prose'
 import { linkSchema } from '@milkdown/preset-commonmark'
 import { linkTooltipConfig, linkTooltipState } from '../slices'
@@ -34,6 +34,7 @@ export class LinkEditTooltip implements PluginView {
       debounce: 0,
       shouldShow: () => false,
       tippyOptions: {
+        appendTo: () => ctx.get(rootDOMCtx),
         onHidden: () => {
           this.#content.update().catch((e) => {
             throw e

--- a/packages/components/src/link-tooltip/preview/preview-view.ts
+++ b/packages/components/src/link-tooltip/preview/preview-view.ts
@@ -4,17 +4,14 @@ import type { EditorView } from '@milkdown/prose/view'
 import type { Mark } from '@milkdown/prose/model'
 import { TooltipProvider } from '@milkdown/plugin-tooltip'
 import type { Ctx } from '@milkdown/ctx'
+import { rootDOMCtx } from '@milkdown/core'
 import type { LinkToolTipState } from '../slices'
 import { linkTooltipAPI, linkTooltipConfig, linkTooltipState } from '../slices'
 import { LinkPreviewElement } from './preview-component'
 
 export class LinkPreviewTooltip implements PluginView {
   #content = new LinkPreviewElement()
-  #provider = new TooltipProvider({
-    debounce: 0,
-    content: this.#content,
-    shouldShow: () => false,
-  })
+  #provider: TooltipProvider
 
   #hovering = false
 
@@ -23,6 +20,14 @@ export class LinkPreviewTooltip implements PluginView {
   }
 
   constructor(readonly ctx: Ctx, view: EditorView) {
+    this.#provider = new TooltipProvider({
+      debounce: 0,
+      content: this.#content,
+      shouldShow: () => false,
+      tippyOptions: {
+        appendTo: () => ctx.get(rootDOMCtx),
+      },
+    })
     this.#provider.update(view)
     ctx.use(linkTooltipState.key).on(this.#onStateChange)
   }

--- a/packages/crepe/src/feature/block-edit/handle/index.ts
+++ b/packages/crepe/src/feature/block-edit/handle/index.ts
@@ -5,7 +5,7 @@ import { BlockProvider, block } from '@milkdown/plugin-block'
 import type { Ctx } from '@milkdown/ctx'
 import type { EditorView } from '@milkdown/prose/view'
 import type { AtomicoThis } from 'atomico/types/dom'
-import { editorViewCtx } from '@milkdown/core'
+import { editorViewCtx, rootDOMCtx } from '@milkdown/core'
 import { paragraphSchema } from '@milkdown/preset-commonmark'
 import { menuAPI } from '../menu'
 import type { BlockHandleProps } from './component'
@@ -25,6 +25,7 @@ export class BlockHandleView implements PluginView {
       ctx,
       content,
       tippyOptions: {
+        appendTo: () => ctx.get(rootDOMCtx),
         onShow: () => {
           this.#content.show = true
         },

--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -5,6 +5,7 @@ import { SlashProvider, slashFactory } from '@milkdown/plugin-slash'
 import type { Ctx } from '@milkdown/ctx'
 import type { AtomicoThis } from 'atomico/types/dom'
 import { $ctx } from '@milkdown/utils'
+import { rootDOMCtx } from '@milkdown/core'
 import { isInCodeBlock, isInList } from '../../../utils'
 import type { MenuProps } from './component'
 import { MenuElement } from './component'
@@ -43,6 +44,7 @@ class MenuView implements PluginView {
       content: this.#content,
       debounce: 20,
       tippyOptions: {
+        appendTo: () => ctx.get(rootDOMCtx),
         onShow: () => {
           this.#content.show = true
         },

--- a/packages/crepe/src/feature/toolbar/index.ts
+++ b/packages/crepe/src/feature/toolbar/index.ts
@@ -5,6 +5,7 @@ import { TextSelection } from '@milkdown/prose/state'
 import type { Ctx } from '@milkdown/ctx'
 import type { EditorView } from '@milkdown/prose/view'
 import type { AtomicoThis } from 'atomico/types/dom'
+import { rootDOMCtx } from '@milkdown/core'
 import type { DefineFeature } from '../shared'
 import { injectStyle } from '../../core/slice'
 import type { ToolbarProps } from './component'
@@ -26,6 +27,7 @@ class ToolbarView implements PluginView {
       content: this.#content,
       debounce: 20,
       tippyOptions: {
+        appendTo: () => ctx.get(rootDOMCtx),
         onShow: () => {
           this.#content.show = true
         },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Add `appendTo` property for tippy options to silent the warning.


## How did you test this change?

CI
