### PR TITLE
feat: make integrations accept crepe editor

### DIFF
--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -45,6 +45,7 @@
     "react-dom": "*"
   },
   "dependencies": {
+    "@milkdown/crepe": "workspace:*",
     "@milkdown/kit": "workspace:*",
     "tslib": "^2.8.1"
   },

--- a/packages/integrations/react/src/types.ts
+++ b/packages/integrations/react/src/types.ts
@@ -1,8 +1,8 @@
+import type { Crepe } from '@milkdown/crepe'
 import type { Editor } from '@milkdown/kit/core'
 import type { Dispatch, RefObject, SetStateAction } from 'react'
 
-export type GetEditor = (container: HTMLElement) => Editor | undefined
-
+export type GetEditor = (container: HTMLElement) => Editor | Crepe | undefined
 export interface UseEditorReturn {
   readonly loading: boolean
   readonly get: () => Editor | undefined

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -44,6 +44,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
+    "@milkdown/crepe": "workspace:*",
     "@milkdown/kit": "workspace:*",
     "tslib": "^2.8.1"
   },

--- a/packages/integrations/vue/src/types.ts
+++ b/packages/integrations/vue/src/types.ts
@@ -1,7 +1,8 @@
+import type { Crepe } from '@milkdown/crepe'
 import type { Editor } from '@milkdown/kit/core'
 import type { Ref } from 'vue'
 
-export type GetEditor = (container: HTMLDivElement) => Editor
+export type GetEditor = (container: HTMLDivElement) => Editor | Crepe
 
 export interface EditorInfoCtx {
   dom: Ref<HTMLDivElement | null>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
 
   packages/integrations/react:
     dependencies:
+      '@milkdown/crepe':
+        specifier: workspace:*
+        version: link:../../crepe
       '@milkdown/kit':
         specifier: workspace:*
         version: link:../../kit
@@ -445,6 +448,9 @@ importers:
 
   packages/integrations/vue:
     dependencies:
+      '@milkdown/crepe':
+        specifier: workspace:*
+        version: link:../../crepe
       '@milkdown/kit':
         specifier: workspace:*
         version: link:../../kit


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Make react and vue `useEditor` hook accept crepe editor.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

CI and manually
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
