### PR TITLE
feat: migrate tippy to floating ui in plugin slash

### DIFF
--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -4,7 +4,6 @@ import { SlashProvider, slashFactory } from '@milkdown/plugin-slash'
 import type { Ctx } from '@milkdown/ctx'
 import type { AtomicoThis } from 'atomico/types/dom'
 import { $ctx } from '@milkdown/utils'
-import { rootDOMCtx } from '@milkdown/core'
 import { defIfNotExists, isInCodeBlock, isInList } from '../../../utils'
 import type { MenuProps } from './component'
 import { MenuElement } from './component'
@@ -42,15 +41,6 @@ class MenuView implements PluginView {
     this.#slashProvider = new SlashProvider({
       content: this.#content,
       debounce: 20,
-      tippyOptions: {
-        appendTo: () => ctx.get(rootDOMCtx),
-        onShow: () => {
-          this.#content.show = true
-        },
-        onHidden: () => {
-          this.#content.show = false
-        },
-      },
       shouldShow(this: SlashProvider, view: EditorView) {
         if (isInCodeBlock(view.state.selection) || isInList(view.state.selection))
           return false
@@ -81,6 +71,13 @@ class MenuView implements PluginView {
         return true
       },
     })
+
+    this.#slashProvider.onShow = () => {
+      this.#content.show = true
+    }
+    this.#slashProvider.onHide = () => {
+      this.#content.show = false
+    }
     this.update(view)
 
     ctx.set(menuAPI.key, {

--- a/packages/crepe/src/theme/common/block-edit.css
+++ b/packages/crepe/src/theme/common/block-edit.css
@@ -34,6 +34,11 @@
   }
 
   milkdown-slash-menu {
+    &[data-show='false'] {
+      opacity: 0;
+    }
+    transition: opacity 0.2s;
+    position: absolute;
     display: block;
     width: 254px;
     font-family: var(--crepe-font-default);

--- a/packages/plugins/plugin-slash/package.json
+++ b/packages/plugins/plugin-slash/package.json
@@ -45,11 +45,12 @@
     "@milkdown/prose": "^7.2.0"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.5.1",
     "@milkdown/exception": "workspace:*",
     "@milkdown/utils": "workspace:*",
     "@types/lodash.debounce": "^4.0.7",
+    "composed-offset-position": "^0.0.4",
     "lodash.debounce": "^4.0.8",
-    "tippy.js": "^6.3.7",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
 
   packages/plugins/plugin-slash:
     dependencies:
+      '@floating-ui/dom':
+        specifier: ^1.5.1
+        version: 1.6.3
       '@milkdown/exception':
         specifier: workspace:*
         version: link:../../exception
@@ -861,12 +864,12 @@ importers:
       '@types/lodash.debounce':
         specifier: ^4.0.7
         version: 4.0.9
+      composed-offset-position:
+        specifier: ^0.0.4
+        version: 0.0.4
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
-      tippy.js:
-        specifier: ^6.3.7
-        version: 6.3.7
       tslib:
         specifier: ^2.5.0
         version: 2.6.2


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Migrate tippy in slash plugin to `@flating-ui/dom`

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
CI & Manually