### PR TITLE
fix: 🐛 should focus editor when clicking todo list

### DIFF
--- a/e2e/tests/crepe/list.spec.ts
+++ b/e2e/tests/crepe/list.spec.ts
@@ -26,3 +26,28 @@ test('latex block preview toggle', async ({ page }) => {
   const markdown = await getMarkdown(page)
   expect(markdown.trim()).toBe('1. First item\n2. Second item')
 })
+
+test('should focus on the editor after clicking on the list item', async ({
+  page,
+}) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await page.keyboard.type('- [ ]')
+  await page.keyboard.press('Space')
+  await waitNextFrame(page)
+  await page.keyboard.type('First item')
+  const li = editor.locator('ul li')
+  await expect(li).toHaveCount(1)
+  await expect(li).toContainText('First item')
+
+  await editor.blur()
+
+  // Click on the list item
+  await li.locator('.label-wrapper').click()
+  // Check if the editor is focused
+  const isFocused = await editor.evaluate(() => window.__view__.hasFocus())
+  expect(isFocused).toBe(true)
+
+  const markdown = await getMarkdown(page)
+  expect(markdown.trim()).toBe('* [x] First item')
+})

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -31,6 +31,9 @@ export const listItemBlockView = $view(
         if (!view.editable) return
         const pos = getPos()
         if (pos == null) return
+
+        if (!view.hasFocus()) view.focus()
+
         view.dispatch(view.state.tr.setNodeAttribute(pos, attr, value))
       }
       const disposeSelectedWatcher = watchEffect(() => {


### PR DESCRIPTION
✅ Closes: #1917

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Should focus the editor when clicking todo list.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

E2E
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
