### PR TITLE
fix: allow running in insecure context

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -127,7 +127,8 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "tslib": "^2.8.1",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "nanoid": "^5.0.9"
   },
   "devDependencies": {
     "@codemirror/language": "^6.10.1",

--- a/packages/components/src/image-block/view/component.ts
+++ b/packages/components/src/image-block/view/component.ts
@@ -1,5 +1,6 @@
 import type { Component } from 'atomico'
 import { c, html, useEffect, useRef, useState } from 'atomico'
+import { nanoid } from 'nanoid'
 import clsx from 'clsx'
 import type { ImageBlockConfig } from '../config'
 import { IMAGE_DATA_TYPE } from '../schema'
@@ -34,7 +35,7 @@ export const imageComponent: Component<ImageComponentProps> = ({
   const linkInput = useRef<HTMLInputElement>()
   const [showCaption, setShowCaption] = useState(caption.length > 0)
   const [hidePlaceholder, setHidePlaceholder] = useState(src.length !== 0)
-  const [uuid] = useState(crypto.randomUUID())
+  const [uuid] = useState(nanoid())
   const [focusLinkInput, setFocusLinkInput] = useState(false)
   const [currentLink, setCurrentLink] = useState(src)
 

--- a/packages/components/src/image-inline/component.ts
+++ b/packages/components/src/image-inline/component.ts
@@ -1,5 +1,6 @@
 import { c, html, useRef, useState } from 'atomico'
 import type { Component } from 'atomico'
+import { nanoid } from 'nanoid'
 import clsx from 'clsx'
 import type { InlineImageConfig } from './config'
 
@@ -24,7 +25,7 @@ export const inlineImageComponent: Component<InlineImageComponentProps> = ({
   config,
 }) => {
   const linkInput = useRef<HTMLInputElement>()
-  const [uuid] = useState(crypto.randomUUID())
+  const [uuid] = useState(nanoid())
   const [focusLinkInput, setFocusLinkInput] = useState(false)
   const [hidePlaceholder, setHidePlaceholder] = useState(src.length !== 0)
   const [currentLink, setCurrentLink] = useState(src)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.0.9
       tslib:
         specifier: ^2.8.1
         version: 2.8.1


### PR DESCRIPTION
- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

The current packages for inline and image blocks use crypto.randomuuid to generate UUID for useState but crypto.randomuuid is not available in non-HTTPS context. This means it cannot run in insecure context.

## How did you test this change?
  I ran the tests and it passed all tests (pnpm test). I also used the mono repo in my existing project and it solves the issue.

  I ran the package in an insecure context and I no longer run into issues. I fixed the issue by including nanoid to generate random UUIDs instead of relying on crypto. It adds bloat but nanoid is reliable and is one of the smallest (if not the smallest) package.
