### PR TITLE
fix: 🐛 google doc paste

### DIFF
--- a/packages/plugins/preset-commonmark/src/mark/strong.ts
+++ b/packages/plugins/preset-commonmark/src/mark/strong.ts
@@ -29,11 +29,19 @@ export const strongSchema = $markSchema('strong', (ctx) => ({
     // This works around a Google Docs misbehavior where
     // pasted content will be inexplicably wrapped in `<b>`
     // tags with a font-weight normal.
-    {tag: "b", getAttrs: (node: HTMLElement) => node.style.fontWeight != "normal" && null},
+    {
+      tag: 'b',
+      getAttrs: (node: HTMLElement) =>
+        node.style.fontWeight != 'normal' && null,
+    },
     { tag: 'strong' },
     { style: 'font-style', getAttrs: (value) => (value === 'bold') as false },
-    {style: "font-weight=400", clearMark: m => m.type.name == "strong"},
-    {style: "font-weight", getAttrs: (value: string) => /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null},
+    { style: 'font-weight=400', clearMark: (m) => m.type.name == 'strong' },
+    {
+      style: 'font-weight',
+      getAttrs: (value: string) =>
+        /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null,
+    },
   ],
   toDOM: (mark) => ['strong', ctx.get(strongAttr.key)(mark)],
   parseMarkdown: {

--- a/packages/plugins/preset-commonmark/src/mark/strong.ts
+++ b/packages/plugins/preset-commonmark/src/mark/strong.ts
@@ -26,9 +26,14 @@ export const strongSchema = $markSchema('strong', (ctx) => ({
     },
   },
   parseDOM: [
-    { tag: 'b' },
+    // This works around a Google Docs misbehavior where
+    // pasted content will be inexplicably wrapped in `<b>`
+    // tags with a font-weight normal.
+    {tag: "b", getAttrs: (node: HTMLElement) => node.style.fontWeight != "normal" && null},
     { tag: 'strong' },
     { style: 'font-style', getAttrs: (value) => (value === 'bold') as false },
+    {style: "font-weight=400", clearMark: m => m.type.name == "strong"},
+    {style: "font-weight", getAttrs: (value: string) => /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null},
   ],
   toDOM: (mark) => ['strong', ctx.get(strongAttr.key)(mark)],
   parseMarkdown: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
✅ Closes: #1209

Fix google doc misbehavior where pasted content will be wrapped in`<b>` tags.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
CI