### PR TITLE
fix: 🐛 list item component should be focused when created

### DIFF
--- a/e2e/tests/crepe/list.spec.ts
+++ b/e2e/tests/crepe/list.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test'
+
+import { focusEditor, getMarkdown, waitNextFrame } from '../misc'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/crepe/')
+})
+
+test('latex block preview toggle', async ({ page }) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await page.keyboard.type('1.')
+  await page.keyboard.press('Space')
+  await waitNextFrame(page)
+  await page.keyboard.type('First item')
+  const li = editor.locator('ol li')
+  await expect(li).toHaveCount(1)
+  await expect(li).toContainText('First item')
+
+  await page.keyboard.press('Enter')
+  await waitNextFrame(page)
+  await page.keyboard.type('Second item')
+  await expect(li).toHaveCount(2)
+  await expect(li.nth(1)).toContainText('Second item')
+
+  const markdown = await getMarkdown(page)
+  expect(markdown.trim()).toBe('1. First item\n2. Second item')
+})

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -2,6 +2,7 @@ import type { Node } from '@milkdown/prose/model'
 import type { NodeViewConstructor } from '@milkdown/prose/view'
 
 import { listItemSchema } from '@milkdown/preset-commonmark'
+import { TextSelection } from '@milkdown/prose/state'
 import { $view } from '@milkdown/utils'
 import { createApp, ref, watchEffect } from 'vue'
 
@@ -40,7 +41,16 @@ export const listItemBlockView = $view(
         }
       })
       const onMount = (div: HTMLElement) => {
+        const { anchor, head } = view.state.selection
         div.appendChild(contentDOM)
+        // put the cursor to the new created list item
+        requestAnimationFrame(() => {
+          const anchorPos = view.state.doc.resolve(anchor)
+          const headPos = view.state.doc.resolve(head)
+          view.dispatch(
+            view.state.tr.setSelection(new TextSelection(anchorPos, headPos))
+          )
+        })
       }
 
       const app = createApp(ListItem, {


### PR DESCRIPTION
✅ Closes: #1853

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Fix the focus behavior of list item.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

E2E
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
