### PR TITLE
feat: 🎸 Add plugin feature to crepe

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,72 @@
+# Crepe Plugin Examples
+
+This directory contains organized examples of Crepe editor plugins, demonstrating text highlighting and interactive quiz functionality.
+
+## Structure
+
+```
+dev/
+├── vanilla/            # Vanilla JavaScript examples
+│   ├── index.html      # Main demo page
+│   ├── index.ts        # Editor setup
+│   ├── features/       # Feature definitions
+│   │   ├── highlight.ts
+│   │   └── quiz.ts
+│   └── components/     # Component implementations
+│       └── quiz-component.ts
+├── react/              # React-based examples
+│   ├── index.html      # Main demo page
+│   ├── index.tsx       # Editor setup
+│   ├── features/       # Feature definitions
+│   │   ├── highlight.ts
+│   │   └── quiz.ts
+│   ├── components/     # React components
+│   │   ├── QuizComponent.tsx
+│   │   ├── QuizReactView.tsx
+│   │   └── QuizEditModal.tsx
+│   └── types/          # TypeScript types
+│       └── quiz.ts
+```
+
+## Features Demonstrated
+
+### 🎨 Text Highlighting
+
+- **Multiple Colors**: Yellow, Pink, Green, Blue, Orange
+- **Toolbar Integration**: Custom toolbar buttons with visual feedback
+- **State Management**: Active/disabled states based on selection
+- **ProseMirror Schema**: Complete mark schema with DOM parsing/serialization
+
+### 📝 Interactive Quiz Blocks
+
+- **Drag & Drop**: Fully draggable quiz blocks
+- **Live Editing**: In-place editing with modal interface
+- **Answer Validation**: Immediate feedback on correct/incorrect answers
+- **State Persistence**: Quiz state maintained across editor operations
+- **Slash Menu**: Easy insertion via `/quiz` command
+
+## Running Examples
+
+### Development Server
+
+```bash
+cd dev
+npx vite --config vite.config.mts
+echo "http://localhost:5173/vanilla/index.html or http://localhost:5173/vanilla/index.html for React"
+```
+
+## Key Implementation Details
+
+### Non-React Example
+
+- Uses vanilla JavaScript DOM manipulation
+- Direct ProseMirror node view implementation
+- Manual state management and event handling
+- No external UI library dependencies
+
+### React Example
+
+- Uses React components for UI rendering
+- React Portal integration for modals
+- React state management within components
+- Clean separation of concerns with TypeScript types

--- a/dev/package.json
+++ b/dev/package.json
@@ -31,8 +31,12 @@
   },
   "dependencies": {
     "@types/lodash-es": "^4.17.12",
+    "@types/react": "^19.1.5",
+    "@types/react-dom": "^19.1.5",
     "chalk": "^5.4.1",
     "jsonc-parser": "^3.3.1",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.17.21",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   }
 }

--- a/dev/react/components/quiz-component.tsx
+++ b/dev/react/components/quiz-component.tsx
@@ -1,0 +1,184 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+
+import type { QuizOption, QuizAttrs } from '../types/quiz'
+
+import { QuizEditModal } from './quiz-edit-modal'
+import { QuizReactView } from './quiz-react-view'
+
+export class QuizComponent {
+  dom: HTMLElement
+  node: any
+  view: any
+  getPos: () => number
+  ctx: any
+  reactRoot: any = null
+  modalRoot: HTMLDivElement | null = null
+  popupEl: HTMLDivElement | null = null
+  selected: boolean = false
+
+  constructor(node: any, view: any, getPos: () => number, ctx: any) {
+    this.node = node
+    this.view = view
+    this.getPos = getPos
+    this.ctx = ctx
+    this.dom = document.createElement('div')
+    this.render()
+    this.setupSelectionObserver()
+  }
+
+  render() {
+    if (!this.reactRoot) {
+      this.reactRoot = createRoot(this.dom)
+    }
+
+    const { question, options, selectedAnswer, showResult } =
+      this.node.attrs || {}
+
+    this.reactRoot.render(
+      <QuizReactView
+        question={question}
+        options={options}
+        selectedAnswer={selectedAnswer}
+        showResult={showResult}
+        onSelect={this.selectAnswer}
+        onEdit={this.openEditModal}
+        isSelected={this.selected}
+      />
+    )
+  }
+
+  selectAnswer = (answerId: string) => {
+    const options = Array.isArray(this.node.attrs?.options)
+      ? this.node.attrs.options
+      : []
+    const selected = options.find((o: QuizOption) => o.id === answerId)
+
+    if (selected && selected.isCorrect) {
+      this.showPopup('🎉 Correct! Well done!')
+    } else {
+      this.showPopup('❌ Not quite right, try again!')
+    }
+
+    this.updateAttributes({ selectedAnswer: answerId, showResult: true })
+  }
+
+  updateAttributes(attrs: Partial<QuizAttrs>) {
+    const pos = this.getPos()
+    if (typeof pos !== 'number') return
+
+    const baseAttrs =
+      typeof this.node.attrs === 'object' && this.node.attrs !== null
+        ? this.node.attrs
+        : {}
+    const patchAttrs = typeof attrs === 'object' && attrs !== null ? attrs : {}
+
+    const tr = this.view.state.tr.setNodeMarkup(pos, undefined, {
+      ...baseAttrs,
+      ...patchAttrs,
+    })
+    this.view.dispatch(tr)
+  }
+
+  setupSelectionObserver() {
+    document.addEventListener('selectionchange', this.updateSelection)
+    setTimeout(() => this.updateSelection(), 100)
+  }
+
+  updateSelection = () => {
+    const selection = this.view.state.selection
+    const pos = this.getPos()
+    this.selected = false
+
+    if (
+      selection.from <= pos &&
+      selection.to >= pos + (this.node.nodeSize || 1)
+    ) {
+      this.selected = true
+    }
+
+    this.render()
+  }
+
+  openEditModal = () => {
+    if (this.modalRoot) return
+
+    this.modalRoot = document.createElement('div')
+    document.body.appendChild(this.modalRoot)
+
+    const { question, options } = this.node.attrs || {}
+
+    const closeModal = () => {
+      if (this.modalRoot) {
+        document.body.removeChild(this.modalRoot)
+        this.modalRoot = null
+      }
+    }
+
+    const save = (newQuestion: string, newOptions: QuizOption[]) => {
+      this.updateAttributes({ question: newQuestion, options: newOptions })
+      closeModal()
+    }
+
+    const modalRoot = createRoot(this.modalRoot)
+    modalRoot.render(
+      <QuizEditModal
+        question={question}
+        options={options}
+        onSave={save}
+        onCancel={closeModal}
+      />
+    )
+  }
+
+  showPopup(message: string) {
+    if (this.popupEl) {
+      this.popupEl.remove()
+      this.popupEl = null
+    }
+
+    this.popupEl = document.createElement('div')
+    this.popupEl.className = 'quiz-popup'
+    this.popupEl.textContent = message
+    document.body.appendChild(this.popupEl)
+
+    const rect = this.dom.getBoundingClientRect()
+    this.popupEl.style.cssText = `
+      position: absolute;
+      left: ${rect.left + window.scrollX + 20}px;
+      top: ${rect.top + window.scrollY - 40}px;
+      background: ${message.indexOf('🎉') !== -1 ? '#4caf50' : '#f44336'};
+      color: #fff;
+      padding: 8px 16px;
+      border-radius: 6px;
+      z-index: 9999;
+      font-size: 14px;
+      font-weight: bold;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+      pointer-events: none;
+    `
+
+    setTimeout(() => {
+      if (this.popupEl) {
+        this.popupEl.remove()
+        this.popupEl = null
+      }
+    }, 2000)
+  }
+
+  destroy() {
+    if (this.reactRoot) {
+      this.reactRoot.unmount()
+      this.reactRoot = null
+    }
+    if (this.modalRoot) {
+      document.body.removeChild(this.modalRoot)
+      this.modalRoot = null
+    }
+    if (this.popupEl) {
+      this.popupEl.remove()
+      this.popupEl = null
+    }
+    document.removeEventListener('selectionchange', this.updateSelection)
+  }
+}

