### PR TITLE
fix: 🐛 code block component can't work for empty language

### DIFF
--- a/packages/components/src/code-block/view/component.ts
+++ b/packages/components/src/code-block/view/component.ts
@@ -35,7 +35,9 @@ export const codeComponent: Component<CodeComponentProps> = ({
   useCssLightDom(style)
 
   useEffect(() => {
-    const lang = getAllLanguages?.()?.find(languageInfo => languageInfo.alias.some(alias => alias.toLowerCase() === language?.toLowerCase()))
+    const lang = getAllLanguages?.()?.find(languageInfo =>
+      languageInfo.alias.some(alias =>
+        alias.toLowerCase() === language?.toLowerCase()))
 
     if (lang && lang.name !== language)
       setLanguage?.(lang.name)

--- a/packages/components/src/code-block/view/node-view.ts
+++ b/packages/components/src/code-block/view/node-view.ts
@@ -74,7 +74,7 @@ export class CodeMirrorBlock implements NodeView {
       return
 
     this.dom.language = languageName
-    const language = this.loader.load(languageName)
+    const language = this.loader.load(languageName ?? '')
 
     language.then((lang) => {
       if (lang) {


### PR DESCRIPTION
✅ Closes: #1293

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Fix empty language for code block component.

## How did you test this change?

CI
