### PR TITLE
feat: the integrations are adapted to Crepe

### DIFF
--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -43,6 +43,7 @@
   "peerDependencies": {
     "@milkdown/core": "^7.2.0",
     "@milkdown/prose": "^7.2.0",
+    "@milkdown/crepe": "^7.3.3",
     "react": "*",
     "react-dom": "*"
   },
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@milkdown/core": "workspace:*",
     "@milkdown/prose": "workspace:*",
+    "@milkdown/crepe": "workspace:*",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",

--- a/packages/integrations/react/src/Editor.tsx
+++ b/packages/integrations/react/src/Editor.tsx
@@ -1,3 +1,4 @@
+import type { Crepe } from '@milkdown/crepe'
 import type { Editor } from '@milkdown/core'
 import type { FC, ReactNode } from 'react'
 import React, { useMemo, useRef, useState } from 'react'
@@ -15,12 +16,14 @@ export const MilkdownProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const dom = useRef<HTMLDivElement | undefined>(undefined)
   const [editorFactory, setEditorFactory] = useState<GetEditor | undefined>(undefined)
   const editor = useRef<Editor>()
+  const crepe = useRef<Crepe>()
   const [loading, setLoading] = useState(true)
 
   const editorInfoCtx = useMemo<EditorInfoCtx>(() => ({
     loading,
     dom,
     editor,
+    crepe,
     setLoading,
     editorFactory,
     setEditorFactory,

--- a/packages/integrations/react/src/types.ts
+++ b/packages/integrations/react/src/types.ts
@@ -1,11 +1,13 @@
+import type { Crepe } from '@milkdown/crepe'
 import type { Editor } from '@milkdown/core'
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 
-export type GetEditor = (container: HTMLElement) => Editor | undefined
+export type GetEditor = (container: HTMLElement) => Editor | Crepe | undefined
 
 export interface UseEditorReturn {
   readonly loading: boolean
   readonly get: () => Editor | undefined
+  readonly getCrepe: () => Crepe | undefined
 }
 
 export interface EditorInfoCtx {
@@ -13,6 +15,7 @@ export interface EditorInfoCtx {
   setLoading: Dispatch<SetStateAction<boolean>>
   dom: MutableRefObject<HTMLDivElement | undefined>
   editor: MutableRefObject<Editor | undefined>
+  crepe: MutableRefObject<Crepe | undefined>
   editorFactory: GetEditor | undefined
   setEditorFactory: Dispatch<SetStateAction<GetEditor | undefined>>
 }

--- a/packages/integrations/react/src/useEditor.ts
+++ b/packages/integrations/react/src/useEditor.ts
@@ -16,5 +16,6 @@ export function useEditor(getEditor: GetEditor, deps: DependencyList = []): UseE
   return {
     loading: editorInfo.loading,
     get: () => editorInfo.editor.current,
+    getCrepe: () => editorInfo.crepe.current,
   }
 }

--- a/packages/integrations/react/src/useGetEditor.ts
+++ b/packages/integrations/react/src/useGetEditor.ts
@@ -1,3 +1,4 @@
+import { Crepe } from '@milkdown/crepe'
 import { createContext, useContext, useEffect, useRef } from 'react'
 
 import type { EditorInfoCtx } from './types'
@@ -5,7 +6,7 @@ import type { EditorInfoCtx } from './types'
 export const editorInfoContext = createContext<EditorInfoCtx>({} as EditorInfoCtx)
 
 export function useGetEditor() {
-  const { dom, editor: editorRef, setLoading, editorFactory: getEditor } = useContext(editorInfoContext)
+  const { dom, editor: editorRef, setLoading, editorFactory: getEditor, crepe } = useContext(editorInfoContext)
   const domRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -24,15 +25,28 @@ export function useGetEditor() {
       return
 
     setLoading(true)
-    editor
-      .create()
-      .then((editor) => {
-        editorRef.current = editor
-      })
-      .finally(() => {
-        setLoading(false)
-      })
-      .catch(console.error)
+    if (editor instanceof Crepe) {
+      crepe.current = editor
+      editor
+        .create()
+        .then((editor) => {
+          editorRef.current = editor
+        })
+        .finally(() => {
+          setLoading(false)
+        })
+        .catch(console.error)
+    } else {
+      editor
+        .create()
+        .then((editor) => {
+          editorRef.current = editor
+        })
+        .finally(() => {
+          setLoading(false)
+        })
+        .catch(console.error)
+    }
 
     return () => {
       editorRef.current?.destroy()

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -43,6 +43,7 @@
   "peerDependencies": {
     "@milkdown/core": "^7.2.0",
     "@milkdown/prose": "^7.2.0",
+    "@milkdown/crepe": "^7.3.3",
     "vue": "^3.0.0"
   },
   "dependencies": {
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@milkdown/core": "workspace:*",
     "@milkdown/prose": "workspace:*",
+    "@milkdown/crepe": "workspace:*",
     "vue": "^3.3.4"
   },
   "nx": {

--- a/packages/integrations/vue/src/Editor.tsx
+++ b/packages/integrations/vue/src/Editor.tsx
@@ -1,3 +1,4 @@
+import type { Crepe } from '@milkdown/crepe'
 import type { Editor } from '@milkdown/core'
 import type { InjectionKey, Ref } from 'vue'
 import {
@@ -21,7 +22,10 @@ export const Milkdown = defineComponent({
   setup: () => {
     const domRef = useGetEditor()
 
-    return () => <div data-milkdown-root ref={domRef} />
+    return () => h('div', {
+      'data-milkdown-root': true,
+      ref: domRef,
+    })
   },
 })
 
@@ -31,6 +35,7 @@ export const MilkdownProvider = defineComponent({
     const dom = ref<HTMLDivElement | null>(null)
     const editorFactory = ref<GetEditor | undefined>(undefined)
     const editor = ref<Editor | undefined>(undefined) as Ref<Editor | undefined>
+    const crepe = ref<Crepe | undefined>(undefined) as Ref<Crepe | undefined>
     const loading = ref(true)
 
     provide(editorInfoCtxKey, {
@@ -38,8 +43,9 @@ export const MilkdownProvider = defineComponent({
       dom,
       editor,
       editorFactory,
+      crepe,
     })
 
-    return () => <>{slots.default?.()}</>
+    return () => slots.default?.()
   },
 })

--- a/packages/integrations/vue/src/types.ts
+++ b/packages/integrations/vue/src/types.ts
@@ -1,16 +1,19 @@
+import type { Crepe } from '@milkdown/crepe'
 import type { Editor } from '@milkdown/core'
 import type { Ref } from 'vue'
 
-export type GetEditor = (container: HTMLDivElement) => Editor
+export type GetEditor = (container: HTMLDivElement) => Editor | Crepe
 
 export interface EditorInfoCtx {
   dom: Ref<HTMLDivElement | null>
   editor: Ref<Editor | undefined>
   editorFactory: Ref<GetEditor | undefined>
   loading: Ref<boolean>
+  crepe: Ref<Crepe | undefined>
 }
 
 export interface UseEditorReturn {
   loading: Ref<boolean>
   get: () => Editor | undefined
+  getCrepe: () => Crepe | undefined
 }

--- a/packages/integrations/vue/src/useEditor.ts
+++ b/packages/integrations/vue/src/useEditor.ts
@@ -4,12 +4,13 @@ import { editorInfoCtxKey } from './Editor'
 import type { GetEditor, UseEditorReturn } from './types'
 
 export function useEditor(getEditor: GetEditor): UseEditorReturn {
-  const { editorFactory, loading, editor } = inject(editorInfoCtxKey)!
+  const { editorFactory, loading, editor, crepe } = inject(editorInfoCtxKey)!
 
   editorFactory.value = getEditor
 
   return {
     loading,
     get: () => editor.value,
+    getCrepe: () => crepe.value,
   }
 }

--- a/packages/integrations/vue/src/useGetEditor.ts
+++ b/packages/integrations/vue/src/useGetEditor.ts
@@ -1,10 +1,11 @@
+import { Crepe } from '@milkdown/crepe'
 import { inject, onMounted, onUnmounted } from 'vue'
 
 import type { EditorInfoCtx } from './types'
 import { editorInfoCtxKey } from '.'
 
 export function useGetEditor() {
-  const { dom, loading, editor: editorRef, editorFactory: getEditor } = inject(editorInfoCtxKey, {} as EditorInfoCtx)
+  const { dom, loading, editor: editorRef, editorFactory: getEditor, crepe } = inject(editorInfoCtxKey, {} as EditorInfoCtx)
 
   onMounted(() => {
     if (!dom.value)
@@ -15,7 +16,20 @@ export function useGetEditor() {
       return
 
     loading.value = true
-    editor
+
+    if (editor instanceof Crepe) {
+      crepe.value = editor
+      editor
+        .create()
+        .then((editor) => {
+          editorRef.value = editor
+        })
+        .finally(() => {
+          loading.value = false
+        })
+        .catch(console.error)
+    } else {
+      editor
       .create()
       .then((editor) => {
         editorRef.value = editor
@@ -24,6 +38,7 @@ export function useGetEditor() {
         loading.value = false
       })
       .catch(console.error)
+    }
   })
   onUnmounted(() => {
     editorRef.value?.destroy()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@milkdown/core':
         specifier: workspace:*
         version: link:../../core
+      '@milkdown/crepe':
+        specifier: workspace:*
+        version: link:../../crepe
       '@milkdown/prose':
         specifier: workspace:*
         version: link:../../prose
@@ -453,6 +456,9 @@ importers:
       '@milkdown/core':
         specifier: workspace:*
         version: link:../../core
+      '@milkdown/crepe':
+        specifier: workspace:*
+        version: link:../../crepe
       '@milkdown/prose':
         specifier: workspace:*
         version: link:../../prose


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Crepe editor is easier to use than Milkdown, but it is not compatible with Crepe in the integration solution, so I cannot use Crepe in a more friendly way.

I adapted Crepe in `@milkdown/vue` and `@milkdown/react`.

## How did you test this change?

I refer to the document sample https://milkdown.dev/docs/recipes/vue and https://milkdown.dev/docs/recipes/react, And use `pnpm link` packages `@milkdown/vue` and `@milkdown/react` to pass.