--- a/dev/react/components/quiz-edit-modal.tsx
+++ b/dev/react/components/quiz-edit-modal.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react'
+
+import type { QuizOption } from '../types/quiz'
+
+interface QuizEditModalProps {
+  question: string
+  options: QuizOption[]
+  onSave: (question: string, options: QuizOption[]) => void
+  onCancel: () => void
+}
+
+export function QuizEditModal({
+  question,
+  options,
+  onSave,
+  onCancel,
+}: QuizEditModalProps) {
+  const [q, setQ] = useState(question)
+  const [opts, setOpts] = useState([...options])
+
+  const updateOption = (idx: number, key: keyof QuizOption, value: any) => {
+    setOpts((opts) =>
+      opts.map((o, i) => (i === idx ? { ...o, [key]: value } : o))
+    )
+  }
+
+  const addOption = () => {
+    setOpts((opts) => [
+      ...opts,
+      { id: Date.now().toString(), text: '', isCorrect: false },
+    ])
+  }
+
+  const removeOption = (idx: number) => {
+    setOpts((opts) => opts.filter((_, i) => i !== idx))
+  }
+
+  return (
+    <div
+      className="quiz-modal-overlay"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        background: 'rgba(0,0,0,0.3)',
+        zIndex: 10000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        className="quiz-modal"
+        style={{
+          background: '#fff',
+          padding: 24,
+          borderRadius: 8,
+          minWidth: 320,
+          maxWidth: 400,
+          maxHeight: '80vh',
+          overflow: 'auto',
+        }}
+      >
+        <h3 style={{ margin: '0 0 16px 0' }}>Edit Quiz</h3>
+
+        <div style={{ marginBottom: 12 }}>
+          <label
+            style={{ display: 'block', marginBottom: 4, fontWeight: 'bold' }}
+          >
+            Question:
+          </label>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            style={{
+              width: '100%',
+              padding: '8px',
+              border: '1px solid #ddd',
+              borderRadius: '4px',
+              boxSizing: 'border-box',
+            }}
+          />
+        </div>
+
+        <div>
+          <label
+            style={{ display: 'block', marginBottom: 8, fontWeight: 'bold' }}
+          >
+            Options:
+          </label>
+          {opts.map((opt, idx) => (
+            <div
+              key={opt.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                marginBottom: 6,
+                gap: 8,
+              }}
+            >
+              <input
+                value={opt.text}
+                onChange={(e) => updateOption(idx, 'text', e.target.value)}
+                placeholder={`Option ${idx + 1}`}
+                style={{
+                  flex: 1,
+                  padding: '4px 8px',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                }}
+              />
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  fontSize: '14px',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={!!opt.isCorrect}
+                  onChange={(e) =>
+                    updateOption(idx, 'isCorrect', e.target.checked)
+                  }
+                />
+                Correct
+              </label>
+              <button
+                onClick={() => removeOption(idx)}
+                style={{
+                  padding: '4px 8px',
+                  border: '1px solid #ddd',
+                  background: '#fff',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                }}
+                title="Delete option"
+              >
+                🗑️
+              </button>
+            </div>
+          ))}
+          <button
+            onClick={addOption}
+            style={{
+              marginTop: 8,
+              padding: '8px 16px',
+              border: '1px solid #007bff',
+              background: '#fff',
+              color: '#007bff',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: '14px',
+            }}
+          >
+            Add Option
+          </button>
+        </div>
+
+        <div
+          style={{
+            marginTop: 16,
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 8,
+          }}
+        >
+          <button
+            onClick={onCancel}
+            style={{
+              padding: '8px 16px',
+              border: '1px solid #ddd',
+              background: '#fff',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: '14px',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onSave(q, opts)}
+            style={{
+              padding: '8px 16px',
+              background: '#007bff',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: '14px',
+              fontWeight: 'bold',
+            }}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dev/react/components/quiz-react-view.tsx
+++ b/dev/react/components/quiz-react-view.tsx
@@ -1,0 +1,137 @@
+import React from 'react'
+
+import type { QuizOption } from '../types/quiz'
+
+interface QuizReactViewProps {
+  question: string
+  options: QuizOption[]
+  selectedAnswer: string | null
+  showResult: boolean
+  onSelect: (id: string) => void
+  onEdit: () => void
+  isSelected: boolean
+}
+
+export function QuizReactView({
+  question,
+  options,
+  selectedAnswer,
+  showResult,
+  onSelect,
+  onEdit,
+  isSelected,
+}: QuizReactViewProps) {
+  return (
+    <div
+      className="quiz-component"
+      style={{
+        border: '2px solid #e1e5e9',
+        borderRadius: '8px',
+        padding: '16px',
+        margin: '8px 0',
+        backgroundColor: isSelected ? '#f8f9fa' : '#fff',
+        borderColor: isSelected ? '#007bff' : '#e1e5e9',
+        transition: 'all 0.2s ease',
+      }}
+    >
+      <div
+        className="quiz-question"
+        style={{
+          fontSize: '16px',
+          fontWeight: 'bold',
+          marginBottom: '12px',
+          color: '#333',
+        }}
+      >
+        {question}
+      </div>
+
+      <div className="quiz-options">
+        {options.map((option) => (
+          <div
+            key={option.id}
+            className={`quiz-option${selectedAnswer === option.id ? ' selected' : ''}`}
+            style={{
+              padding: '10px',
+              margin: '4px 0',
+              border: '1px solid #ddd',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              backgroundColor:
+                selectedAnswer === option.id ? '#e3f2fd' : '#fff',
+              borderColor: selectedAnswer === option.id ? '#2196f3' : '#ddd',
+              transition: 'all 0.2s ease',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+            onClick={() => onSelect(option.id)}
+          >
+            <span
+              style={{
+                marginRight: '8px',
+                color: selectedAnswer === option.id ? '#2196f3' : '#666',
+              }}
+            >
+              {selectedAnswer === option.id ? '●' : '○'}
+            </span>
+            {option.text}
+            {showResult && option.isCorrect && (
+              <span
+                style={{
+                  marginLeft: 'auto',
+                  color: '#4caf50',
+                  fontWeight: 'bold',
+                }}
+              >
+                ✓
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {showResult && (
+        <div
+          className="quiz-result"
+          style={{
+            marginTop: '12px',
+            padding: '8px 12px',
+            backgroundColor: '#e8f5e8',
+            borderRadius: '4px',
+            color: '#2e7d32',
+            fontWeight: 'bold',
+          }}
+        >
+          Correct answer:{' '}
+          {options
+            .filter((o) => o.isCorrect)
+            .map((o) => o.text)
+            .join(', ')}
+        </div>
+      )}
+
+      {isSelected && (
+        <button
+          className="quiz-edit-btn"
+          onClick={(e) => {
+            e.stopPropagation()
+            onEdit()
+          }}
+          style={{
+            marginTop: '12px',
+            padding: '8px 16px',
+            backgroundColor: '#007bff',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: '14px',
+            fontWeight: 'bold',
+          }}
+        >
+          Edit Quiz
+        </button>
+      )}
+    </div>
+  )
+}

--- a/dev/react/crepe-react-test-entry.tsx
+++ b/dev/react/crepe-react-test-entry.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { MilkdownEditorWrapper } from './index.tsx'
+
+const root = document.getElementById('root')
+if (root) {
+  createRoot(root).render(<MilkdownEditorWrapper />)
+}

--- a/dev/react/features/highlight.ts
+++ b/dev/react/features/highlight.ts
@@ -1,0 +1,125 @@
+import type { DefineFeature } from '../../../packages/crepe/src/feature/shared'
+import type { ToolbarItem } from '../../../packages/crepe/src/feature/toolbar'
+import { ToolbarItemPresets } from '@milkdown/crepe'
+
+import { editorViewCtx, commandsCtx } from '../../../packages/kit/src/core'
+import { toggleMark } from '../../../packages/kit/src/prose/commands'
+import { $markSchema, $command } from '../../../packages/utils/src'
+
+// Highlight mark schema
+export const highlightSchema = $markSchema('highlight', () => ({
+  attrs: {
+    color: {
+      default: 'yellow',
+      validate: 'string',
+    },
+  },
+  parseDOM: [
+    {
+      tag: 'mark[data-highlight]',
+      getAttrs: (node) => ({
+        color: (node as HTMLElement).style.backgroundColor || 'yellow',
+      }),
+    },
+  ],
+  toDOM: (mark) => [
+    'mark',
+    {
+      'data-highlight': 'true',
+      style: `background-color: ${mark.attrs.color}`,
+      class: 'milkdown-highlight',
+    },
+  ],
+}))
+
+// Toggle highlight command
+export const toggleHighlightCommand = $command(
+  'ToggleHighlight',
+  (ctx) =>
+    (color = 'yellow') => {
+      return toggleMark(highlightSchema.type(ctx), { color })
+    }
+)
+
+// Helper function to check if text is highlighted
+function isHighlightActive(ctx: any, selection: any): boolean {
+  const highlightType = highlightSchema.type(ctx)
+  const { from, to } = selection
+  const view = ctx.get(editorViewCtx)
+  if (!view || !view.state) return false
+  const { doc } = view.state
+
+  let hasHighlight = false
+  doc.nodesBetween(from, to, (node: any) => {
+    if (hasHighlight) return false
+    if (node.marks.some((mark: any) => mark.type === highlightType)) {
+      hasHighlight = true
+      return false
+    }
+  })
+
+  return hasHighlight
+}
+
+// Highlight feature
+export const highlightFeature: DefineFeature = (editor) => {
+  editor.use(highlightSchema).use(toggleHighlightCommand)
+}
+
+// Main highlight toolbar item
+export const highlightToolbarItem: ToolbarItem = ToolbarItemPresets.requiresSelection({
+  key: 'highlight',
+  icon: `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+    <path d="m13.498.795.149-.149a1.207 1.207 0 1 1 1.707 1.708l-.149.148a1.5 1.5 0 0 1-.059 2.059L4.854 14.854a.5.5 0 0 1-.233.131l-4 1a.5.5 0 0 1-.606-.606l1-4a.5.5 0 0 1 .131-.232l9.642-9.642a.5.5 0 0 0-.642.056L6.854 4.854a.5.5 0 1 1-.708-.708L9.44.854A1.5 1.5 0 0 1 11.5.796a1.5 1.5 0 0 1 1.998-.001z"/>
+  </svg>`,
+  tooltip: 'Highlight selected text',
+  onClick: (ctx) => {
+    const commands = ctx.get(commandsCtx)
+    commands.call(toggleHighlightCommand.key)
+  },
+  isActive: (ctx, selection) => {
+    return isHighlightActive(ctx, selection)
+  },
+})
+
+// Color-specific highlight items
+export const createHighlightItem = (
+  color: string,
+  name: string
+): ToolbarItem => ToolbarItemPresets.requiresSelection({
+  key: `highlight-${color.replace('#', '')}`,
+  icon: `<span style="background-color: ${color}; padding: 2px 6px; border-radius: 3px; font-weight: bold; font-size: 12px; color: ${
+    color === 'yellow' || color === '#ffff00' ? '#333' : '#fff'
+  };">A</span>`,
+  tooltip: `Highlight with ${name}`,
+  onClick: (ctx) => {
+    const commands = ctx.get(commandsCtx)
+    commands.call(toggleHighlightCommand.key, color)
+  },
+  isActive: (ctx, selection) => {
+    const highlightType = highlightSchema.type(ctx)
+    const view = ctx.get(editorViewCtx)
+    if (!view || !view.state) return false
+    const { from, to } = selection
+    let hasColorHighlight = false
+    view.state.doc.nodesBetween(from, to, (node: any) => {
+      if (hasColorHighlight) return false
+      const mark = node.marks.find((m: any) => m.type === highlightType)
+      if (mark && mark.attrs.color === color) {
+        hasColorHighlight = true
+        return false
+      }
+    })
+    return hasColorHighlight
+  },
+})
+
+// Predefined color toolbar items
+export const highlightToolbarItems: ToolbarItem[] = [
+  highlightToolbarItem,
+  createHighlightItem('yellow', 'Yellow'),
+  createHighlightItem('#ffcccc', 'Pink'),
+  createHighlightItem('#ccffcc', 'Green'),
+  createHighlightItem('#ccccff', 'Blue'),
+  createHighlightItem('#ffcc99', 'Orange'),
+]

--- a/dev/react/features/quiz.ts
+++ b/dev/react/features/quiz.ts
@@ -1,0 +1,168 @@
+import type { DefineFeature } from '../../../packages/crepe/src/feature/shared'
+import type { QuizOption, QuizAttrs } from '../types/quiz'
+
+import { commandsCtx } from '../../../packages/kit/src/core'
+import { $nodeSchema, $command, $component } from '../../../packages/utils/src'
+import { QuizComponent } from '../components/quiz-component'
+
+// Quiz node schema
+export const quizSchema = $nodeSchema('quiz', () => ({
+  group: 'block',
+  content: '',
+  atom: true,
+  selectable: true,
+  attrs: {
+    question: { default: 'Enter your question here' },
+    options: {
+      default: [
+        { id: '1', text: 'Option A', isCorrect: false },
+        { id: '2', text: 'Option B', isCorrect: true },
+        { id: '3', text: 'Option C', isCorrect: false },
+      ] as QuizOption[],
+    },
+    selectedAnswer: { default: null },
+    showResult: { default: false },
+  },
+  parseDOM: [
+    {
+      tag: 'div[data-type="quiz"]',
+      getAttrs: (dom) => {
+        const element = dom as HTMLElement
+        return {
+          question: element.dataset.question || 'Enter your question here',
+          options: JSON.parse(element.dataset.options || '[]'),
+          selectedAnswer: element.dataset.selectedAnswer || null,
+          showResult: element.dataset.showResult === 'true',
+        }
+      },
+    },
+  ],
+  toDOM: (node) => [
+    'div',
+    {
+      'data-type': 'quiz',
+      'data-question': node.attrs.question,
+      'data-options': JSON.stringify(node.attrs.options),
+      'data-selected-answer': node.attrs.selectedAnswer || '',
+      'data-show-result': node.attrs.showResult.toString(),
+      class: 'milkdown-quiz',
+    },
+  ],
+  markdown: {
+    serialize: 'quiz-block',
+    parse: 'quiz-block',
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === 'quiz',
+    runner: (state, node) => {
+      state.addNode(
+        'html',
+        undefined,
+        `<div data-type="quiz" data-attrs='${encodeURIComponent(
+          JSON.stringify({
+            question: node.attrs.question,
+            options: node.attrs.options,
+            selectedAnswer: node.attrs.selectedAnswer,
+            showResult: node.attrs.showResult,
+          })
+        )}'></div>`
+      )
+    },
+  },
+  fromMarkdown: {
+    match: (node) =>
+      node.type === 'html' &&
+      typeof node.value === 'string' &&
+      node.value.includes('data-type="quiz"'),
+    runner: (state, node, type) => {
+      if (typeof node.value === 'string') {
+        const match = node.value.match(/data-attrs='([^']+)'/)
+        const attrs = match ? JSON.parse(decodeURIComponent(match[1])) : {}
+        state.addNode(type, attrs)
+      }
+    },
+  },
+  parseMarkdown: {
+    match: (node) =>
+      node.type === 'html' &&
+      typeof node.value === 'string' &&
+      node.value.includes('data-type="quiz"'),
+    runner: (state, node, type) => {
+      if (typeof node.value === 'string') {
+        const match = node.value.match(/data-attrs='([^']+)'/)
+        const attrs = match ? JSON.parse(decodeURIComponent(match[1])) : {}
+        state.addNode(type, attrs)
+      }
+    },
+  },
+}))
+
+// Command to insert a quiz
+export const insertQuizCommand = $command(
+  'InsertQuiz',
+  (ctx) => (attrs?: Partial<QuizAttrs>) => {
+    return (state, dispatch) => {
+      const quizType = quizSchema.type(ctx)
+      const { tr, selection } = state
+      const patchAttrs =
+        typeof attrs === 'object' && attrs !== null ? attrs : {}
+
+      const quizNode = quizType.create({
+        question: 'What is the correct answer?',
+        options: [
+          { id: '1', text: 'Option A', isCorrect: false },
+          { id: '2', text: 'Option B', isCorrect: true },
+          { id: '3', text: 'Option C', isCorrect: false },
+          { id: '4', text: 'Option D', isCorrect: false },
+        ],
+        selectedAnswer: null,
+        showResult: false,
+        ...patchAttrs,
+      })
+
+      // If selection is inside a paragraph, replace the parent block
+      const $from = selection.$from
+      const parent = $from.node($from.depth)
+      if (parent.type.name === 'paragraph') {
+        const pos = $from.before($from.depth)
+        if (dispatch) {
+          dispatch(tr.replaceWith(pos, pos + parent.nodeSize, quizNode))
+        }
+        return true
+      }
+
+      if (dispatch) {
+        dispatch(tr.replaceSelectionWith(quizNode))
+      }
+      return true
+    }
+  }
+)
+
+// Quiz component registration
+export const quizComponent = $component('quiz', (ctx) => {
+  return {
+    component: QuizComponent,
+    as: 'div',
+    shouldUpdate: (prev, next) => prev.attrs !== next.attrs,
+  }
+})
+
+// Quiz feature that registers everything
+export const quizFeature: DefineFeature = (editor) => {
+  editor.use(quizSchema).use(insertQuizCommand).use(quizComponent)
+}
+
+// Custom slash menu builder function
+export const customSlashMenu = (builder: any) => {
+  builder.addGroup('custom', 'Custom').addItem('quiz', {
+    label: 'Quiz',
+    icon: '<svg width="20" height="20" fill="none" viewBox="0 0 20 20"><rect width="20" height="20" rx="4" fill="#FFD600"/><text x="10" y="15" text-anchor="middle" font-size="12" fill="#222">Quiz</text></svg>',
+    onRun: (ctx: any) => {
+      const commands = ctx.get(commandsCtx)
+      commands.call(insertQuizCommand.key)
+    },
+  })
+}
+
+export type { QuizOption, QuizAttrs }

--- a/dev/react/index.html
+++ b/dev/react/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crepe Editor - React Example</title>
+  </head>
+  <body>
+    <div class="container">
+      <div id="root"></div>
+    </div>
+    <script type="module" src="./crepe-react-test-entry.tsx"></script>
+  </body>
+</html>

--- a/dev/react/index.tsx
+++ b/dev/react/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { toolbar } from '../../packages/crepe/src/feature/toolbar'
+import { Crepe, blockEdit } from '../../packages/crepe/src/index'
+import {
+  Milkdown,
+  MilkdownProvider,
+  useEditor,
+} from '../../packages/integrations/react/src'
+// Import features
+import { highlightFeature, highlightToolbarItems } from './features/highlight'
+import { quizFeature, customSlashMenu } from './features/quiz'
+// Import styles
+import '../../packages/crepe/src/theme/common/style.css'
+import '../../packages/crepe/src/theme/frame/style.css'
+
+// Crepe Editor component
+const CrepeEditor = () => {
+  useEditor((root) => {
+    const crepe = new Crepe({ root })
+    crepe
+      .addFeature(quizFeature)
+      .addFeature(highlightFeature)
+      .addFeature(toolbar, {
+        customItems: highlightToolbarItems,
+      })
+      .addFeature(blockEdit, {
+        buildMenu: customSlashMenu,
+      })
+    return crepe
+  })
+  return <Milkdown />
+}
+
+// Main wrapper component
+export const MilkdownEditorWrapper = () => (
+  <MilkdownProvider>
+    <CrepeEditor />
+  </MilkdownProvider>
+)

--- a/dev/react/types/quiz.ts
+++ b/dev/react/types/quiz.ts
@@ -1,0 +1,12 @@
+export interface QuizOption {
+  id: string
+  text: string
+  isCorrect: boolean
+}
+
+export interface QuizAttrs {
+  question: string
+  options: QuizOption[]
+  selectedAnswer?: string
+  showResult: boolean
+}

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    "tsBuildInfoFile": "./lib/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./lib/tsconfig.tsbuildinfo",
+    "jsx": "react-jsx",
+    "moduleResolution": "node"
   },
   "include": ["src"],
   "references": []

--- a/dev/vanilla/components/quiz-component.ts
+++ b/dev/vanilla/components/quiz-component.ts
@@ -1,0 +1,392 @@
+export interface QuizOption {
+  id: string
+  text: string
+  isCorrect: boolean
+}
+
+export interface QuizAttrs {
+  question: string
+  options: QuizOption[]
+  selectedAnswer?: string
+  showResult: boolean
+}
+
+export class QuizComponent {
+  dom: HTMLElement
+  node: any
+  view: any
+  getPos: () => number
+  ctx: any
+  modalEl: HTMLDivElement | null = null
+  popupEl: HTMLDivElement | null = null
+  selected: boolean = false
+
+  constructor(node: any, view: any, getPos: () => number, ctx: any) {
+    this.node = node
+    this.view = view
+    this.getPos = getPos
+    this.ctx = ctx
+    this.dom = document.createElement('div')
+    this.render()
+    this.setupSelectionObserver()
+  }
+
+  render() {
+    const { question, options, selectedAnswer, showResult } = this.node.attrs || {}
+    
+    this.dom.innerHTML = ''
+    this.dom.className = 'quiz-component'
+    this.dom.style.cssText = `
+      border: 2px solid ${this.selected ? '#007bff' : '#e1e5e9'};
+      border-radius: 8px;
+      padding: 16px;
+      margin: 8px 0;
+      background-color: ${this.selected ? '#f8f9fa' : '#fff'};
+      transition: all 0.2s ease;
+    `
+
+    // Question element
+    const questionEl = document.createElement('div')
+    questionEl.className = 'quiz-question'
+    questionEl.style.cssText = `
+      font-size: 16px;
+      font-weight: bold;
+      margin-bottom: 12px;
+      color: #333;
+    `
+    questionEl.textContent = question
+    this.dom.appendChild(questionEl)
+
+    // Options container
+    const optionsEl = document.createElement('div')
+    optionsEl.className = 'quiz-options'
+    this.dom.appendChild(optionsEl)
+
+    options.forEach((option: QuizOption) => {
+      const optionEl = document.createElement('div')
+      optionEl.className = 'quiz-option'
+      const isSelected = selectedAnswer === option.id
+      optionEl.style.cssText = `
+        padding: 10px;
+        margin: 4px 0;
+        border: 1px solid ${isSelected ? '#2196f3' : '#ddd'};
+        border-radius: 4px;
+        cursor: pointer;
+        background-color: ${isSelected ? '#e3f2fd' : '#fff'};
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+      `
+
+      const radioIcon = document.createElement('span')
+      radioIcon.style.cssText = `
+        margin-right: 8px;
+        color: ${isSelected ? '#2196f3' : '#666'};
+      `
+      radioIcon.textContent = isSelected ? '●' : '○'
+      optionEl.appendChild(radioIcon)
+
+      const textSpan = document.createElement('span')
+      textSpan.textContent = option.text
+      optionEl.appendChild(textSpan)
+
+      if (showResult && option.isCorrect) {
+        const checkIcon = document.createElement('span')
+        checkIcon.style.cssText = `
+          margin-left: auto;
+          color: #4caf50;
+          font-weight: bold;
+        `
+        checkIcon.textContent = '✓'
+        optionEl.appendChild(checkIcon)
+      }
+
+      optionEl.addEventListener('click', () => this.selectAnswer(option.id))
+      optionsEl.appendChild(optionEl)
+    })
+
+    // Show result
+    if (showResult) {
+      const resultEl = document.createElement('div')
+      resultEl.className = 'quiz-result'
+      resultEl.style.cssText = `
+        margin-top: 12px;
+        padding: 8px 12px;
+        background-color: #e8f5e8;
+        border-radius: 4px;
+        color: #2e7d32;
+        font-weight: bold;
+      `
+      const correctOptions = options.filter((o: QuizOption) => o.isCorrect)
+      resultEl.textContent = `Correct answer: ${correctOptions.map(o => o.text).join(', ')}`
+      this.dom.appendChild(resultEl)
+    }
+
+    // Edit button (when selected)
+    if (this.selected) {
+      const editBtn = document.createElement('button')
+      editBtn.className = 'quiz-edit-btn'
+      editBtn.textContent = 'Edit Quiz'
+      editBtn.style.cssText = `
+        margin-top: 12px;
+        padding: 8px 16px;
+        background-color: #007bff;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: bold;
+      `
+      editBtn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        this.openEditModal()
+      })
+      this.dom.appendChild(editBtn)
+    }
+  }
+
+  selectAnswer = (answerId: string) => {
+    const options = Array.isArray(this.node.attrs?.options) ? this.node.attrs.options : []
+    const selected = options.find((o: QuizOption) => o.id === answerId)
+    
+    if (selected && selected.isCorrect) {
+      this.showPopup('🎉 Correct! Well done!')
+    } else {
+      this.showPopup('❌ Not quite right, try again!')
+    }
+    
+    this.updateAttributes({ selectedAnswer: answerId, showResult: true })
+  }
+
+  updateAttributes(attrs: Partial<QuizAttrs>) {
+    const pos = this.getPos()
+    if (typeof pos !== 'number') return
+    
+    const baseAttrs = typeof this.node.attrs === 'object' && this.node.attrs !== null ? this.node.attrs : {}
+    const patchAttrs = typeof attrs === 'object' && attrs !== null ? attrs : {}
+    
+    const tr = this.view.state.tr.setNodeMarkup(pos, undefined, {
+      ...baseAttrs,
+      ...patchAttrs,
+    })
+    this.view.dispatch(tr)
+  }
+
+  setupSelectionObserver() {
+    document.addEventListener('selectionchange', this.updateSelection)
+    setTimeout(() => this.updateSelection(), 100)
+  }
+
+  updateSelection = () => {
+    const selection = this.view.state.selection
+    const pos = this.getPos()
+    this.selected = false
+    
+    if (selection.from <= pos && selection.to >= pos + (this.node.nodeSize || 1)) {
+      this.selected = true
+    }
+    
+    this.render()
+  }
+
+  openEditModal = () => {
+    if (this.modalEl) return
+    
+    this.modalEl = document.createElement('div')
+    this.modalEl.className = 'quiz-modal-overlay'
+    this.modalEl.style.cssText = `
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: rgba(0,0,0,0.3);
+      z-index: 10000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    `
+
+    const { question, options } = this.node.attrs || {}
+    
+    const modal = this.createEditModalContent(question, options)
+    this.modalEl.appendChild(modal)
+    document.body.appendChild(this.modalEl)
+  }
+
+  createEditModalContent(question: string, options: QuizOption[]): HTMLElement {
+    const modal = document.createElement('div')
+    modal.className = 'quiz-modal'
+    modal.style.cssText = `
+      background: #fff;
+      padding: 24px;
+      border-radius: 8px;
+      min-width: 320px;
+      max-width: 400px;
+      max-height: 80vh;
+      overflow-y: auto;
+    `
+
+    const title = document.createElement('h3')
+    title.textContent = 'Edit Quiz'
+    modal.appendChild(title)
+
+    // Question input
+    const questionLabel = document.createElement('label')
+    questionLabel.textContent = 'Question:'
+    questionLabel.style.marginBottom = '8px'
+    modal.appendChild(questionLabel)
+
+    const questionInput = document.createElement('input')
+    questionInput.value = question
+    questionInput.style.cssText = 'width: 100%; margin-bottom: 12px; padding: 8px; border: 1px solid #ddd; border-radius: 4px;'
+    modal.appendChild(questionInput)
+
+    // Options section
+    const optionsLabel = document.createElement('label')
+    optionsLabel.textContent = 'Options:'
+    optionsLabel.style.marginBottom = '8px'
+    modal.appendChild(optionsLabel)
+
+    const optionsContainer = document.createElement('div')
+    modal.appendChild(optionsContainer)
+
+    let currentOptions = [...options]
+
+    const renderOptions = () => {
+      optionsContainer.innerHTML = ''
+      currentOptions.forEach((opt, idx) => {
+        const optionRow = document.createElement('div')
+        optionRow.style.cssText = 'display: flex; align-items: center; margin-bottom: 6px; gap: 8px;'
+
+        const textInput = document.createElement('input')
+        textInput.value = opt.text
+        textInput.style.cssText = 'flex: 1; padding: 4px; border: 1px solid #ddd; border-radius: 4px;'
+        textInput.addEventListener('input', (e) => {
+          currentOptions[idx].text = (e.target as HTMLInputElement).value
+        })
+
+        const correctCheckbox = document.createElement('input')
+        correctCheckbox.type = 'checkbox'
+        correctCheckbox.checked = opt.isCorrect
+        correctCheckbox.addEventListener('change', (e) => {
+          currentOptions[idx].isCorrect = (e.target as HTMLInputElement).checked
+        })
+
+        const correctLabel = document.createElement('label')
+        correctLabel.textContent = 'Correct'
+        correctLabel.style.cssText = 'display: flex; align-items: center; gap: 4px;'
+        correctLabel.appendChild(correctCheckbox)
+
+        const deleteBtn = document.createElement('button')
+        deleteBtn.textContent = '🗑️'
+        deleteBtn.style.cssText = 'padding: 4px 8px; border: 1px solid #ddd; background: #fff; border-radius: 4px; cursor: pointer;'
+        deleteBtn.addEventListener('click', () => {
+          currentOptions.splice(idx, 1)
+          renderOptions()
+        })
+
+        optionRow.appendChild(textInput)
+        optionRow.appendChild(correctLabel)
+        optionRow.appendChild(deleteBtn)
+        optionsContainer.appendChild(optionRow)
+      })
+    }
+
+    renderOptions()
+
+    const addOptionBtn = document.createElement('button')
+    addOptionBtn.textContent = 'Add Option'
+    addOptionBtn.style.cssText = 'margin-top: 8px; padding: 8px 16px; border: 1px solid #ddd; background: #fff; border-radius: 4px; cursor: pointer;'
+    addOptionBtn.addEventListener('click', () => {
+      currentOptions.push({
+        id: Date.now().toString(),
+        text: '',
+        isCorrect: false
+      })
+      renderOptions()
+    })
+    modal.appendChild(addOptionBtn)
+
+    // Buttons
+    const buttonsDiv = document.createElement('div')
+    buttonsDiv.style.cssText = 'margin-top: 16px; display: flex; justify-content: flex-end; gap: 8px;'
+
+    const cancelBtn = document.createElement('button')
+    cancelBtn.textContent = 'Cancel'
+    cancelBtn.style.cssText = 'padding: 8px 16px; border: 1px solid #ddd; background: #fff; border-radius: 4px; cursor: pointer;'
+    cancelBtn.addEventListener('click', () => this.closeModal())
+
+    const saveBtn = document.createElement('button')
+    saveBtn.textContent = 'Save'
+    saveBtn.style.cssText = 'padding: 8px 16px; background: #222; color: #fff; border: none; border-radius: 4px; cursor: pointer;'
+    saveBtn.addEventListener('click', () => {
+      this.updateAttributes({
+        question: questionInput.value,
+        options: currentOptions
+      })
+      this.closeModal()
+    })
+
+    buttonsDiv.appendChild(cancelBtn)
+    buttonsDiv.appendChild(saveBtn)
+    modal.appendChild(buttonsDiv)
+
+    return modal
+  }
+
+  closeModal() {
+    if (this.modalEl) {
+      document.body.removeChild(this.modalEl)
+      this.modalEl = null
+    }
+  }
+
+  showPopup(message: string) {
+    if (this.popupEl) {
+      this.popupEl.remove()
+      this.popupEl = null
+    }
+    
+    this.popupEl = document.createElement('div')
+    this.popupEl.className = 'quiz-popup'
+    this.popupEl.textContent = message
+    document.body.appendChild(this.popupEl)
+    
+    const rect = this.dom.getBoundingClientRect()
+    this.popupEl.style.cssText = `
+      position: absolute;
+      left: ${rect.left + window.scrollX + 20}px;
+      top: ${rect.top + window.scrollY - 40}px;
+      background: ${message.indexOf('🎉') !== -1 ? '#4caf50' : '#f44336'};
+      color: #fff;
+      padding: 8px 16px;
+      border-radius: 6px;
+      z-index: 9999;
+      font-size: 14px;
+      font-weight: bold;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+      pointer-events: none;
+    `
+    
+    setTimeout(() => {
+      if (this.popupEl) {
+        this.popupEl.remove()
+        this.popupEl = null
+      }
+    }, 2000)
+  }
+
+  destroy() {
+    if (this.modalEl) {
+      document.body.removeChild(this.modalEl)
+      this.modalEl = null
+    }
+    if (this.popupEl) {
+      this.popupEl.remove()
+      this.popupEl = null
+    }
+    document.removeEventListener('selectionchange', this.updateSelection)
+  }
+}

--- a/dev/vanilla/features/highlight.ts
+++ b/dev/vanilla/features/highlight.ts
@@ -1,0 +1,126 @@
+import { $markSchema, $command } from '@milkdown/utils'
+import { toggleMark } from '@milkdown/kit/prose/commands'
+import { editorViewCtx, commandsCtx } from '@milkdown/kit/core'
+import type { Ctx } from '@milkdown/kit/ctx'
+import type { Selection } from '@milkdown/kit/prose/state'
+import type { DefineFeature } from '../../../packages/crepe/src/feature/shared'
+import type { ToolbarItem } from '@milkdown/crepe/feature/toolbar'
+import { ToolbarItemPresets } from '@milkdown/crepe'
+
+// Highlight mark schema
+export const highlightSchema = $markSchema('highlight', () => ({
+  attrs: {
+    color: {
+      default: 'yellow',
+      validate: 'string',
+    },
+  },
+  parseDOM: [
+    {
+      tag: 'mark[data-highlight]',
+      getAttrs: (node) => ({
+        color: (node as HTMLElement).style.backgroundColor || 'yellow',
+      }),
+    },
+  ],
+  toDOM: (mark) => [
+    'mark',
+    {
+      'data-highlight': 'true',
+      style: `background-color: ${mark.attrs.color}`,
+      class: 'milkdown-highlight',
+    },
+  ],
+}))
+
+// Toggle highlight command
+export const toggleHighlightCommand = $command(
+  'ToggleHighlight',
+  (ctx) =>
+    (color = 'yellow') => {
+      return toggleMark(highlightSchema.type(ctx), { color })
+    }
+)
+
+// Helper function to check if text is highlighted
+function isHighlightActive(ctx: Ctx, selection: Selection): boolean {
+  const highlightType = highlightSchema.type(ctx)
+  const { from, to } = selection
+  const view = ctx.get(editorViewCtx)
+  if (!view || !view.state) return false
+  const { doc } = view.state
+
+  let hasHighlight = false
+  doc.nodesBetween(from, to, (node) => {
+    if (hasHighlight) return false
+    if (node.marks.some((mark) => mark.type === highlightType)) {
+      hasHighlight = true
+      return false
+    }
+  })
+
+  return hasHighlight
+}
+
+// Highlight feature
+export const highlightFeature: DefineFeature = (editor) => {
+  editor.use(highlightSchema).use(toggleHighlightCommand)
+}
+
+// Main highlight toolbar item
+export const highlightToolbarItem: ToolbarItem = ToolbarItemPresets.requiresSelection({
+  key: 'highlight',
+  icon: `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+    <path d="m13.498.795.149-.149a1.207 1.207 0 1 1 1.707 1.708l-.149.148a1.5 1.5 0 0 1-.059 2.059L4.854 14.854a.5.5 0 0 1-.233.131l-4 1a.5.5 0 0 1-.606-.606l1-4a.5.5 0 0 1 .131-.232l9.642-9.642a.5.5 0 0 0-.642.056L6.854 4.854a.5.5 0 1 1-.708-.708L9.44.854A1.5 1.5 0 0 1 11.5.796a1.5 1.5 0 0 1 1.998-.001z"/>
+  </svg>`,
+  tooltip: 'Highlight selected text',
+  onClick: (ctx) => {
+    const commands = ctx.get(commandsCtx)
+    commands.call(toggleHighlightCommand.key)
+  },
+  isActive: (ctx, selection) => {
+    return isHighlightActive(ctx, selection)
+  },
+})
+
+// Color-specific highlight items
+export const createHighlightItem = (
+  color: string,
+  name: string
+): ToolbarItem => ToolbarItemPresets.requiresSelection({
+  key: `highlight-${color.replace('#', '')}`,
+  icon: `<span style="background-color: ${color}; padding: 2px 6px; border-radius: 3px; font-weight: bold; font-size: 12px; color: ${
+    color === 'yellow' || color === '#ffff00' ? '#333' : '#fff'
+  };">A</span>`,
+  tooltip: `Highlight with ${name}`,
+  onClick: (ctx) => {
+    const commands = ctx.get(commandsCtx)
+    commands.call(toggleHighlightCommand.key, color)
+  },
+  isActive: (ctx, selection) => {
+    const highlightType = highlightSchema.type(ctx)
+    const view = ctx.get(editorViewCtx)
+    if (!view || !view.state) return false
+    const { from, to } = selection
+    let hasColorHighlight = false
+    view.state.doc.nodesBetween(from, to, (node) => {
+      if (hasColorHighlight) return false
+      const mark = node.marks.find((m) => m.type === highlightType)
+      if (mark && mark.attrs.color === color) {
+        hasColorHighlight = true
+        return false
+      }
+    })
+    return hasColorHighlight
+  },
+})
+
+// Predefined color toolbar items
+export const highlightToolbarItems: ToolbarItem[] = [
+  highlightToolbarItem,
+  createHighlightItem('yellow', 'Yellow'),
+  createHighlightItem('#ffcccc', 'Pink'),
+  createHighlightItem('#ccffcc', 'Green'),
+  createHighlightItem('#ccccff', 'Blue'),
+  createHighlightItem('#ffcc99', 'Orange'),
+]

--- a/dev/vanilla/features/quiz.ts
+++ b/dev/vanilla/features/quiz.ts
@@ -1,0 +1,170 @@
+import { $nodeSchema, $command, $component } from '@milkdown/utils'
+import { commandsCtx } from '@milkdown/kit/core'
+import type { DefineFeature } from '../../../packages/crepe/src/feature/shared'
+import {
+  QuizComponent,
+  type QuizOption,
+  type QuizAttrs,
+} from '../components/quiz-component'
+
+// Quiz node schema
+export const quizSchema = $nodeSchema('quiz', () => ({
+  group: 'block',
+  content: '',
+  atom: true,
+  selectable: true,
+  attrs: {
+    question: { default: 'Enter your question here' },
+    options: {
+      default: [
+        { id: '1', text: 'Option A', isCorrect: false },
+        { id: '2', text: 'Option B', isCorrect: true },
+        { id: '3', text: 'Option C', isCorrect: false },
+      ] as QuizOption[],
+    },
+    selectedAnswer: { default: null },
+    showResult: { default: false },
+  },
+  parseDOM: [
+    {
+      tag: 'div[data-type="quiz"]',
+      getAttrs: (dom) => {
+        const element = dom as HTMLElement
+        return {
+          question: element.dataset.question || 'Enter your question here',
+          options: JSON.parse(element.dataset.options || '[]'),
+          selectedAnswer: element.dataset.selectedAnswer || null,
+          showResult: element.dataset.showResult === 'true',
+        }
+      },
+    },
+  ],
+  toDOM: (node) => [
+    'div',
+    {
+      'data-type': 'quiz',
+      'data-question': node.attrs.question,
+      'data-options': JSON.stringify(node.attrs.options),
+      'data-selected-answer': node.attrs.selectedAnswer || '',
+      'data-show-result': node.attrs.showResult.toString(),
+      class: 'milkdown-quiz',
+    },
+  ],
+  markdown: {
+    serialize: 'quiz-block',
+    parse: 'quiz-block',
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === 'quiz',
+    runner: (state, node) => {
+      state.addNode(
+        'html',
+        undefined,
+        `<div data-type="quiz" data-attrs='${encodeURIComponent(
+          JSON.stringify({
+            question: node.attrs.question,
+            options: node.attrs.options,
+            selectedAnswer: node.attrs.selectedAnswer,
+            showResult: node.attrs.showResult,
+          })
+        )}'></div>`
+      )
+    },
+  },
+  fromMarkdown: {
+    match: (node) =>
+      node.type === 'html' &&
+      typeof node.value === 'string' &&
+      node.value.includes('data-type="quiz"'),
+    runner: (state, node, type) => {
+      if (typeof node.value === 'string') {
+        const match = node.value.match(/data-attrs='([^']+)'/)
+        const attrs = match ? JSON.parse(decodeURIComponent(match[1])) : {}
+        state.addNode(type, attrs)
+      }
+    },
+  },
+  parseMarkdown: {
+    match: (node) =>
+      node.type === 'html' &&
+      typeof node.value === 'string' &&
+      node.value.includes('data-type="quiz"'),
+    runner: (state, node, type) => {
+      if (typeof node.value === 'string') {
+        const match = node.value.match(/data-attrs='([^']+)'/)
+        const attrs = match ? JSON.parse(decodeURIComponent(match[1])) : {}
+        state.addNode(type, attrs)
+      }
+    },
+  },
+}))
+
+// Command to insert a quiz
+export const insertQuizCommand = $command(
+  'InsertQuiz',
+  (ctx) => (attrs?: Partial<QuizAttrs>) => {
+    return (state, dispatch) => {
+      const quizType = quizSchema.type(ctx)
+      const { tr, selection } = state
+      const patchAttrs =
+        typeof attrs === 'object' && attrs !== null ? attrs : {}
+
+      const quizNode = quizType.create({
+        question: 'What is the correct answer?',
+        options: [
+          { id: '1', text: 'Option A', isCorrect: false },
+          { id: '2', text: 'Option B', isCorrect: true },
+          { id: '3', text: 'Option C', isCorrect: false },
+          { id: '4', text: 'Option D', isCorrect: false },
+        ],
+        selectedAnswer: null,
+        showResult: false,
+        ...patchAttrs,
+      })
+
+      // If selection is inside a paragraph, replace the parent block
+      const $from = selection.$from
+      const parent = $from.node($from.depth)
+      if (parent.type.name === 'paragraph') {
+        const pos = $from.before($from.depth)
+        if (dispatch) {
+          dispatch(tr.replaceWith(pos, pos + parent.nodeSize, quizNode))
+        }
+        return true
+      }
+
+      if (dispatch) {
+        dispatch(tr.replaceSelectionWith(quizNode))
+      }
+      return true
+    }
+  }
+)
+
+// Quiz component registration
+export const quizComponent = $component('quiz', (ctx) => {
+  return {
+    component: QuizComponent,
+    as: 'div',
+    shouldUpdate: (prev, next) => prev.attrs !== next.attrs,
+  }
+})
+
+// Quiz feature that registers everything
+export const quizFeature: DefineFeature = (editor) => {
+  editor.use(quizSchema).use(insertQuizCommand).use(quizComponent)
+}
+
+// Custom slash menu builder function
+export const customSlashMenu = (builder: any) => {
+  builder.addGroup('custom', 'Custom').addItem('quiz', {
+    label: 'Quiz',
+    icon: '<svg width="20" height="20" fill="none" viewBox="0 0 20 20"><rect width="20" height="20" rx="4" fill="#FFD600"/><text x="10" y="15" text-anchor="middle" font-size="12" fill="#222">Quiz</text></svg>',
+    onRun: (ctx: any) => {
+      const commands = ctx.get(commandsCtx)
+      commands.call(insertQuizCommand.key)
+    },
+  })
+}
+
+export type { QuizOption, QuizAttrs }

--- a/dev/vanilla/index.html
+++ b/dev/vanilla/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crepe Editor - Non-React Example</title>
+  </head>
+  <body>
+    <div class="container">
+      <div id="editor"></div>
+    </div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/dev/vanilla/index.ts
+++ b/dev/vanilla/index.ts
@@ -1,0 +1,34 @@
+import { CrepeBuilder } from '@milkdown/crepe/builder'
+import { toolbar } from '@milkdown/crepe/feature/toolbar'
+import { blockEdit } from '@milkdown/crepe/feature/block-edit'
+
+// Import highlight feature and toolbar items
+import { highlightFeature, highlightToolbarItems } from './features/highlight'
+
+// Import quiz feature and slash menu
+import { quizFeature, customSlashMenu } from './features/quiz'
+
+// Import styles
+import '../../packages/crepe/src/theme/common/style.css'
+import '../../packages/crepe/src/theme/frame/style.css'
+
+// Build the editor with both highlight and quiz features
+const builder = new CrepeBuilder({ root: '#editor' })
+
+builder
+  // Register features
+  .addFeature(highlightFeature)
+  .addFeature(quizFeature)
+
+  // Add toolbar with highlight items
+  .addFeature(toolbar, {
+    customItems: highlightToolbarItems,
+  })
+
+  // Add block edit with custom slash menu
+  .addFeature(blockEdit, {
+    buildMenu: customSlashMenu,
+  })
+
+// Create the editor
+const editor = builder.create()

--- a/dev/vite.config.mts
+++ b/dev/vite.config.mts
@@ -1,0 +1,35 @@
+import react from '@vitejs/plugin-react'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+export default defineConfig({
+  plugins: [react()],
+  root: path.resolve(__dirname, '.'),
+  build: {
+    outDir: path.resolve(__dirname, 'dist'),
+    rollupOptions: {
+      input: {
+        vanilla: path.resolve(__dirname, 'vanilla/index.html'),
+        react: path.resolve(__dirname, 'react/index.html'),
+      },
+    },
+  },
+  server: {
+    open: '/vanilla/index.html',
+  },
+  resolve: {
+    alias: {
+      '@milkdown/crepe': path.resolve(__dirname, '../packages/crepe/src'),
+      '@milkdown/utils': path.resolve(__dirname, '../packages/utils/src'),
+      '@milkdown/kit': path.resolve(__dirname, '../packages/kit/src'),
+      '@milkdown/integrations/react': path.resolve(
+        __dirname,
+        '../packages/integrations/react/src'
+      ),
+    },
+  },
+})

--- a/docs/api/crepe.md
+++ b/docs/api/crepe.md
@@ -260,6 +260,16 @@ interface ToolbarFeatureConfig {
   linkIcon?: string
   strikethroughIcon?: string
   latexIcon?: string
+  customItems?: ToolbarItem[]
+}
+
+interface ToolbarItem {
+  key: string
+  icon: string
+  tooltip?: string
+  onClick: (ctx: Ctx) => void
+  isActive?: (ctx: Ctx, selection: Selection) => boolean
+  isDisabled?: (ctx: Ctx, selection: Selection) => boolean
 }
 
 // Example:
@@ -271,6 +281,18 @@ const config: CrepeConfig = {
     [Crepe.Feature.Toolbar]: {
       boldIcon: customBoldIcon,
       italicIcon: customItalicIcon,
+      customItems: [
+        {
+          key: 'highlight',
+          icon: '<svg>...</svg>',
+          tooltip: 'Highlight text',
+          onClick: (ctx) => {
+            // Custom highlight logic
+          },
+          isActive: (ctx, selection) => false,
+          isDisabled: (ctx, selection) => selection.empty
+        }
+      ]
     },
   },
 }

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,148 @@
+# Crepe Plugin Development Guide
+
+This guide shows how to create custom plugins for the Crepe editor to extend both the toolbar and slash menu functionality. The examples below are based on the working implementations in `./dev` directory.
+
+## Quick Start
+
+### Vanilla JavaScript / TypeScript
+
+```typescript
+import { CrepeBuilder } from '@milkdown/crepe/builder'
+import { toolbar, blockEdit } from '@milkdown/crepe'
+
+const builder = new CrepeBuilder({ root: '#editor' })
+
+// Add custom toolbar items
+builder.addFeature(toolbar, {
+  customItems: [
+    {
+      key: 'highlight',
+      icon: '🎨',
+      tooltip: 'Highlight text',
+      onClick: (ctx) => {
+        // Your custom logic
+      },
+      isActive: (ctx, selection) => false,
+      isDisabled: (ctx, selection) => selection.empty,
+    },
+  ],
+})
+
+// Add custom slash menu items
+builder.addFeature(blockEdit, {
+  buildMenu: (builder) => {
+    builder.addGroup('custom', 'My Plugins').addItem('widget', {
+      label: 'Custom Widget',
+      icon: '⭐',
+      onRun: (ctx) => {
+        // Your custom logic
+      },
+    })
+  },
+})
+
+const editor = builder.create()
+```
+
+### React Integration
+
+```tsx
+import React from 'react'
+import { Crepe, toolbar, blockEdit } from '@milkdown/crepe'
+import {
+  Milkdown,
+  MilkdownProvider,
+  useEditor,
+} from '@milkdown/integrations/react'
+
+const CrepeEditor = () => {
+  useEditor((root) => {
+    const crepe = new Crepe({ root })
+    crepe
+      .addFeature(toolbar, {
+        customItems: [
+          /* your toolbar items */
+        ],
+      })
+      .addFeature(blockEdit, {
+        buildMenu: (builder) => {
+          // your menu customization
+        },
+      })
+    return crepe
+  })
+  return <Milkdown />
+}
+
+export const App = () => (
+  <MilkdownProvider>
+    <CrepeEditor />
+  </MilkdownProvider>
+)
+```
+
+## Plugin Utilities
+
+Crepe provides helpful utility functions to simplify common plugin patterns. These utilities reduce boilerplate code and ensure consistent behavior across plugins.
+
+### ToolbarItemPresets
+
+The `ToolbarItemPresets` utility provides common toolbar item configurations:
+
+```typescript
+import { ToolbarItemPresets } from '@milkdown/crepe'
+
+// Item that requires text selection (automatically disabled when selection is empty)
+const selectionItem = ToolbarItemPresets.requiresSelection({
+  key: 'my-item',
+  icon: '🎨',
+  tooltip: 'My Action',
+  onClick: (ctx) => {
+    /* your logic */
+  },
+  isActive: (ctx, selection) => false, // optional
+})
+
+// Item that is always enabled
+const alwaysEnabledItem = ToolbarItemPresets.alwaysEnabled({
+  key: 'my-item',
+  icon: '🔧',
+  tooltip: 'Always Available',
+  onClick: (ctx) => {
+    /* your logic */
+  },
+  isActive: (ctx, selection) => false, // optional
+})
+```
+
+### SlashMenuItemPresets
+
+The `SlashMenuItemPresets` utility provides common slash menu item patterns:
+
+```typescript
+import { SlashMenuItemPresets } from '@milkdown/crepe'
+
+// Simple text insertion
+const textItem = SlashMenuItemPresets.textInsertion({
+  key: 'signature',
+  label: 'Insert Signature',
+  icon: '✍️',
+  text: 'Best regards,\nJohn Doe',
+})
+
+// Block replacement (requires NodeType)
+const blockItem = SlashMenuItemPresets.blockReplacement({
+  key: 'callout',
+  label: 'Callout Block',
+  icon: '📢',
+  nodeType: myNodeType, // Your ProseMirror NodeType
+  attrs: { type: 'info' }, // optional attributes
+})
+```
+
+These utilities handle common patterns like:
+
+- Automatic disabling when selection is empty (`requiresSelection`)
+- Text insertion at cursor position (`textInsertion`)
+- Block type replacement (`blockReplacement`)
+- Consistent state management

--- a/package.json
+++ b/package.json
@@ -125,5 +125,8 @@
       "safe-buffer": "npm:@nolyfill/safe-buffer@^1",
       "safer-buffer": "npm:@nolyfill/safer-buffer@^1"
     }
