### PR TITLE
feat: replace tippy with floating ui in plugin block

### DIFF
--- a/packages/crepe/src/feature/block-edit/handle/index.ts
+++ b/packages/crepe/src/feature/block-edit/handle/index.ts
@@ -4,7 +4,7 @@ import { BlockProvider, block } from '@milkdown/plugin-block'
 import type { Ctx } from '@milkdown/ctx'
 import type { EditorView } from '@milkdown/prose/view'
 import type { AtomicoThis } from 'atomico/types/dom'
-import { editorViewCtx, rootDOMCtx } from '@milkdown/core'
+import { editorViewCtx } from '@milkdown/core'
 import { paragraphSchema } from '@milkdown/preset-commonmark'
 import { menuAPI } from '../menu'
 import { defIfNotExists } from '../../../utils'
@@ -24,21 +24,13 @@ export class BlockHandleView implements PluginView {
     this.#provider = new BlockProvider({
       ctx,
       content,
-      tippyOptions: {
-        appendTo: () => ctx.get(rootDOMCtx),
-        onShow: () => {
-          this.#content.show = true
-        },
-        onHidden: () => {
-          this.#content.show = false
-        },
-      },
     })
-    this.update(view)
+    this.update()
+    view.dom.parentElement?.appendChild(content)
   }
 
-  update = (view: EditorView) => {
-    this.#provider.update(view)
+  update = () => {
+    this.#provider.update()
   }
 
   destroy = () => {

--- a/packages/crepe/src/feature/block-edit/style.css
+++ b/packages/crepe/src/feature/block-edit/style.css
@@ -1,11 +1,16 @@
 .milkdown {
   milkdown-block-handle {
+    &[data-show='false'] {
+      opacity: 0;
+    }
+    transition: opacity 0.2s;
+    position: absolute;
     cursor: pointer;
     display: flex;
     justify-content: center;
     align-items: center;
     gap: 2px;
-    padding-right: 4px;
+    padding-right: 16px;
 
     .operation-item {
       border-radius: 4px;

--- a/packages/plugin-block/package.json
+++ b/packages/plugin-block/package.json
@@ -45,11 +45,11 @@
     "@milkdown/prose": "^7.2.0"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.5.1",
     "@milkdown/exception": "workspace:*",
     "@milkdown/utils": "workspace:*",
     "@types/lodash.throttle": "^4.1.9",
     "lodash.throttle": "^4.1.1",
-    "tippy.js": "^6.3.7",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/plugin-emoji/package.json
+++ b/packages/plugin-emoji/package.json
@@ -48,9 +48,8 @@
   "dependencies": {
     "@milkdown/exception": "workspace:*",
     "@milkdown/utils": "workspace:*",
-    "@types/node-emoji": "^2.0.0",
     "emoji-regex": "^10.0.0",
-    "node-emoji": "^2.0.0",
+    "node-emoji": "^2.1.3",
     "remark-emoji": "^5.0.0",
     "tslib": "^2.5.0",
     "twemoji": "^14.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
 
   packages/plugin-block:
     dependencies:
+      '@floating-ui/dom':
+        specifier: ^1.5.1
+        version: 1.6.3
       '@milkdown/exception':
         specifier: workspace:*
         version: link:../exception

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,14 +631,11 @@ importers:
       '@milkdown/utils':
         specifier: workspace:*
         version: link:../utils
-      '@types/node-emoji':
-        specifier: ^2.0.0
-        version: 2.1.0
       emoji-regex:
         specifier: ^10.0.0
         version: 10.3.0
       node-emoji:
-        specifier: ^2.0.0
+        specifier: ^2.1.3
         version: 2.1.3
       remark-emoji:
         specifier: ^5.0.0
@@ -4119,10 +4116,6 @@ packages:
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
-
-  '@types/node-emoji@2.1.0':
-    resolution: {integrity: sha512-LBGWP2LL5A+PpcvzrgXCFcHt9N1l5bqQn05ZUQFFM625k/tmc2w9ghT4kUwQN6gIPlX6qnDOfekmJmV9BywV9g==}
-    deprecated: This is a stub types definition. node-emoji provides its own type definitions, so you do not need this installed.
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -14084,10 +14077,6 @@ snapshots:
   '@types/minimist@1.2.5': {}
 
   '@types/ms@0.7.34': {}
-
-  '@types/node-emoji@2.1.0':
-    dependencies:
-      node-emoji: 2.1.3
 
   '@types/node@12.20.55': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,9 +503,6 @@ importers:
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
-      tippy.js:
-        specifier: ^6.3.7
-        version: 6.3.7
       tslib:
         specifier: ^2.5.0
         version: 2.6.2


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Replace tippy with floating ui in plugin block

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
CI and manually