### PR TITLE
ci: print lint warnings with github-compatible format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: pnpm build
 
       - name: run lint
-        run: pnpm test:lint
+        run: pnpm test:lint --format github
 
       - name: run unit tests
         run: pnpm test:unit


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

When `oxlint` gets run in CI, lint warnings will be printed with a format that allows Github to display them as annotations on your PR. Thanks for using Oxlint <3
## How did you test this change?
N/A