### PR TITLE
fix: react and vue destroy when using crepe

### DIFF
--- a/packages/integrations/react/src/use-get-editor.ts
+++ b/packages/integrations/react/src/use-get-editor.ts
@@ -39,7 +39,7 @@ export function useGetEditor() {
       .catch(console.error)
 
     return () => {
-      editorRef.current?.destroy()
+      editor.destroy()
     }
   }, [dom, editorRef, getEditor, setLoading])
 

--- a/packages/integrations/vue/src/use-get-editor.ts
+++ b/packages/integrations/vue/src/use-get-editor.ts
@@ -1,7 +1,9 @@
-import { inject, onMounted, onUnmounted } from 'vue'
+import { inject, onMounted, onUnmounted, ref } from 'vue'
 
 import type { EditorInfoCtx } from './types'
 import { editorInfoCtxKey } from './consts'
+import type { Crepe } from '@milkdown/crepe'
+import type { Editor } from '@milkdown/kit/core'
 
 export function useGetEditor() {
   const {
@@ -10,6 +12,7 @@ export function useGetEditor() {
     editor: editorRef,
     editorFactory: getEditor,
   } = inject(editorInfoCtxKey, {} as EditorInfoCtx)
+  const currentEditorRef = ref<Editor | Crepe>()
 
   onMounted(() => {
     if (!dom.value) return
@@ -18,6 +21,7 @@ export function useGetEditor() {
     if (!editor) return
 
     loading.value = true
+    currentEditorRef.value = editor
     editor
       .create()
       .then((editor) => {
@@ -29,7 +33,7 @@ export function useGetEditor() {
       .catch(console.error)
   })
   onUnmounted(() => {
-    editorRef.value?.destroy()
+    currentEditorRef.value?.destroy()
   })
 
   return dom


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Fix destroy when using crepe with react/vue.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

CI
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
