### PR TITLE
fix: 🐛 heading id in readonly mode

### DIFF
--- a/packages/preset-commonmark/src/plugin/sync-heading-id-plugin.ts
+++ b/packages/preset-commonmark/src/plugin/sync-heading-id-plugin.ts
@@ -11,7 +11,7 @@ export const syncHeadingIdPlugin = $prose((ctx) => {
   const headingIdPluginKey = new PluginKey('MILKDOWN_HEADING_ID')
 
   const updateId = (view: EditorView) => {
-    if (view.composing || !view.editable)
+    if (view.composing)
       return
 
     const getId = ctx.get(headingIdGenerator.key)


### PR DESCRIPTION
✅ Closes: #1252

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Heading id not synced in readonly mode.

## How did you test this change?

CI