+  },
+  "dependencies": {
+    "react-dom": "19.1.0"
   }
 }

--- a/packages/crepe/src/feature/index.ts
+++ b/packages/crepe/src/feature/index.ts
@@ -7,7 +7,16 @@ import type { LinkTooltipFeatureConfig } from './link-tooltip'
 import type { ListItemFeatureConfig } from './list-item'
 import type { PlaceholderFeatureConfig } from './placeholder'
 import type { TableFeatureConfig } from './table'
-import type { ToolbarFeatureConfig } from './toolbar'
+import type { ToolbarFeatureConfig, ToolbarItem } from './toolbar'
+
+// Export types for plugin developers
+export type { ToolbarItem }
+export type { MenuItem, MenuItemGroup } from './block-edit/menu/utils'
+export type { GroupBuilder } from './block-edit/menu/group-builder'
+
+// Export plugin development utilities
+export { ToolbarItemPresets, SlashMenuItemPresets } from './plugin-utils'
+export type { ToolbarStateChecker, ToolbarAction, SlashMenuAction } from './plugin-utils'
 
 /// The crepe editor feature flags.
 /// Every feature is enabled by default.

--- a/packages/crepe/src/feature/plugin-utils.ts
+++ b/packages/crepe/src/feature/plugin-utils.ts
@@ -1,0 +1,83 @@
+import type { Ctx } from '@milkdown/kit/ctx'
+import type { Selection } from '@milkdown/kit/prose/state'
+
+import { editorViewCtx } from '@milkdown/kit/core'
+
+/// Utility types for plugin development
+
+/// A helper function type for toolbar item state checking
+export type ToolbarStateChecker = (ctx: Ctx, selection: Selection) => boolean
+
+/// A helper function type for toolbar item actions
+export type ToolbarAction = (ctx: Ctx) => void
+
+/// A helper function type for slash menu actions
+export type SlashMenuAction = (ctx: Ctx) => void
+
+/// Common toolbar item configurations
+export const ToolbarItemPresets = {
+  /// Creates a toolbar item that's disabled when selection is empty
+  requiresSelection: (config: {
+    key: string
+    icon: string
+    tooltip?: string
+    onClick: ToolbarAction
+    isActive?: ToolbarStateChecker
+  }) => ({
+    ...config,
+    isDisabled: (_ctx: Ctx, selection: Selection) => selection.empty,
+  }),
+
+  /// Creates a toolbar item that's always enabled
+  alwaysEnabled: (config: {
+    key: string
+    icon: string
+    tooltip?: string
+    onClick: ToolbarAction
+    isActive?: ToolbarStateChecker
+  }) => ({
+    ...config,
+    isDisabled: () => false,
+  }),
+}
+
+/// Common slash menu item configurations
+export const SlashMenuItemPresets = {
+  /// Creates a simple text insertion item
+  textInsertion: (config: {
+    key: string
+    label: string
+    icon: string
+    text: string
+  }) => ({
+    key: config.key,
+    label: config.label,
+    icon: config.icon,
+    onRun: (ctx: Ctx) => {
+      const view = ctx.get(editorViewCtx)
+      const { dispatch, state } = view
+      const tr = state.tr.insertText(config.text)
+      dispatch(tr)
+    },
+  }),
+
+  /// Creates a block replacement item
+  blockReplacement: (config: {
+    key: string
+    label: string
+    icon: string
+    nodeType: any // NodeType from prosemirror
+    attrs?: any
+  }) => ({
+    key: config.key,
+    label: config.label,
+    icon: config.icon,
+    onRun: (ctx: Ctx) => {
+      const view = ctx.get(editorViewCtx)
+      const { dispatch, state } = view
+      const { from, to } = state.selection
+      const tr = state.tr.setBlockType(from, to, config.nodeType, config.attrs)
+      dispatch(tr)
+    },
+  }),
+}

