### PR TITLE
fix: 🐛 incompatibility between Promise.resolve and angular change detection mechanism

### DIFF
--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -41,7 +41,7 @@ export const listItemBlockView = $view(
       dom.onMount = () => {
         const { anchor, head } = view.state.selection
         if (view.hasFocus()) {
-          Promise.resolve().then(() => {
+         setTimeout(() => {
             const anchorPos = view.state.doc.resolve(anchor)
             const headPos = view.state.doc.resolve(head)
             view.dispatch(

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -41,7 +41,7 @@ export const listItemBlockView = $view(
       dom.onMount = () => {
         const { anchor, head } = view.state.selection
         if (view.hasFocus()) {
-         setTimeout(() => {
+          setTimeout(() => {
             const anchorPos = view.state.doc.resolve(anchor)
             const headPos = view.state.doc.resolve(head)
             view.dispatch(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

> ✅ Closes: #1524

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

### Why does `Promise.resolve().then(...)` work immediately in Angular?

In Angular, the change detection mechanism listens for changes in the data and updates the view immediately. When you use Promise.resolve().then(...), the callback function is placed in a microtask queue and executed at the end of the current JavaScript event loop. Since Angular's change detection mechanism executes synchronously in the current event loop, view.dispatch triggers the view update immediately, causing the selection settings to take effect immediately.

### Why does it work after changing to setTimeout?

setTimeout puts the callback function into the macro queue and waits for the next event loop before executing it. This means that view.dispatch will be executed after Angular's current change detection cycle, avoiding conflicts with Angular's change detection mechanism.
In some cases, Angular's change detection may create a race condition with ProseMirror's view update mechanism, causing the selection settings to not take effect correctly. With setTimeout, you can avoid this problem by ensuring that the constituency settings are executed after Angular completes the current change detection cycle.

### Summary

**Promise.resolve().then(...)**: microtasks, which execute at the end of the current event loop, may conflict with Angular's change detection mechanism.

**setTimeout**: macro task, executed at the next event loop, can avoid conflict with Angular change detection.

## How did you test this change?

Tested to fix #1524.

Also, #1535 references #1524 in the issue, but doesn't provide a way to reproduce it so there's no way to tell if it also solves #1535.
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
