### PR TITLE
fix: 🐛 missing style for codemirror search panel

### DIFF
--- a/packages/crepe/src/theme/common/code-mirror.css
+++ b/packages/crepe/src/theme/common/code-mirror.css
@@ -75,7 +75,14 @@
             transform: scale(0);
             transition: 120ms transform ease-in-out;
             box-shadow: inset 1em 1em var(--crepe-color-outline);
-            clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+            clip-path: polygon(
+              14% 44%,
+              0 65%,
+              50% 100%,
+              100% 16%,
+              80% 0%,
+              43% 62%
+            );
           }
           &:checked::before {
             transform: scale(1);

--- a/packages/crepe/src/theme/common/code-mirror.css
+++ b/packages/crepe/src/theme/common/code-mirror.css
@@ -10,7 +10,7 @@
       padding-top: 10px;
       width: max-content;
       position: absolute;
-      z-index: 1;
+      z-index: 999;
     }
 
     .hidden {
@@ -29,6 +29,59 @@
     .cm-gutters {
       border-right: none;
       background: var(--crepe-color-surface);
+    }
+
+    .cm-panel {
+      font-family: var(--crepe-font-default);
+      background: var(--crepe-color-surface);
+      color: var(--crepe-color-on-surface);
+      input {
+        caret-color: var(--crepe-color-outline);
+        border-radius: 4px;
+        background: var(--crepe-color-surface-low);
+      }
+      & > button {
+        text-transform: capitalize;
+        background: var(--crepe-color-surface-low);
+        color: var(--crepe-color-on-surface-variant);
+        border: 1px solid var(--crepe-color-outline);
+        font-weight: 600;
+        cursor: pointer;
+        border-radius: 4px;
+        &:hover {
+          background: var(--crepe-color-hover);
+        }
+      }
+      & > label {
+        display: inline-flex;
+        align-items: center;
+        text-transform: capitalize;
+        input[type='checkbox'] {
+          border-radius: 4px;
+          cursor: pointer;
+          appearance: none;
+          -webkit-appearance: none;
+          background: var(--crepe-color-surface-low);
+          width: 1.15em;
+          height: 1.15em;
+          border: 1px solid var(--crepe-color-outline);
+          display: grid;
+          place-content: center;
+          &::before {
+            content: '';
+            transform-origin: bottom left;
+            width: 0.65em;
+            height: 0.65em;
+            transform: scale(0);
+            transition: 120ms transform ease-in-out;
+            box-shadow: inset 1em 1em var(--crepe-color-outline);
+            clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+          }
+          &:checked::before {
+            transform: scale(1);
+          }
+        }
+      }
     }
 
     .tools {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Add missing style for codemirror search panel.

<img width="662" alt="Screenshot 2025-05-24 at 20 29 32" src="https://github.com/user-attachments/assets/6e0da018-7971-44c9-8ea1-1e88d5a85b80" />

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Manually.
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
