### PR TITLE
fix: should disable image resizer for readonly mode

### DIFF
--- a/packages/components/src/image-block/view/component.ts
+++ b/packages/components/src/image-block/view/component.ts
@@ -47,6 +47,7 @@ export const imageComponent: Component<ImageComponentProps> = ({
     ratio,
     setRatio: (r) => setAttr?.('ratio', r),
     src,
+    readonly,
   })
 
   useEffect(() => {

--- a/packages/components/src/image-block/view/event.ts
+++ b/packages/components/src/image-block/view/event.ts
@@ -6,6 +6,7 @@ interface Options {
   ratio: number
   setRatio: (ratio: number) => void
   src: string
+  readonly: boolean
 }
 
 export function useBlockEffect({
@@ -14,6 +15,7 @@ export function useBlockEffect({
   ratio,
   setRatio,
   src,
+  readonly,
 }: Options) {
   const host = useHost()
   const root = useMemo(() => host.current.getRootNode() as HTMLElement, [host])
@@ -53,6 +55,7 @@ export function useBlockEffect({
     }
 
     const pointerDown = (e: PointerEvent) => {
+      if (readonly) return
       e.preventDefault()
       root.addEventListener('pointermove', onMove)
       root.addEventListener('pointerup', pointerUp)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Should disable image resizer for readonly mode.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Manually
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
