### PR TITLE
fix: image block style offset in storybook

### DIFF
--- a/e2e/src/components/image-block.css
+++ b/e2e/src/components/image-block.css
@@ -65,6 +65,7 @@ milkdown-image-block > .image-edit .link-importer .placeholder {
 
 milkdown-image-block > .image-edit .link-importer .link-input-area {
   line-height: 24px;
+  padding: 8px 0;
 }
 
 milkdown-image-block > .image-edit .link-importer .placeholder .uploader {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Image block style offset in storybook

## How did you test this change?

CI
