### PR TITLE
fix(prosemirror): undoable inputrules

### DIFF
--- a/packages/prose/src/toolkit/input-rules/custom-input-rules.ts
+++ b/packages/prose/src/toolkit/input-rules/custom-input-rules.ts
@@ -22,7 +22,10 @@ function run(view: EditorView, from: number, to: number, text: string, rules: In
             ).handler(state, match, from - (match[0].length - text.length), to)
     if (!tr)
       continue
-    view.dispatch(tr.setMeta(plugin, { transform: tr, from, to, text }))
+    // @ts-expect-error Internal property that should be in the class; only relevant if explicitly false.
+    if (rules[i]?.undoable !== false)
+      tr.setMeta(plugin, { transform: tr, from, to, text })
+    view.dispatch(tr)
     return true
   }
   return false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Specifying `undoable` for inputrules does not currently seem to work. 

The upstream implementation of `run` from prosemirror-inputrules checks if the [rule is undoable](https://github.com/ProseMirror/prosemirror-inputrules/blob/8433778a3ce4e45c0188341b72fd71da3a440b5b/src/inputrules.ts#L107) before adding the meta information. The custom implementation of the `run` function in Milkdown does not seem to do that [here](https://github.com/Milkdown/milkdown/blob/a1262cfa933f04a1be8cc976957c12c0ba2e346c/packages/prose/src/toolkit/input-rules/custom-input-rules.ts#L25).

Not all the type information seems to be captured for the `InputRule` class, such as the [`undoable` property](https://github.com/ProseMirror/prosemirror-inputrules/blob/8433778a3ce4e45c0188341b72fd71da3a440b5b/src/inputrules.ts#L13) that should be stored on it, so I have inserted a `ts-expect-error` comment for now...

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

I have not tested this yet. The testing procedure would involve creating an inputrule, such as the Markdown "replace with emoji when text surrounded by colon" and specifying it as undoable. Immediately after triggering it, the user should hit backspace and "undoInputRule" should not trigger. In my own project, this means that it would look like this.

1. Type the emoji `:smile:`
2. Triggered replacement `😄`
3. Backspace deletes entire emoji node ` `

Currently, it will do this

1. Type the emoji `:smile:`
2. Triggered replacement `😄`
3. Backspace restores the emoji text (deletes entire emoji node) `:smile:`

## Motivation
For this emoji node in particular, I would like `:smile:` sequences to be replaced with an emoji upon successful completion, and if the user immediately hits "Backspace" for the emoji to be removed entirely.

## Project
Resolves #1545 