### PR TITLE
feat: add crepe ctx to make users can access crepe from editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,10 @@
 name: ci
 
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
-  merge_group:
     branches: [main]
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/packages/crepe/src/core/crepe.ts
+++ b/packages/crepe/src/core/crepe.ts
@@ -52,9 +52,11 @@ export class Crepe {
       (typeof root === 'string' ? document.querySelector(root) : root) ??
       document.body
     this.#editor = Editor.make()
+      .config((ctx) => {
+        ctx.inject(crepeCtx, this)
+      })
       .config(configureFeatures(enabledFeatures))
       .config((ctx) => {
-        ctx.set(crepeCtx, this)
         ctx.set(rootCtx, this.#rootElement)
         ctx.set(defaultValueCtx, defaultValue)
         ctx.set(editorViewOptionsCtx, {

--- a/packages/crepe/src/core/crepe.ts
+++ b/packages/crepe/src/core/crepe.ts
@@ -17,7 +17,7 @@ import { trailing } from '@milkdown/kit/plugin/trailing'
 
 import type { CrepeFeatureConfig } from '../feature'
 import { CrepeFeature, defaultFeatures, loadFeature } from '../feature'
-import { configureFeatures } from './slice'
+import { configureFeatures, crepeCtx } from './slice'
 import type { ListenerManager } from '@milkdown/kit/plugin/listener'
 import { listener, listenerCtx } from '@milkdown/kit/plugin/listener'
 
@@ -54,6 +54,7 @@ export class Crepe {
     this.#editor = Editor.make()
       .config(configureFeatures(enabledFeatures))
       .config((ctx) => {
+        ctx.set(crepeCtx, this)
         ctx.set(rootCtx, this.#rootElement)
         ctx.set(defaultValueCtx, defaultValue)
         ctx.set(editorViewOptionsCtx, {

--- a/packages/crepe/src/core/index.ts
+++ b/packages/crepe/src/core/index.ts
@@ -1,1 +1,2 @@
 export { Crepe, type CrepeConfig } from './crepe'
+export { crepeCtx } from './slice'

--- a/packages/crepe/src/core/slice.ts
+++ b/packages/crepe/src/core/slice.ts
@@ -1,8 +1,11 @@
 import type { Ctx } from '@milkdown/kit/ctx'
 import { createSlice } from '@milkdown/kit/ctx'
 import type { CrepeFeature } from '../feature'
+import type { Crepe } from './crepe'
 
 export const FeaturesCtx = createSlice([] as CrepeFeature[], 'FeaturesCtx')
+
+export const crepeCtx = createSlice({} as Crepe, 'CrepeCtx')
 
 export function configureFeatures(features: CrepeFeature[]) {
   return (ctx: Ctx) => {

--- a/packages/crepe/src/index.ts
+++ b/packages/crepe/src/index.ts
@@ -1,2 +1,2 @@
 export { CrepeFeature } from './feature'
-export * from './core'
+export { Crepe, type CrepeConfig, crepeCtx } from './core'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Add crepe ctx to make users can access crepe from editor
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

CI
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
