### PR TITLE
fix: 🐛 marks end with space with lead to wrong markdown

### DIFF
--- a/e2e/cypress/e2e/preset-commonmark/shortcut.cy.ts
+++ b/e2e/cypress/e2e/preset-commonmark/shortcut.cy.ts
@@ -90,14 +90,76 @@ describe('input:', () => {
   })
 
   describe('mark:', () => {
-    it('bold', () => {
-      cy.get('.editor').type('The lunatic is on the grass')
-      cy.get('.editor').type('{selectAll}')
-      cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
-      cy.get('strong').should('have.text', 'The lunatic is on the grass')
-      cy.get('.editor').type('{selectAll}')
-      cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
-      cy.get('strong').should('not.exist')
+    describe('bold', () => {
+      it('standard bold', () => {
+        cy.get('.editor').type('The lunatic is on the grass')
+        cy.get('.editor').type('{selectAll}')
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('strong').should('have.text', 'The lunatic is on the grass')
+        cy.get('.editor').type('{selectAll}')
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('strong').should('not.exist')
+      })
+
+      it('end with space', () => {
+        cy.get('.editor').type('The lunatic ')
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(`on the `)
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(' grass')
+        cy.window().then((win) => {
+          cy.wrap(win.__getMarkdown__())
+            .should('equal', 'The lunatic **on the**  grass\n')
+        })
+      })
+
+      it('end with spaces', () => {
+        cy.get('.editor').type('The lunatic ')
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(`on the    `)
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(' grass')
+        cy.window().then((win) => {
+          cy.wrap(win.__getMarkdown__())
+            .should('equal', 'The lunatic **on the**     grass\n')
+        })
+      })
+
+      it('start with space', () => {
+        cy.get('.editor').type('The lunatic ')
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(` is on the`)
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(' grass')
+        cy.window().then((win) => {
+          cy.wrap(win.__getMarkdown__())
+            .should('equal', 'The lunatic  **is on the** grass\n')
+        })
+      })
+
+      it('start with spaces', () => {
+        cy.get('.editor').type('The lunatic ')
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(`    is on the`)
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(' grass')
+        cy.window().then((win) => {
+          cy.wrap(win.__getMarkdown__())
+            .should('equal', 'The lunatic     **is on the** grass\n')
+        })
+      })
+
+      it('start and end with spaces', () => {
+        cy.get('.editor').type('The lunatic ')
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(`    is on the    `)
+        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`)
+        cy.get('.editor').type(' grass')
+        cy.window().then((win) => {
+          cy.wrap(win.__getMarkdown__())
+            .should('equal', 'The lunatic     **is on the**     grass\n')
+        })
+      })
     })
 
     it('italic', () => {

--- a/packages/transformer/src/serializer/state.ts
+++ b/packages/transformer/src/serializer/state.ts
@@ -189,10 +189,11 @@ export class SerializerState extends Stack<MarkdownNode, SerializerStackElement>
         }
       })
     }
+
     if (children) {
       findIndex(children)
-      const lastChild = children?.at(last) as MarkdownNode & { value: string } | undefined
-      const firstChild = children?.at(first) as MarkdownNode & { value: string } | undefined
+      const lastChild = children?.[last] as MarkdownNode & { value: string } | undefined
+      const firstChild = children?.[first] as MarkdownNode & { value: string } | undefined
       if (lastChild && lastChild.value.endsWith(' ')) {
         endSpaces = lastChild.value.match(/ +$/)![0]
         lastChild.value = lastChild.value.trimEnd()

--- a/packages/transformer/src/serializer/state.ts
+++ b/packages/transformer/src/serializer/state.ts
@@ -171,10 +171,59 @@ export class SerializerState extends Stack<MarkdownNode, SerializerStackElement>
     return this
   }
 
+  #moveSpaces = (element: SerializerStackElement, onPush: () => MarkdownNode) => {
+    let startdSpaces = ''
+    let endSpaces = ''
+    const children = element.children
+    let first = -1
+    let last = -1
+    const findIndex = (node: MarkdownNode[]) => {
+      if (!node)
+        return
+      node.forEach((child, index) => {
+        if (child.type === 'text') {
+          if (first < 0)
+            first = index
+
+          last = index
+        }
+      })
+    }
+    if (children) {
+      findIndex(children)
+      const lastChild = children?.at(last) as MarkdownNode & { value: string } | undefined
+      const firstChild = children?.at(first) as MarkdownNode & { value: string } | undefined
+      if (lastChild && lastChild.value.endsWith(' ')) {
+        endSpaces = lastChild.value.match(/ +$/)![0]
+        lastChild.value = lastChild.value.trimEnd()
+      }
+      if (firstChild && firstChild.value.startsWith(' ')) {
+        startdSpaces = firstChild.value.match(/^ +/)![0]
+        firstChild.value = firstChild.value.trimStart()
+      }
+    }
+
+    if (startdSpaces.length)
+      this.#addNodeAndPush('text', undefined, startdSpaces)
+
+    const result = onPush()
+
+    if (endSpaces.length)
+      this.#addNodeAndPush('text', undefined, endSpaces)
+
+    return result
+  }
+
   /// @internal
-  #closeNodeAndPush = (): MarkdownNode => {
+  #closeNodeAndPush = (trim: boolean = false): MarkdownNode => {
     const element = this.close()
-    return this.#addNodeAndPush(element.type, element.children, element.value, element.props)
+
+    const onPush = () => this.#addNodeAndPush(element.type, element.children, element.value, element.props)
+
+    if (trim)
+      return this.#moveSpaces(element, onPush)
+
+    return onPush()
   }
 
   /// Close the current node and push it into the parent node.
@@ -216,7 +265,7 @@ export class SerializerState extends Stack<MarkdownNode, SerializerStackElement>
       return
 
     this.#marks = mark.type.removeFromSet(this.#marks)
-    this.#closeNodeAndPush()
+    this.#closeNodeAndPush(true)
   }
 
   /// Open a new mark, the next nodes added will have that mark.

--- a/packages/transformer/src/serializer/state.ts
+++ b/packages/transformer/src/serializer/state.ts
@@ -181,7 +181,7 @@ export class SerializerState extends Stack<MarkdownNode, SerializerStackElement>
       if (!node)
         return
       node.forEach((child, index) => {
-        if (child.type === 'text') {
+        if (child.type === 'text' && child.value) {
           if (first < 0)
             first = index
 

--- a/packages/transformer/src/serializer/state.ts
+++ b/packages/transformer/src/serializer/state.ts
@@ -172,7 +172,7 @@ export class SerializerState extends Stack<MarkdownNode, SerializerStackElement>
   }
 
   #moveSpaces = (element: SerializerStackElement, onPush: () => MarkdownNode) => {
-    let startdSpaces = ''
+    let startSpaces = ''
     let endSpaces = ''
     const children = element.children
     let first = -1
@@ -198,13 +198,13 @@ export class SerializerState extends Stack<MarkdownNode, SerializerStackElement>
         lastChild.value = lastChild.value.trimEnd()
       }
       if (firstChild && firstChild.value.startsWith(' ')) {
-        startdSpaces = firstChild.value.match(/^ +/)![0]
+        startSpaces = firstChild.value.match(/^ +/)![0]
         firstChild.value = firstChild.value.trimStart()
       }
     }
 
-    if (startdSpaces.length)
-      this.#addNodeAndPush('text', undefined, startdSpaces)
+    if (startSpaces.length)
+      this.#addNodeAndPush('text', undefined, startSpaces)
 
     const result = onPush()
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

✅ Closes: 1402

Auto move spaces for marks.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
Test cases.
