### PR TITLE
fix: 🐛 list item can have other block as first children

### DIFF
--- a/packages/preset-commonmark/src/node/list-item.ts
+++ b/packages/preset-commonmark/src/node/list-item.ts
@@ -18,7 +18,7 @@ withMeta(listItemAttr, {
 /// Schema for list item node.
 export const listItemSchema = $nodeSchema('list_item', ctx => ({
   group: 'listItem',
-  content: 'paragraph block*',
+  content: 'block+',
   attrs: {
     label: {
       default: '•',


### PR DESCRIPTION
✅ Closes: #1276

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Allow list item to have other types of block as first child.

## How did you test this change?

CI
