### PR TITLE
fix: 🐛 should not display slash menu if has following chars

### DIFF
--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -1,4 +1,4 @@
-import type { Selection} from '@milkdown/kit/prose/state';
+import type { Selection } from '@milkdown/kit/prose/state'
 import { TextSelection, type PluginView } from '@milkdown/kit/prose/state'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { SlashProvider, slashFactory } from '@milkdown/kit/plugin/slash'
@@ -125,13 +125,12 @@ class MenuView implements PluginView {
   }
 }
 
-
 function isSelectionAtEndOfNode(selection: Selection) {
-  if (!(selection instanceof TextSelection)) return false;
+  if (!(selection instanceof TextSelection)) return false
 
-  const { $head } = selection;
-  const parent = $head.parent;
-  const offset = $head.parentOffset;
+  const { $head } = selection
+  const parent = $head.parent
+  const offset = $head.parentOffset
 
-  return offset === parent.content.size;
+  return offset === parent.content.size
 }

--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -1,4 +1,8 @@
-import { TextSelection, type PluginView, type Selection } from '@milkdown/kit/prose/state'
+import {
+  TextSelection,
+  type PluginView,
+  type Selection,
+} from '@milkdown/kit/prose/state'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { SlashProvider, slashFactory } from '@milkdown/kit/plugin/slash'
 import type { Ctx } from '@milkdown/kit/ctx'

--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -1,4 +1,5 @@
-import type { PluginView } from '@milkdown/kit/prose/state'
+import type { Selection} from '@milkdown/kit/prose/state';
+import { TextSelection, type PluginView } from '@milkdown/kit/prose/state'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { SlashProvider, slashFactory } from '@milkdown/kit/plugin/slash'
 import type { Ctx } from '@milkdown/kit/ctx'
@@ -59,6 +60,10 @@ class MenuView implements PluginView {
 
         if (currentText == null) return false
 
+        if (!isSelectionAtEndOfNode(view.state.selection)) {
+          return false
+        }
+
         const pos = self.#programmaticallyPos
 
         self.#content.filter = currentText.startsWith('/')
@@ -118,4 +123,15 @@ class MenuView implements PluginView {
     this.#slashProvider.destroy()
     this.#content.remove()
   }
+}
+
+
+function isSelectionAtEndOfNode(selection: Selection) {
+  if (!(selection instanceof TextSelection)) return false;
+
+  const { $head } = selection;
+  const parent = $head.parent;
+  const offset = $head.parentOffset;
+
+  return offset === parent.content.size;
 }

--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -1,5 +1,4 @@
-import type { Selection } from '@milkdown/kit/prose/state'
-import { TextSelection, type PluginView } from '@milkdown/kit/prose/state'
+import { TextSelection, type PluginView, type Selection } from '@milkdown/kit/prose/state'
 import type { EditorView } from '@milkdown/kit/prose/view'
 import { SlashProvider, slashFactory } from '@milkdown/kit/plugin/slash'
 import type { Ctx } from '@milkdown/kit/ctx'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Should not display slash menu if selection is not at the end of the line.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
Manually.
