### PR TITLE
fix(crepe): button type in toolbar

### DIFF
--- a/packages/crepe/src/feature/toolbar/component.ts
+++ b/packages/crepe/src/feature/toolbar/component.ts
@@ -52,6 +52,7 @@ export const toolbarComponent: Component<ToolbarProps> = ({
 
   return html`<host>
     <button
+      type="button"
       class=${clsx('toolbar-item', ctx && isActive(strongSchema.type(ctx)) && 'active')}
       onmousedown=${onClick((ctx) => {
         const commands = ctx.get(commandsCtx)
@@ -61,6 +62,7 @@ export const toolbarComponent: Component<ToolbarProps> = ({
       ${config?.boldIcon?.() ?? boldIcon}
     </button>
     <button
+      type="button"
       class=${clsx('toolbar-item', ctx && isActive(emphasisSchema.type(ctx)) && 'active')}
       onmousedown=${onClick((ctx) => {
         const commands = ctx.get(commandsCtx)
@@ -70,6 +72,7 @@ export const toolbarComponent: Component<ToolbarProps> = ({
       ${config?.italicIcon?.() ?? italicIcon}
     </button>
     <button
+      type="button"
       class=${clsx('toolbar-item', ctx && isActive(strikethroughSchema.type(ctx)) && 'active')}
       onmousedown=${onClick((ctx) => {
         const commands = ctx.get(commandsCtx)
@@ -80,6 +83,7 @@ export const toolbarComponent: Component<ToolbarProps> = ({
     </button>
     <div class="divider"></div>
     <button
+      type="button"
       class=${clsx('toolbar-item', ctx && isActive(inlineCodeSchema.type(ctx)) && 'active')}
       onmousedown=${onClick((ctx) => {
         const commands = ctx.get(commandsCtx)
@@ -89,6 +93,7 @@ export const toolbarComponent: Component<ToolbarProps> = ({
       ${config?.codeIcon?.() ?? codeIcon}
     </button>
     <button
+      type="button"
       class=${clsx('toolbar-item', ctx && isActive(linkSchema.type(ctx)) && 'active')}
       onmousedown=${onClick((ctx) => {
         const view = ctx.get(editorViewCtx)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

- using the crepe bundle inside a form triggers a submit when a button in the toolbar is pressed
- the default type of a button is `submit`, changing it to type `button` prevents this
- there are potentially more cases of a missing button type, but didn't wanna explode the scope of this pr

## How did you test this change?

- checked on storybook that crepe stories are rendering and also that `type="button"` is present