--- a/packages/crepe/src/feature/toolbar/component.tsx
+++ b/packages/crepe/src/feature/toolbar/component.tsx
@@ -25,7 +25,7 @@ import {
 import clsx from 'clsx'
 import { defineComponent, type Ref, type ShallowRef, h, Fragment } from 'vue'
 
-import type { ToolbarFeatureConfig } from '.'
+import type { ToolbarFeatureConfig, ToolbarItem } from '.'
 
 import { useCrepeFeatures } from '../../core/slice'
 import { CrepeFeature } from '../../feature'
@@ -158,6 +158,28 @@ export const Toolbar = defineComponent<ToolbarProps>({
       )
     }
 
+    const renderCustomItem = (item: ToolbarItem) => {
+      const isItemActive = item.isActive?.(ctx, props.selection.value) ?? false
+      const isItemDisabled = item.isDisabled?.(ctx, props.selection.value) ?? false
+
+      return (
+        <button
+          key={item.key}
+          type="button"
+          class={clsx(
+            'toolbar-item',
+            isItemActive && 'active',
+            isItemDisabled && 'disabled'
+          )}
+          disabled={isItemDisabled}
+          title={item.tooltip}
+          onPointerdown={onClick(() => item.onClick(ctx))}
+        >
+          <Icon icon={item.icon} />
+        </button>
+      )
+    }
+
     return () => {
       return (
         <>
@@ -249,6 +271,12 @@ export const Toolbar = defineComponent<ToolbarProps>({
           >
             <Icon icon={config?.linkIcon ?? linkIcon} />
           </button>
+          {config?.customItems && config.customItems.length > 0 && (
+            <>
+              <div class="divider"></div>
+              {config.customItems.map(renderCustomItem)}
+            </>
+          )}
         </>
       )
     }

--- a/packages/crepe/src/feature/toolbar/index.ts
+++ b/packages/crepe/src/feature/toolbar/index.ts
@@ -16,6 +16,22 @@ import { crepeFeatureConfig } from '../../core/slice'
 import { CrepeFeature } from '../../feature'
 import { Toolbar } from './component'
 
+/// Custom toolbar item configuration
+export interface ToolbarItem {
+  /// Unique identifier for the toolbar item
+  key: string
+  /// Icon to display (SVG string or icon identifier)
+  icon: string
+  /// Tooltip text for the item
+  tooltip?: string
+  /// Function to execute when the item is clicked
+  onClick: (ctx: Ctx) => void
+  /// Function to determine if the item should be active/highlighted
+  isActive?: (ctx: Ctx, selection: Selection) => boolean
+  /// Function to determine if the item should be disabled
+  isDisabled?: (ctx: Ctx, selection: Selection) => boolean
+}
+
 interface ToolbarConfig {
   boldIcon: string
   codeIcon: string
@@ -23,6 +39,8 @@ interface ToolbarConfig {
   linkIcon: string
   strikethroughIcon: string
   latexIcon: string
+  /// Custom toolbar items to add to the toolbar
+  customItems?: ToolbarItem[]
 }
 
 export type ToolbarFeatureConfig = Partial<ToolbarConfig>

--- a/packages/crepe/src/index.ts
+++ b/packages/crepe/src/index.ts
@@ -1,2 +1,16 @@
-export { CrepeFeature } from './feature'
+export { 
+  CrepeFeature, 
+  type ToolbarItem, 
+  type MenuItem, 
+  type MenuItemGroup, 
+  type GroupBuilder,
+  ToolbarItemPresets,
+  SlashMenuItemPresets,
+  type ToolbarStateChecker,
+  type ToolbarAction,
+  type SlashMenuAction
+} from './feature'
+export { toolbar } from './feature/toolbar'
+export { blockEdit } from './feature/block-edit'
+export type { DefineFeature } from './feature/shared'
 export * from './core'

--- a/packages/utils/src/composable/$component.ts
+++ b/packages/utils/src/composable/$component.ts
@@ -1,0 +1,29 @@
+// Minimal $component utility for registering custom node views/components
+import type { Ctx, MilkdownPlugin } from '@milkdown/ctx'
+import type { NodeViewConstructor } from '@milkdown/prose/view'
+
+import { nodeViewCtx, SchemaReady } from '@milkdown/core'
+
+export function $component(
+  id: string,
+  factory: (ctx: Ctx) => {
+    component: any
+    as?: string
+    shouldUpdate?: (prev: any, next: any) => boolean
+  }
+): MilkdownPlugin {
+  return (ctx) => async () => {
+    await ctx.wait(SchemaReady)
+    const { component } = factory(ctx)
+    const nodeView: NodeViewConstructor = (node, view, getPos) => {
+      return new component(node, view, getPos, ctx)
+    }
+    ctx.update(nodeViewCtx, (ps) => [
+      ...ps,
+      [id, nodeView] as [string, NodeViewConstructor],
+    ])
+    return () => {
+      ctx.update(nodeViewCtx, (ps) => ps.filter((x) => x[0] !== id))
+    }
+  }
+}

--- a/packages/utils/src/composable/index.ts
+++ b/packages/utils/src/composable/index.ts
@@ -1,4 +1,5 @@
 export * from './$command'
+export * from './$component'
 export * from './$input-rule'
 export * from './$mark'
 export * from './$node'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.22.0
@@ -178,6 +182,12 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
+      '@types/react':
+        specifier: ^19.1.5
+        version: 19.1.5
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.1.5(@types/react@19.1.5)
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -187,6 +197,12 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
 
   docs:
     devDependencies:


### PR DESCRIPTION
This commit adds the ability to add to the toolbar and slash menu with custom actions and rendering.

BREAKING CHANGE: 🧨 None

✅ Closes: NA

- [X] I read the contributing guide
- [X] I agree to follow the code of conduct

## Summary

Hello I needed to be able to extend the Crepe editor and couldn't find a clean way to do it.  This PR adds hooks into Crepe that allows for additional toolbar and slash menu features. The actual change is quite small, most of it is the examples. If there is interest in this PR, I'd move everything in dev to the stackblitz examples and would remove the package changes.

## How did you test this change?

Under ./dev in the PR (to move to stackblitz) there are a vanilla and react example which implement custom toolbar and slash menu examples. They add support for extra text features and custom elements.

![image](https://github.com/user-attachments/assets/f1645721-3fe2-4e7a-af23-7aa5d2346616)
![image](https://github.com/user-attachments/assets/b151acd0-401e-402f-a8d9-ff7605e0fa2a)
![image](https://github.com/user-attachments/assets/651594af-332e-4b14-b72d-04954dec0638)
![image](https://github.com/user-attachments/assets/04464387-a6e2-41f3-8f5b-12e62a192e11)
