### PR TITLE
fix(plugin-block): fix mouse move debouncing does not work

### DIFF
--- a/packages/plugin-block/src/block-service.ts
+++ b/packages/plugin-block/src/block-service.ts
@@ -166,7 +166,7 @@ export class BlockService {
   }
 
   /// @internal
-  #mousemoveCallback = (view: EditorView, event: MouseEvent) => {
+  #mousemoveCallback = debounce((view: EditorView, event: MouseEvent) => {
     if (!view.editable)
       return
 
@@ -192,14 +192,14 @@ export class BlockService {
       return
     }
     this.#show(result)
-  }
+  }, 20)
 
   /// @internal
   mousemoveCallback = (view: EditorView, event: MouseEvent) => {
     if (view.composing || !view.editable)
       return false
 
-    debounce(this.#mousemoveCallback, 20)(view, event)
+    this.#mousemoveCallback(view, event)
 
     return false
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

The lodash.debounce function creates a wrapped function, and if you recreate the wrapped function each time, debounce will not take effect.

The following sample code briefly explains how it works, you can see that the timerId is saved in the context of the debounce function, you need to save it to achieve the debounce effect, if you call the lodash.debounce function every time, it will always be the initial value.

```javascript
function debounce(fn, wait = 500) {
  let timerId;
  return (...args) => {
    clearTimeout(timerId);
    timerId = setTimeout(() => {
      fn(...args);
    }, wait);
  };
}
```

## How did you test this change?

**before**

> You can see that the buttons on the left side of the mouse are constantly jumping when you move the mouse, and debounce has no effect.

![before](https://github.com/Milkdown/milkdown/assets/28844480/08749f7d-402d-46e3-bf4e-1f068b5bf1ec)

**after**

![after](https://github.com/Milkdown/milkdown/assets/28844480/e0b86201-fedd-46e6-a162-b75b2bc9ca3e)
