### PR TITLE
fix(slash): reset index when out of bounds

### DIFF
--- a/packages/crepe/src/feature/block-edit/menu/component.ts
+++ b/packages/crepe/src/feature/block-edit/menu/component.ts
@@ -39,8 +39,8 @@ export const menuComponent: Component<MenuProps> = ({
   }, [])
 
   useEffect(() => {
-    if (size === 0 && show)
-      hide?.()
+    if (size === 0 && show) hide?.()
+    else if (hoverIndex >= size) setHoverIndex(0)
   }, [size, show])
 
   const onHover = useCallback((


### PR DESCRIPTION
-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Addressing issue reported in #1536

## How did you test this change?

- [x] Storybook

Before: hover index was out of menu
https://github.com/user-attachments/assets/a3e21563-5749-4444-8476-50dc5e4abaf8

After: hover index reset to zero when out of bounds
https://github.com/user-attachments/assets/805f312a-5a96-4416-b480-f40bf103fcd5

