### PR TITLE
fix: tooltip plugin will make the editor auto focused

### DIFF
--- a/packages/plugins/plugin-tooltip/src/tooltip-provider.ts
+++ b/packages/plugins/plugin-tooltip/src/tooltip-provider.ts
@@ -54,6 +54,7 @@ export class TooltipProvider {
     this.#debounce = options.debounce ?? 200
     this.#shouldShow = options.shouldShow ?? this.#_shouldShow
     this.#offset = options.offset
+    this.element.dataset.show = 'false'
   }
 
   /// @internal
@@ -151,6 +152,8 @@ export class TooltipProvider {
 
   /// Hide the tooltip.
   hide = () => {
+    if (this.element.dataset.show === 'false')
+      return
     this.element.dataset.show = 'false'
 
     this.onHide()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary
Should not auto focus the editor on loaded.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Manually.
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
