### PR TITLE
fix: fix running postcss-cli error with single quotes on Windows OS

### DIFF
--- a/packages/crepe/package.json
+++ b/packages/crepe/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "build": "pnpm run build:es && pnpm run build:theme && echo",
     "build:es": "rollup -c",
-    "build:theme": "postcss 'src/theme' --base 'src/theme' --dir 'lib/theme'"
+    "build:theme": "postcss src/theme --base src/theme --dir lib/theme"
   },
   "dependencies": {
     "@codemirror/commands": "^6.2.4",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -344,7 +344,7 @@
     "src"
   ],
   "scripts": {
-    "build": "postcss 'src' --base 'src' --dir 'lib'"
+    "build": "postcss src --base src --dir lib"
   },
   "dependencies": {
     "@milkdown/components": "workspace:*",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The postcss-cli cannot resolve input params around with single quotes on Windows OS.

![426dbb7823dcc61e255a30bfa40a18e1](https://github.com/user-attachments/assets/d2a11ca9-1266-470b-bb15-f0ca36930d1d)

```bash
C:\Users\86159\AppData\Local\pnpm\pnpm.cmd run build

> @milkdown/kit@7.11.1 build D:\person\milkdown\packages\kit
> postcss 'src' --base 'src' --dir 'lib'

Input Error: You must pass a valid list of files to parse
 ELIFECYCLE  Command failed with exit code 1.

Process finished with exit code 1
```

Also the single quotes is unnecessary on Linux OS.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Running `pnpm build` on my Windows machine and running `pnpm build` on GitHub Codespaces virtual Linux workspace.
