### PR TITLE
feat: migrate to floating ui in plugin tooltip

### DIFF
--- a/e2e/stories/components/link-tooltip.css
+++ b/e2e/stories/components/link-tooltip.css
@@ -1,6 +1,10 @@
 .milkdown-storybook {
 
   .link-insert-button {
+    position: absolute;
+    &[data-show="false"] {
+      display: none;
+    }
     background: bisque;
     cursor: pointer;
     padding: 4px 16px;
@@ -12,6 +16,10 @@
   }
 
   milkdown-link-preview {
+    position: absolute;
+    &[data-show="false"] {
+      display: none;
+    }
     & > .link-preview {
       height: 42px;
       display: flex;
@@ -78,6 +86,10 @@
   }
 
   milkdown-link-edit {
+    position: absolute;
+    &[data-show="false"] {
+      display: none;
+    }
     & > .link-edit {
       height: 42px;
       display: flex;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -101,6 +101,7 @@
     "@milkdown/ctx": "^7.2.0",
     "@milkdown/plugin-tooltip": "^7.2.0",
     "@milkdown/preset-commonmark": "^7.2.0",
+    "@milkdown/preset-gfm": "^7.2.0",
     "@milkdown/prose": "^7.2.0",
     "@milkdown/transformer": "^7.2.0"
   },
@@ -125,6 +126,7 @@
     "@milkdown/ctx": "workspace:*",
     "@milkdown/plugin-tooltip": "workspace:*",
     "@milkdown/preset-commonmark": "workspace:*",
+    "@milkdown/preset-gfm": "workspace:*",
     "@milkdown/prose": "workspace:*",
     "@milkdown/transformer": "workspace:*"
   },

--- a/packages/components/src/link-tooltip/edit/edit-component.ts
+++ b/packages/components/src/link-tooltip/edit/edit-component.ts
@@ -50,7 +50,7 @@ export const linkEditComponent: Component<LinkEditProps> = ({
           oninput=${(e: InputEvent) => setLink((e.target as HTMLInputElement).value)}
           value=${link}
         />
-        <span class=${clsx('button confirm', link.length === 0 && 'hidden')} onclick=${onConfirmEdit}>
+        <span class=${clsx('button confirm', !link && 'hidden')} onclick=${onConfirmEdit}>
           ${config?.confirmButton()}
         </span>
       </div>

--- a/packages/components/src/link-tooltip/preview/preview-configure.ts
+++ b/packages/components/src/link-tooltip/preview/preview-configure.ts
@@ -30,8 +30,7 @@ export function configureLinkPreviewTooltip(ctx: Ctx) {
       const markPosition = findMarkPosition(result.mark, result.node, view.state.doc, position.before(), position.after())
       const from = markPosition.start
       const to = markPosition.end
-      linkPreviewTooltipView.setRect(posToDOMRect(view, from, to))
-      linkPreviewTooltipView.show(result.mark, from, to)
+      linkPreviewTooltipView.show(result.mark, from, to, posToDOMRect(view, from, to))
       return
     }
 

--- a/packages/crepe/src/feature/block-edit/handle/index.ts
+++ b/packages/crepe/src/feature/block-edit/handle/index.ts
@@ -2,7 +2,6 @@ import type { PluginView } from '@milkdown/prose/state'
 import { TextSelection } from '@milkdown/prose/state'
 import { BlockProvider, block } from '@milkdown/plugin-block'
 import type { Ctx } from '@milkdown/ctx'
-import type { EditorView } from '@milkdown/prose/view'
 import type { AtomicoThis } from 'atomico/types/dom'
 import { editorViewCtx } from '@milkdown/core'
 import { paragraphSchema } from '@milkdown/preset-commonmark'
@@ -16,7 +15,7 @@ export class BlockHandleView implements PluginView {
   #provider: BlockProvider
   #ctx: Ctx
 
-  constructor(ctx: Ctx, view: EditorView) {
+  constructor(ctx: Ctx) {
     this.#ctx = ctx
     const content = new BlockHandleElement()
     this.#content = content
@@ -26,7 +25,6 @@ export class BlockHandleView implements PluginView {
       content,
     })
     this.update()
-    view.dom.parentElement?.appendChild(content)
   }
 
   update = () => {
@@ -66,6 +64,6 @@ export class BlockHandleView implements PluginView {
 defIfNotExists('milkdown-block-handle', BlockHandleElement)
 export function configureBlockHandle(ctx: Ctx) {
   ctx.set(block.key, {
-    view: view => new BlockHandleView(ctx, view),
+    view: () => new BlockHandleView(ctx),
   })
 }

--- a/packages/crepe/src/feature/toolbar/index.ts
+++ b/packages/crepe/src/feature/toolbar/index.ts
@@ -4,7 +4,6 @@ import { TextSelection } from '@milkdown/prose/state'
 import type { Ctx } from '@milkdown/ctx'
 import type { EditorView } from '@milkdown/prose/view'
 import type { AtomicoThis } from 'atomico/types/dom'
-import { rootDOMCtx } from '@milkdown/core'
 import type { DefineFeature } from '../shared'
 import { defIfNotExists } from '../../utils'
 import type { ToolbarProps } from './component'
@@ -24,15 +23,6 @@ class ToolbarView implements PluginView {
     this.#tooltipProvider = new TooltipProvider({
       content: this.#content,
       debounce: 20,
-      tippyOptions: {
-        appendTo: () => ctx.get(rootDOMCtx),
-        onShow: () => {
-          this.#content.show = true
-        },
-        onHidden: () => {
-          this.#content.show = false
-        },
-      },
       shouldShow(view: EditorView) {
         const { doc, selection } = view.state
         const { empty, from, to } = selection
@@ -41,7 +31,8 @@ class ToolbarView implements PluginView {
 
         const isNotTextBlock = !(selection instanceof TextSelection)
 
-        const isTooltipChildren = content.contains(document.activeElement)
+        const activeElement = (view.dom.getRootNode() as ShadowRoot | Document).activeElement
+        const isTooltipChildren = content.contains(activeElement)
 
         const notHasFocus = !view.hasFocus() && !isTooltipChildren
 
@@ -59,6 +50,12 @@ class ToolbarView implements PluginView {
         return true
       },
     })
+    this.#tooltipProvider.onShow = () => {
+      this.#content.show = true
+    }
+    this.#tooltipProvider.onHide = () => {
+      this.#content.show = false
+    }
     this.update(view)
   }
 

--- a/packages/crepe/src/theme/classic-dark/style.css
+++ b/packages/crepe/src/theme/classic-dark/style.css
@@ -24,6 +24,8 @@
   --crepe-shadow-1: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
   --crepe-shadow-2: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 2px 6px 2px rgba(0, 0, 0, 0.15);
 
+  position: relative;
+
   * {
     margin: 0;
     padding: 0;

--- a/packages/crepe/src/theme/classic/style.css
+++ b/packages/crepe/src/theme/classic/style.css
@@ -24,6 +24,8 @@
   --crepe-shadow-1: 0px 1px 3px 1px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.30);
   --crepe-shadow-2: 0px 2px 6px 2px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.30);
 
+  position: relative;
+
   * {
     margin: 0;
     padding: 0;

--- a/packages/crepe/src/theme/common/link-tooltip.css
+++ b/packages/crepe/src/theme/common/link-tooltip.css
@@ -1,5 +1,9 @@
 .milkdown {
   milkdown-link-preview {
+    position: absolute;
+    &[data-show='false'] {
+      display: none;
+    }
     & > .link-preview {
       height: 32px;
       display: flex;
@@ -66,6 +70,10 @@
   }
 
   milkdown-link-edit {
+    position: absolute;
+    &[data-show='false'] {
+      display: none;
+    }
     & > .link-edit {
       height: 32px;
       display: flex;

--- a/packages/crepe/src/theme/common/toolbar.css
+++ b/packages/crepe/src/theme/common/toolbar.css
@@ -1,5 +1,9 @@
 .milkdown {
   milkdown-toolbar {
+    &[data-show="false"] {
+      display: none;
+    }
+    position: absolute;
     display: flex;
     background: var(--crepe-color-surface);
     box-shadow: var(--crepe-shadow-1);

--- a/packages/plugins/plugin-block/src/block-provider.ts
+++ b/packages/plugins/plugin-block/src/block-provider.ts
@@ -6,6 +6,7 @@ import type { VirtualElement } from '@floating-ui/dom'
 import { computePosition, flip, platform } from '@floating-ui/dom'
 
 import { offsetParent } from 'composed-offset-position'
+import { editorViewCtx } from '@milkdown/core'
 import type { BlockService } from './block-service'
 import { blockService } from './block-plugin'
 import type { ActiveNode } from './types'
@@ -49,6 +50,9 @@ export class BlockProvider {
 
   /// @internal
   #init() {
+    const view = this.#ctx.get(editorViewCtx)
+    view.dom.parentElement?.appendChild(this.#element)
+
     const service = this.#ctx.get(blockService.key)
     service.bind(this.#ctx, (message) => {
       if (message.type === 'hide') {

--- a/packages/plugins/plugin-tooltip/package.json
+++ b/packages/plugins/plugin-tooltip/package.json
@@ -45,9 +45,11 @@
     "@milkdown/prose": "^7.2.0"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.5.1",
     "@milkdown/exception": "workspace:*",
     "@milkdown/utils": "workspace:*",
     "@types/lodash.debounce": "^4.0.7",
+    "composed-offset-position": "^0.0.4",
     "lodash.debounce": "^4.0.8",
     "tippy.js": "^6.3.7",
     "tslib": "^2.5.0"

--- a/packages/plugins/preset-gfm/src/composed/plugins.ts
+++ b/packages/plugins/preset-gfm/src/composed/plugins.ts
@@ -9,7 +9,7 @@ import {
 /// @internal
 export const plugins: MilkdownPlugin[] = [
   autoInsertZeroSpaceInTablePlugin,
+  remarkGFMPlugin,
   columnResizingPlugin,
   tableEditingPlugin,
-  remarkGFMPlugin,
 ].flat()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       '@milkdown/preset-commonmark':
         specifier: workspace:*
         version: link:../plugins/preset-commonmark
+      '@milkdown/preset-gfm':
+        specifier: workspace:*
+        version: link:../plugins/preset-gfm
       '@milkdown/prose':
         specifier: workspace:*
         version: link:../prose
@@ -880,6 +883,9 @@ importers:
 
   packages/plugins/plugin-tooltip:
     dependencies:
+      '@floating-ui/dom':
+        specifier: ^1.5.1
+        version: 1.6.3
       '@milkdown/exception':
         specifier: workspace:*
         version: link:../../exception
@@ -889,6 +895,9 @@ importers:
       '@types/lodash.debounce':
         specifier: ^4.0.7
         version: 4.0.9
+      composed-offset-position:
+        specifier: ^0.0.4
+        version: 0.0.4
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Migrate the tippy package to floating ui in plugin-tooltip

## How did you test this change?

CI and manully
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
