### PR TITLE
fix: 🐛 liftListItem command has wrong command key

### DIFF
--- a/packages/preset-commonmark/src/node/list-item.ts
+++ b/packages/preset-commonmark/src/node/list-item.ts
@@ -118,7 +118,7 @@ withMeta(sinkListItemCommand, {
 /// * List item 1
 /// * List item 2
 /// ```
-export const liftListItemCommand = $command('SplitListItem', ctx => () => liftListItem(listItemSchema.type(ctx)))
+export const liftListItemCommand = $command('LiftListItem', ctx => () => liftListItem(listItemSchema.type(ctx)))
 
 withMeta(liftListItemCommand, {
   displayName: 'Command<liftListItemCommand>',


### PR DESCRIPTION
✅ Closes: #1270

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

The `liftListItem` command has wrong command key.

## How did you test this change?

CI
