### PR TITLE
fix: link preview text not properly truncated

### DIFF
--- a/packages/crepe/src/theme/common/link-tooltip.css
+++ b/packages/crepe/src/theme/common/link-tooltip.css
@@ -46,6 +46,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         font-size: 14px;
+        white-space: nowrap;
         &:hover {
           text-decoration: underline;
         }

--- a/storybook/stories/components/link-tooltip.css
+++ b/storybook/stories/components/link-tooltip.css
@@ -62,6 +62,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         font-size: 14px;
+        white-space: nowrap;
 
         &:hover {
           text-decoration: underline;


### PR DESCRIPTION
## Summary

Go to https://milkdown.dev/docs/api/plugin-diagram 

Hover the link. It shows "https://mermaid-". The full link is https://mermaid-js.github.io/mermaid/#/. It looks like the intent of the CSS is to apply an ellipsis but that doesn't happen because the text wraps.

## How did you test this change?

`pnpm build` `pnpm start`, compared in storybook

Before:

![image](https://github.com/user-attachments/assets/f88f1ed4-7713-49b6-a4bc-8ab555e91352)

After:

![image](https://github.com/user-attachments/assets/9f84ae00-263d-4f55-8b64-42c6e19b56b7)
