### PR TITLE
feat: add selectUpload config option to ImageBlock

### DIFF
--- a/packages/components/src/image-block/config.ts
+++ b/packages/components/src/image-block/config.ts
@@ -10,6 +10,7 @@ export interface ImageBlockConfig {
   uploadPlaceholderText: string
   captionPlaceholderText: string
   onUpload: (file: File) => Promise<string>
+  selectUpload?: () => Promise<string>
 }
 
 export const defaultImageBlockConfig: ImageBlockConfig = {

--- a/packages/components/src/image-block/view/component.ts
+++ b/packages/components/src/image-block/view/component.ts
@@ -122,6 +122,21 @@ export const imageComponent: Component<ImageComponentProps> = ({
     e.preventDefault()
   }
 
+  const handleUpload = async (e: PointerEvent) => {
+    if (readonly) {
+      return;
+    }
+    if (typeof config?.selectUpload !== 'undefined') {
+      e.stopPropagation();
+      e.preventDefault();
+      const url = await config.selectUpload();
+      if (url) {
+        setAttr?.('src', url)
+        setHidePlaceholder(true);
+      }
+    }
+  }
+
   return html`<host class=${clsx(selected && 'selected')}>
     <div class=${clsx('image-edit', src.length > 0 && 'hidden')}>
       <div class="image-icon">
@@ -142,7 +157,7 @@ export const imageComponent: Component<ImageComponentProps> = ({
         />
         <div class=${clsx('placeholder', hidePlaceholder && 'hidden')}>
           <input disabled=${readonly} class="hidden" id=${uuid} type="file" accept="image/*" onchange=${onUpload} />
-          <label onpointerdown=${onClickUploader} class="uploader" for=${uuid}>
+          <label onpointerdown=${onClickUploader} onclick=${handleUpload} class="uploader" for=${uuid}>
             ${config?.uploadButton()}
           </label>
           <span class="text" onclick=${() => linkInput.current?.focus()}>

--- a/storybook/stories/components/image-block.stories.ts
+++ b/storybook/stories/components/image-block.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/html'
-import { imageBlockComponent } from '@milkdown/kit/component/image-block'
+import { imageBlockComponent, imageBlockConfig } from '@milkdown/kit/component/image-block'
 
 import type { CommonArgs } from '../utils/shadow'
 import { setupMilkdown } from '../utils/shadow'
@@ -23,6 +23,33 @@ export const Empty: StoryObj<CommonArgs> = {
   render: (args) => {
     return setupMilkdown([style], args, (editor) => {
       editor.use(imageBlockComponent)
+    })
+  },
+  args: {
+    readonly: false,
+    defaultValue: empty,
+  },
+}
+
+export const CustomUpload: StoryObj<CommonArgs> = {
+  render: (args) => {
+    return setupMilkdown([style], args, (editor) => {
+      editor.config((ctx) => {
+        ctx.update(imageBlockConfig.key, value => ({
+          uploadButton: (() => 'Select image'),
+          imageIcon: value.imageIcon,
+          captionIcon: value.captionIcon,
+          confirmButton: value.confirmButton,
+          captionPlaceholderText: value.captionPlaceholderText,
+          uploadPlaceholderText: value.uploadPlaceholderText,
+          onUpload: value.onUpload,
+          selectUpload: () => {
+            return new Promise(resolve => {
+              resolve('/milkdown-logo.png');
+            });
+          }
+        }))
+      }).use(imageBlockComponent)
     })
   },
   args: {


### PR DESCRIPTION
-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Currently it is possible to configure an `onUpload` method for the `ImageBlock` component. This allows you to upload the selected image and return the URL. For our application we already have a collection of images available and it would be nice if the user could also select an image instead of always uploading a new one.

For this I added an `selectUpload` method which can be configured for the `ImageBlock` component. This expects a Promise as return value, which works similar to the `onUpload` configuration option but does not pass a file. Hopefully this is useful for others as well.

## How did you test this change?

Since the implementation for this can vary a lot for each implementation, I added a Storybook story to demonstrate the behavior.
