### PR TITLE
fix: crepe codemirror wrong dependency

### DIFF
--- a/.changeset/wet-dolphins-sniff.md
+++ b/.changeset/wet-dolphins-sniff.md
@@ -1,0 +1,5 @@
+---
+"@milkdown/crepe": patch
+---
+
+The default nord theme has unacceptable dependency @babel/runtime

--- a/packages/crepe/package.json
+++ b/packages/crepe/package.json
@@ -66,7 +66,7 @@
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.16.0",
     "@milkdown/kit": "workspace:*",
-    "@uiw/codemirror-theme-nord": "^4.22.1",
+    "@codemirror/theme-one-dark": "^6.1.2",
     "atomico": "^1.75.1",
     "clsx": "^2.0.0",
     "codemirror": "^6.0.1",

--- a/packages/crepe/src/feature/code-mirror/index.ts
+++ b/packages/crepe/src/feature/code-mirror/index.ts
@@ -36,8 +36,8 @@ export const defineFeature: DefineFeature<CodeMirrorFeatureConfig> = (editor, co
         languages = langList
       }
       if (!theme) {
-        const { nord } = await import('@uiw/codemirror-theme-nord')
-        theme = nord
+        const { oneDark } = await import('@codemirror/theme-one-dark')
+        theme = oneDark
       }
       ctx.update(codeBlockConfig.key, defaultConfig => ({
         extensions: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,15 +373,15 @@ importers:
       '@codemirror/state':
         specifier: ^6.4.1
         version: 6.4.1
+      '@codemirror/theme-one-dark':
+        specifier: ^6.1.2
+        version: 6.1.2
       '@codemirror/view':
         specifier: ^6.16.0
         version: 6.26.0
       '@milkdown/kit':
         specifier: workspace:*
         version: link:../kit
-      '@uiw/codemirror-theme-nord':
-        specifier: ^4.22.1
-        version: 4.22.1(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.0)
       atomico:
         specifier: ^1.75.1
         version: 1.75.1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
The previous default theme has an unacceptable dependency `@babel/runtime`

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
CI and manually