### PR TITLE
fix: resolve build error on Windows by updating __dirname definition

### DIFF
--- a/docs/src/index.ts
+++ b/docs/src/index.ts
@@ -5,11 +5,12 @@ import { ensureDirSync } from 'fs-extra/esm'
 import { readdirSync } from 'node:fs'
 import { writeFile, copyFile } from 'node:fs/promises'
 import { resolve, parse } from 'node:path'
+import { URL, fileURLToPath } from 'node:url'
 
 const logger = new Logger('docs')
 const workspace = new Workspace()
 
-const __dirname = new URL('.', import.meta.url).pathname
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const templatesDir = resolve(__dirname, '..', 'templates')
 const apiDir = resolve(__dirname, '..', 'api')
 const apiOutDir = resolve(__dirname, '..', 'lib')


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Closed #1920

When building milkdown on Windows, the drive letter for the build path of docs will be duplicated.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Run the command on Linux and Windows successfully.

```bash
cd docs
pnpm build
```