### PR TITLE
Check for isImageBlockEnabled and isTableEnabled

### DIFF
--- a/packages/crepe/src/feature/block-edit/menu/config.ts
+++ b/packages/crepe/src/feature/block-edit/menu/config.ts
@@ -213,10 +213,12 @@ export function getGroups(
       },
     })
 
-  const advancedGroup = groupBuilder
-    .addGroup('advanced', config?.slashMenuAdvancedGroupLabel ?? 'Advanced')
+  const advancedGroup = groupBuilder.addGroup(
+    'advanced',
+    config?.slashMenuAdvancedGroupLabel ?? 'Advanced'
+  )
 
-    if ( isImageBlockEnabled ) {
+  if (isImageBlockEnabled) {
     advancedGroup.addItem('image', {
       label: config?.slashMenuImageLabel ?? 'Image',
       icon: config?.slashMenuImageIcon?.() ?? imageIcon,
@@ -231,18 +233,18 @@ export function getGroups(
   }
 
   advancedGroup.addItem('code', {
-      label: config?.slashMenuCodeBlockLabel ?? 'Code',
-      icon: config?.slashMenuCodeBlockIcon?.() ?? codeIcon,
-      onRun: (ctx) => {
-        const view = ctx.get(editorViewCtx)
-        const { dispatch, state } = view
+    label: config?.slashMenuCodeBlockLabel ?? 'Code',
+    icon: config?.slashMenuCodeBlockIcon?.() ?? codeIcon,
+    onRun: (ctx) => {
+      const view = ctx.get(editorViewCtx)
+      const { dispatch, state } = view
 
-        const command = clearContentAndAddBlockType(codeBlockSchema.type(ctx))
-        command(state, dispatch)
-      },
-    })
+      const command = clearContentAndAddBlockType(codeBlockSchema.type(ctx))
+      command(state, dispatch)
+    },
+  })
 
-    if ( isTableEnabled ) {
+  if (isTableEnabled) {
     advancedGroup.addItem('table', {
       label: config?.slashMenuTableLabel ?? 'Table',
       icon: config?.slashMenuTableIcon?.() ?? tableIcon,

--- a/packages/crepe/src/feature/block-edit/menu/config.ts
+++ b/packages/crepe/src/feature/block-edit/menu/config.ts
@@ -1,4 +1,6 @@
+import { imageBlockSchema } from '@milkdown/kit/component/image-block'
 import { editorViewCtx } from '@milkdown/kit/core'
+import type { Ctx } from '@milkdown/kit/ctx'
 import {
   blockquoteSchema,
   bulletListSchema,
@@ -9,13 +11,15 @@ import {
   orderedListSchema,
   paragraphSchema,
 } from '@milkdown/kit/preset/commonmark'
-import { TextSelection } from '@milkdown/kit/prose/state'
-import { imageBlockSchema } from '@milkdown/kit/component/image-block'
 import { createTable } from '@milkdown/kit/preset/gfm'
+import { TextSelection } from '@milkdown/kit/prose/state'
+import { CrepeFeature } from '../../..'
+import { FeaturesCtx } from '../../../core/slice'
 import {
   bulletListIcon,
   codeIcon,
   dividerIcon,
+  functionsIcon,
   h1Icon,
   h2Icon,
   h3Icon,
@@ -28,9 +32,9 @@ import {
   tableIcon,
   textIcon,
   todoListIcon,
-  functionsIcon,
 } from '../../../icons'
 import type { BlockEditFeatureConfig } from '../index'
+import { GroupBuilder } from './group-builder'
 import type { MenuItemGroup } from './utils'
 import {
   clearContentAndAddBlockType,
@@ -38,10 +42,6 @@ import {
   clearContentAndWrapInBlockType,
   clearRange,
 } from './utils'
-import { GroupBuilder } from './group-builder'
-import type { Ctx } from '@milkdown/kit/ctx'
-import { FeaturesCtx } from '../../../core/slice'
-import { CrepeFeature } from '../../..'
 
 export function getGroups(
   filter?: string,
@@ -50,6 +50,8 @@ export function getGroups(
 ) {
   const flags = ctx?.get(FeaturesCtx)
   const isLatexEnabled = flags?.includes(CrepeFeature.Latex)
+  const isImageBlockEnabled = flags?.includes(CrepeFeature.ImageBlock)
+  const isTableEnabled = flags?.includes(CrepeFeature.Table)
 
   const groupBuilder = new GroupBuilder()
   groupBuilder
@@ -213,7 +215,9 @@ export function getGroups(
 
   const advancedGroup = groupBuilder
     .addGroup('advanced', config?.slashMenuAdvancedGroupLabel ?? 'Advanced')
-    .addItem('image', {
+
+    if ( isImageBlockEnabled ) {
+    advancedGroup.addItem('image', {
       label: config?.slashMenuImageLabel ?? 'Image',
       icon: config?.slashMenuImageIcon?.() ?? imageIcon,
       onRun: (ctx) => {
@@ -224,7 +228,9 @@ export function getGroups(
         command(state, dispatch)
       },
     })
-    .addItem('code', {
+  }
+
+  advancedGroup.addItem('code', {
       label: config?.slashMenuCodeBlockLabel ?? 'Code',
       icon: config?.slashMenuCodeBlockIcon?.() ?? codeIcon,
       onRun: (ctx) => {
@@ -235,7 +241,9 @@ export function getGroups(
         command(state, dispatch)
       },
     })
-    .addItem('table', {
+
+    if ( isTableEnabled ) {
+    advancedGroup.addItem('table', {
       label: config?.slashMenuTableLabel ?? 'Table',
       icon: config?.slashMenuTableIcon?.() ?? tableIcon,
       onRun: (ctx) => {
@@ -260,6 +268,7 @@ export function getGroups(
         })
       },
     })
+  }
 
   if (isLatexEnabled) {
     advancedGroup.addItem('math', {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [X] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [X] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary
Fixes #1760 - also updated to properly allow disabling of Table in Advanced Block Edit menu.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
I ran the pnpm test script which has passed, and I have tested using a pnpm pack command to integrate the change into my project that discovered the problem. This fixes the issue, if the configuration is set to now show image uploads or tables they are not present in the menu. If the configuration does not specify, then they will appear as before.

This is my first ever PR so please be gentle ;-)

———————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target tsc for 29 projects and 29 tasks they depend on (40s)

View logs and investigate cache misses at https://nx.app/runs/dFNlOkCTqJ


> @milkdown/monorepo@0.0.0 test:unit /Users/stevebrown/Projects/milkdown
> vitest run


 RUN  v3.0.9 /Users/stevebrown/Projects/milkdown

 ✓ packages/ctx/src/timer/clock.spec.ts (2 tests) 2ms
 ✓ packages/ctx/src/context/slice.spec.ts (3 tests) 3ms
 ✓ packages/ctx/src/context/container.spec.ts (4 tests) 2ms
 ✓ packages/ctx/src/timer/timer.spec.ts (2 tests) 23ms
 ✓ packages/transformer/src/parser/state.spec.ts (7 tests) 4ms
 ✓ packages/transformer/src/serializer/state.spec.ts (4 tests) 5ms
 ✓ packages/ctx/src/plugin/ctx.spec.ts (3 tests) 50ms
 ✓ packages/transformer/src/utility/stack.spec.ts (1 test) 1ms
 ✓ packages/transformer/src/serializer/stack-element.spec.ts (1 test) 1ms
 ✓ packages/transformer/src/parser/stack-element.spec.ts (1 test) 1ms

 Test Files  10 passed (10)
      Tests  28 passed (28)
   Start at  17:53:28
   Duration  1.10s (transform 217ms, setup 0ms, collect 479ms, tests 92ms, environment 3.38s, prepare 724ms)

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
