### PR TITLE
fix: fix run command error in GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/typescript-node/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:1-16-buster
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:1-18-buster
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     // Update 'VARIANT' to pick a Node version: 12, 14, 16
     "args": {
-      "VARIANT": "16"
+      "VARIANT": "18"
     }
   },
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [ ] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [ ] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

> pnpm@10 require Node.js v18

Notice the #1875 bump up pnpm to v10, but the codespaces still using Node.js v16.

Running command failed when we run the source code in the GitHub Codespaces like this:

```bash
@gweesin ➜ /workspaces/milkdown (main) $ pnpm -v
ERROR: This version of pnpm requires at least Node.js v18.12
The current version of Node.js is v16.20.2
Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
```

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

1. Click the link https://github.com/gweesin/milkdown/tree/fix/github-codespaces-container-error
2. Click **Code** / **Codespaces** / **+** button
    ![image](https://github.com/user-attachments/assets/6fd0a693-80c0-41c7-b2a6-70247e246b57)
3. Wait the environment ready
4. Run `node -v` expect v18 and run the `pnpm -v` command successfully