### PR TITLE
fix: 🐛 should not throw error when emoji in code

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,6 +31,7 @@
     "@milkdown/ctx": "workspace:*",
     "@milkdown/plugin-automd": "workspace:*",
     "@milkdown/plugin-clipboard": "workspace:*",
+    "@milkdown/plugin-emoji": "workspace:*",
     "@milkdown/plugin-history": "workspace:*",
     "@milkdown/plugin-listener": "workspace:*",
     "@milkdown/plugin-math": "workspace:*",

--- a/e2e/src/plugin-emoji/main.stories.ts
+++ b/e2e/src/plugin-emoji/main.stories.ts
@@ -1,0 +1,63 @@
+/* Copyright 2021, Milkdown by Mirone. */
+import type { Meta, StoryObj } from '@storybook/html'
+import { Editor, defaultValueCtx, rootCtx } from '@milkdown/core'
+import { nord } from '@milkdown/theme-nord'
+import { commonmark } from '@milkdown/preset-commonmark'
+import { history } from '@milkdown/plugin-history'
+import { emoji } from '@milkdown/plugin-emoji'
+
+import '@milkdown/theme-nord/style.css'
+
+import '../style.css'
+
+interface Args {
+  enableInspector: boolean
+  defaultValue: string
+  instance: Editor
+}
+
+const meta: Meta<Args> = {
+  title: 'Emoji/Main',
+}
+
+export default meta
+
+type Story = StoryObj<Args>
+
+export const Empty: Story = {
+  render: (args) => {
+    const root = document.createElement('div')
+    const editor = Editor.make()
+      .enableInspector(args.enableInspector ?? false)
+      .config((ctx) => {
+        ctx.set(defaultValueCtx, args.defaultValue ?? '')
+        ctx.set(rootCtx, root)
+      })
+      .config(nord)
+      .use(commonmark)
+      .use(history)
+      .use(emoji)
+      .create()
+
+    editor.then((instance) => {
+      args.instance = instance
+    })
+
+    return root
+  },
+}
+
+const defaultValue = `
+# Milkdown
+
+🫥
+
+:+1:
+`
+
+export const WithDefaultValue: Story = {
+  ...Empty,
+  args: {
+    defaultValue: defaultValue.trim(),
+  },
+}

--- a/e2e/src/preset-commonmark/commands.stories.ts
+++ b/e2e/src/preset-commonmark/commands.stories.ts
@@ -61,7 +61,7 @@ export const ToggleStrong: Story = {
 
     await expect(args.instance.action(getMarkdown())).toContain(`**${text}**`)
 
-    const strong = canvasElement.querySelector('strong')
+    const strong = canvasElement.querySelector('strong') ?? undefined
 
     await expect(strong).toHaveTextContent(text)
     await userEvent.pointer([{ target: strong, offset: 0, keys: '[MouseLeft>]' }, { offset: text.length }])
@@ -91,7 +91,7 @@ export const ToggleItalic: Story = {
 
     await expect(args.instance.action(getMarkdown())).toContain(`*${text}*`)
 
-    const em = canvasElement.querySelector('em')
+    const em = canvasElement.querySelector('em') ?? undefined
 
     await expect(em).toHaveTextContent(text)
     await userEvent.pointer([{ target: em, offset: 0, keys: '[MouseLeft>]' }, { offset: text.length }])

--- a/e2e/src/style.css
+++ b/e2e/src/style.css
@@ -20,3 +20,11 @@ input:focus {
   outline: none;
   box-shadow: none;
 }
+
+span[data-type='emoji'] {
+  @apply inline-block;
+}
+
+span[data-type='emoji'] .emoji {
+  @apply w-4;
+}

--- a/packages/plugin-emoji/src/__internal__/remark-twemoji.ts
+++ b/packages/plugin-emoji/src/__internal__/remark-twemoji.ts
@@ -41,6 +41,10 @@ export const twemojiPlugin: RemarkPluginRaw<TwemojiOptions> = (twemojiOptions) =
       if (!isLiteral(node))
         return [node]
 
+      // Should not convert code block
+      if (node.type === 'code')
+        return [node]
+
       const value = node.value
       const output: Array<Node & { value: string }> = []
       let match

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       '@milkdown/plugin-clipboard':
         specifier: workspace:*
         version: link:../packages/plugin-clipboard
+      '@milkdown/plugin-emoji':
+        specifier: workspace:*
+        version: link:../packages/plugin-emoji
       '@milkdown/plugin-history':
         specifier: workspace:*
         version: link:../packages/plugin-history


### PR DESCRIPTION
✅ Closes: #1264

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## How did you test this change?

CI
