### PR TITLE
feat: 🎸 improve the block menu config api

### DIFF
--- a/docs/api/crepe.md
+++ b/docs/api/crepe.md
@@ -199,37 +199,84 @@ interface BlockEditFeatureConfig {
   // Menu configuration
   buildMenu?: (builder: GroupBuilder<SlashMenuItem>) => void
 
-  // Text group labels and icons
-  slashMenuTextGroupLabel?: string
-  slashMenuTextIcon?: string
-  slashMenuTextLabel?: string
-
-  // Heading labels and icons
-  slashMenuH1Icon?: string
-  slashMenuH1Label?: string
-  slashMenuH2Icon?: string
-  slashMenuH2Label?: string
-  // ... H3-H6 similar configuration
+  // Text group configuration
+  textGroup?: {
+    label?: string
+    text?: {
+      label?: string
+      icon?: string
+    } | null
+    h1?: {
+      label?: string
+      icon?: string
+    } | null
+    h2?: {
+      label?: string
+      icon?: string
+    } | null
+    h3?: {
+      label?: string
+      icon?: string
+    } | null
+    h4?: {
+      label?: string
+      icon?: string
+    } | null
+    h5?: {
+      label?: string
+      icon?: string
+    } | null
+    h6?: {
+      label?: string
+      icon?: string
+    } | null
+    quote?: {
+      label?: string
+      icon?: string
+    } | null
+    divider?: {
+      label?: string
+      icon?: string
+    } | null
+  } | null
 
   // List group configuration
-  slashMenuListGroupLabel?: string
-  slashMenuBulletListIcon?: string
-  slashMenuBulletListLabel?: string
-  slashMenuOrderedListIcon?: string
-  slashMenuOrderedListLabel?: string
-  slashMenuTaskListIcon?: string
-  slashMenuTaskListLabel?: string
+  listGroup?: {
+    label?: string
+    bulletList?: {
+      label?: string
+      icon?: string
+    } | null
+    orderedList?: {
+      label?: string
+      icon?: string
+    } | null
+    taskList?: {
+      label?: string
+      icon?: string
+    } | null
+  } | null
 
   // Advanced group configuration
-  slashMenuAdvancedGroupLabel?: string
-  slashMenuImageIcon?: string
-  slashMenuImageLabel?: string
-  slashMenuCodeBlockIcon?: string
-  slashMenuCodeBlockLabel?: string
-  slashMenuTableIcon?: string
-  slashMenuTableLabel?: string
-  slashMenuMathIcon?: string
-  slashMenuMathLabel?: string
+  advancedGroup?: {
+    label?: string
+    image?: {
+      label?: string
+      icon?: string
+    } | null
+    codeBlock?: {
+      label?: string
+      icon?: string
+    } | null
+    table?: {
+      label?: string
+      icon?: string
+    } | null
+    math?: {
+      label?: string
+      icon?: string
+    } | null
+  } | null
 }
 
 // Example:
@@ -239,9 +286,43 @@ const config: CrepeConfig = {
   },
   featureConfigs: {
     [Crepe.Feature.BlockEdit]: {
-      slashMenuTextGroupLabel: 'Text Blocks',
-      slashMenuH1Label: 'Large Heading',
-      slashMenuListGroupLabel: 'Lists',
+      handleAddIcon: customAddIcon,
+      handleDragIcon: customDragIcon,
+      textGroup: {
+        label: 'Text Blocks',
+        text: {
+          label: 'Normal Text',
+          icon: customTextIcon,
+        },
+        h1: {
+          label: 'Heading 1',
+          icon: customH1Icon,
+        },
+        h2: null,
+        h3: null,
+        h4: null,
+        h5: null,
+        h6: null,
+      },
+      listGroup: {
+        label: 'Lists',
+        bulletList: {
+          label: 'Bullet List',
+          icon: customBulletIcon,
+        },
+        orderedList: null,
+        taskList: null,
+      },
+      advancedGroup: {
+        label: 'Advanced',
+        image: {
+          label: 'Image',
+          icon: customImageIcon,
+        },
+        codeBlock: null,
+        table: null,
+        math: null,
+      },
       buildMenu: (builder) => {
         // Custom menu building logic
       },
@@ -249,6 +330,8 @@ const config: CrepeConfig = {
   },
 }
 ```
+
+> **Note**: Setting any group or item to `null` will prevent it from being displayed in the menu. This is useful for customizing which options are available to users. For example, setting `h2: null` will hide the H2 heading option, and setting `textGroup: null` will hide the entire text group.
 
 #### Toolbar Feature
 

--- a/packages/crepe/src/feature/block-edit/index.ts
+++ b/packages/crepe/src/feature/block-edit/index.ts
@@ -1,5 +1,6 @@
 import { block } from '@milkdown/kit/plugin/block'
 
+import type { DeepPartial } from '../../utils'
 import type { GroupBuilder } from '../../utils/group-builder'
 import type { DefineFeature } from '../shared'
 import type { SlashMenuItem } from './menu/utils'
@@ -14,46 +15,84 @@ interface BlockEditConfig {
   handleDragIcon: string
   buildMenu: (builder: GroupBuilder<SlashMenuItem>) => void
 
-  slashMenuTextGroupLabel: string
-  slashMenuTextIcon: string
-  slashMenuTextLabel: string
-  slashMenuH1Icon: string
-  slashMenuH1Label: string
-  slashMenuH2Icon: string
-  slashMenuH2Label: string
-  slashMenuH3Icon: string
-  slashMenuH3Label: string
-  slashMenuH4Icon: string
-  slashMenuH4Label: string
-  slashMenuH5Icon: string
-  slashMenuH5Label: string
-  slashMenuH6Icon: string
-  slashMenuH6Label: string
-  slashMenuQuoteIcon: string
-  slashMenuQuoteLabel: string
-  slashMenuDividerIcon: string
-  slashMenuDividerLabel: string
+  textGroup: {
+    label: string
+    text: {
+      label: string
+      icon: string
+    } | null
+    h1: {
+      label: string
+      icon: string
+    } | null
+    h2: {
+      label: string
+      icon: string
+    } | null
+    h3: {
+      label: string
+      icon: string
+    } | null
+    h4: {
+      label: string
+      icon: string
+    } | null
+    h5: {
+      label: string
+      icon: string
+    } | null
+    h6: {
+      label: string
+      icon: string
+    } | null
+    quote: {
+      label: string
+      icon: string
+    } | null
+    divider: {
+      label: string
+      icon: string
+    } | null
+  } | null
 
-  slashMenuListGroupLabel: string
-  slashMenuBulletListIcon: string
-  slashMenuBulletListLabel: string
-  slashMenuOrderedListIcon: string
-  slashMenuOrderedListLabel: string
-  slashMenuTaskListIcon: string
-  slashMenuTaskListLabel: string
+  listGroup: {
+    label: string
+    bulletList: {
+      label: string
+      icon: string
+    } | null
+    orderedList: {
+      label: string
+      icon: string
+    } | null
+    taskList: {
+      label: string
+      icon: string
+    } | null
+  } | null
 
-  slashMenuAdvancedGroupLabel: string
-  slashMenuImageIcon: string
-  slashMenuImageLabel: string
-  slashMenuCodeBlockIcon: string
-  slashMenuCodeBlockLabel: string
-  slashMenuTableIcon: string
-  slashMenuTableLabel: string
-  slashMenuMathIcon: string
-  slashMenuMathLabel: string
+  advancedGroup: {
+    label: string
+    image: {
+      label: string
+      icon: string
+    } | null
+    codeBlock: {
+      label: string
+      icon: string
+    } | null
+    table: {
+      label: string
+      icon: string
+    } | null
+    math: {
+      label: string
+      icon: string
+    } | null
+  } | null
 }
 
-export type BlockEditFeatureConfig = Partial<BlockEditConfig>
+export type BlockEditFeatureConfig = DeepPartial<BlockEditConfig>
 
 export const blockEdit: DefineFeature<BlockEditFeatureConfig> = (
   editor,

--- a/packages/crepe/src/feature/block-edit/menu/config.ts
+++ b/packages/crepe/src/feature/block-edit/menu/config.ts
@@ -55,260 +55,306 @@ export function getGroups(
   const isTableEnabled = flags?.includes(CrepeFeature.Table)
 
   const groupBuilder = new GroupBuilder<SlashMenuItem>()
-  groupBuilder
-    .addGroup('text', config?.slashMenuTextGroupLabel ?? 'Text')
-    .addItem('text', {
-      label: config?.slashMenuTextLabel ?? 'Text',
-      icon: config?.slashMenuTextIcon ?? textIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const paragraph = paragraphSchema.type(ctx)
+  if (config?.textGroup !== null) {
+    const textGroup = groupBuilder.addGroup(
+      'text',
+      config?.textGroup?.label ?? 'Text'
+    )
+    if (config?.textGroup?.text !== null) {
+      textGroup.addItem('text', {
+        label: config?.textGroup?.text?.label ?? 'Text',
+        icon: config?.textGroup?.text?.icon ?? textIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const paragraph = paragraphSchema.type(ctx)
 
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(setBlockTypeCommand.key, {
-          nodeType: paragraph,
-        })
-      },
-    })
-    .addItem('h1', {
-      label: config?.slashMenuH1Label ?? 'Heading 1',
-      icon: config?.slashMenuH1Icon ?? h1Icon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const heading = headingSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(setBlockTypeCommand.key, {
-          nodeType: heading,
-          attrs: {
-            level: 1,
-          },
-        })
-      },
-    })
-    .addItem('h2', {
-      label: config?.slashMenuH2Label ?? 'Heading 2',
-      icon: config?.slashMenuH2Icon ?? h2Icon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const heading = headingSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(setBlockTypeCommand.key, {
-          nodeType: heading,
-          attrs: {
-            level: 2,
-          },
-        })
-      },
-    })
-    .addItem('h3', {
-      label: config?.slashMenuH3Label ?? 'Heading 3',
-      icon: config?.slashMenuH3Icon ?? h3Icon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const heading = headingSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(setBlockTypeCommand.key, {
-          nodeType: heading,
-          attrs: {
-            level: 3,
-          },
-        })
-      },
-    })
-    .addItem('h4', {
-      label: config?.slashMenuH4Label ?? 'Heading 4',
-      icon: config?.slashMenuH4Icon ?? h4Icon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const heading = headingSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(setBlockTypeCommand.key, {
-          nodeType: heading,
-          attrs: {
-            level: 4,
-          },
-        })
-      },
-    })
-    .addItem('h5', {
-      label: config?.slashMenuH5Label ?? 'Heading 5',
-      icon: config?.slashMenuH5Icon ?? h5Icon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const heading = headingSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(setBlockTypeCommand.key, {
-          nodeType: heading,
-          attrs: {
-            level: 5,
-          },
-        })
-      },
-    })
-    .addItem('h6', {
-      label: config?.slashMenuH6Label ?? 'Heading 6',
-      icon: config?.slashMenuH6Icon ?? h6Icon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const heading = headingSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(setBlockTypeCommand.key, {
-          nodeType: heading,
-          attrs: {
-            level: 6,
-          },
-        })
-      },
-    })
-    .addItem('quote', {
-      label: config?.slashMenuQuoteLabel ?? 'Quote',
-      icon: config?.slashMenuQuoteIcon ?? quoteIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const blockquote = blockquoteSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(wrapInBlockTypeCommand.key, {
-          nodeType: blockquote,
-        })
-      },
-    })
-    .addItem('divider', {
-      label: config?.slashMenuDividerLabel ?? 'Divider',
-      icon: config?.slashMenuDividerIcon ?? dividerIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const hr = hrSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(addBlockTypeCommand.key, {
-          nodeType: hr,
-        })
-      },
-    })
-
-  groupBuilder
-    .addGroup('list', config?.slashMenuListGroupLabel ?? 'List')
-    .addItem('bullet-list', {
-      label: config?.slashMenuBulletListLabel ?? 'Bullet List',
-      icon: config?.slashMenuBulletListIcon ?? bulletListIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const bulletList = bulletListSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(wrapInBlockTypeCommand.key, {
-          nodeType: bulletList,
-        })
-      },
-    })
-    .addItem('ordered-list', {
-      label: config?.slashMenuOrderedListLabel ?? 'Ordered List',
-      icon: config?.slashMenuOrderedListIcon ?? orderedListIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const orderedList = orderedListSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(wrapInBlockTypeCommand.key, {
-          nodeType: orderedList,
-        })
-      },
-    })
-    .addItem('todo-list', {
-      label: config?.slashMenuTaskListLabel ?? 'Todo List',
-      icon: config?.slashMenuTaskListIcon ?? todoListIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const listItem = listItemSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(wrapInBlockTypeCommand.key, {
-          nodeType: listItem,
-          attrs: { checked: false },
-        })
-      },
-    })
-
-  const advancedGroup = groupBuilder.addGroup(
-    'advanced',
-    config?.slashMenuAdvancedGroupLabel ?? 'Advanced'
-  )
-
-  if (isImageBlockEnabled) {
-    advancedGroup.addItem('image', {
-      label: config?.slashMenuImageLabel ?? 'Image',
-      icon: config?.slashMenuImageIcon ?? imageIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const imageBlock = imageBlockSchema.type(ctx)
-
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(addBlockTypeCommand.key, {
-          nodeType: imageBlock,
-        })
-      },
-    })
-  }
-
-  advancedGroup.addItem('code', {
-    label: config?.slashMenuCodeBlockLabel ?? 'Code',
-    icon: config?.slashMenuCodeBlockIcon ?? codeIcon,
-    onRun: (ctx) => {
-      const commands = ctx.get(commandsCtx)
-      const codeBlock = codeBlockSchema.type(ctx)
-
-      commands.call(clearTextInCurrentBlockCommand.key)
-      commands.call(setBlockTypeCommand.key, {
-        nodeType: codeBlock,
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: paragraph,
+          })
+        },
       })
-    },
-  })
+    }
 
-  if (isTableEnabled) {
-    advancedGroup.addItem('table', {
-      label: config?.slashMenuTableLabel ?? 'Table',
-      icon: config?.slashMenuTableIcon ?? tableIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const view = ctx.get(editorViewCtx)
+    if (config?.textGroup?.h1 !== null) {
+      textGroup.addItem('h1', {
+        label: config?.textGroup?.h1?.label ?? 'Heading 1',
+        icon: config?.textGroup?.h1?.icon ?? h1Icon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const heading = headingSchema.type(ctx)
 
-        commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: heading,
+            attrs: {
+              level: 1,
+            },
+          })
+        },
+      })
+    }
 
-        // record the position before the table is inserted
-        const { from } = view.state.selection
-        commands.call(addBlockTypeCommand.key, {
-          nodeType: createTable(ctx, 3, 3),
-        })
+    if (config?.textGroup?.h2 !== null) {
+      textGroup.addItem('h2', {
+        label: config?.textGroup?.h2?.label ?? 'Heading 2',
+        icon: config?.textGroup?.h2?.icon ?? h2Icon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const heading = headingSchema.type(ctx)
 
-        commands.call(selectTextNearPosCommand.key, {
-          pos: from,
-        })
-      },
-    })
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: heading,
+            attrs: {
+              level: 2,
+            },
+          })
+        },
+      })
+    }
+
+    if (config?.textGroup?.h3 !== null) {
+      textGroup.addItem('h3', {
+        label: config?.textGroup?.h3?.label ?? 'Heading 3',
+        icon: config?.textGroup?.h3?.icon ?? h3Icon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const heading = headingSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: heading,
+            attrs: {
+              level: 3,
+            },
+          })
+        },
+      })
+    }
+
+    if (config?.textGroup?.h4 !== null) {
+      textGroup.addItem('h4', {
+        label: config?.textGroup?.h4?.label ?? 'Heading 4',
+        icon: config?.textGroup?.h4?.icon ?? h4Icon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const heading = headingSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: heading,
+            attrs: {
+              level: 4,
+            },
+          })
+        },
+      })
+    }
+
+    if (config?.textGroup?.h5 !== null) {
+      textGroup.addItem('h5', {
+        label: config?.textGroup?.h5?.label ?? 'Heading 5',
+        icon: config?.textGroup?.h5?.icon ?? h5Icon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const heading = headingSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: heading,
+            attrs: {
+              level: 5,
+            },
+          })
+        },
+      })
+    }
+
+    if (config?.textGroup?.h6 !== null) {
+      textGroup.addItem('h6', {
+        label: config?.textGroup?.h6?.label ?? 'Heading 6',
+        icon: config?.textGroup?.h6?.icon ?? h6Icon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const heading = headingSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: heading,
+            attrs: {
+              level: 6,
+            },
+          })
+        },
+      })
+    }
+
+    if (config?.textGroup?.quote !== null) {
+      textGroup.addItem('quote', {
+        label: config?.textGroup?.quote?.label ?? 'Quote',
+        icon: config?.textGroup?.quote?.icon ?? quoteIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const blockquote = blockquoteSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(wrapInBlockTypeCommand.key, {
+            nodeType: blockquote,
+          })
+        },
+      })
+    }
+
+    if (config?.textGroup?.divider !== null) {
+      textGroup.addItem('divider', {
+        label: config?.textGroup?.divider?.label ?? 'Divider',
+        icon: config?.textGroup?.divider?.icon ?? dividerIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const hr = hrSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(addBlockTypeCommand.key, {
+            nodeType: hr,
+          })
+        },
+      })
+    }
   }
 
-  if (isLatexEnabled) {
-    advancedGroup.addItem('math', {
-      label: config?.slashMenuMathLabel ?? 'Math',
-      icon: config?.slashMenuMathIcon ?? functionsIcon,
-      onRun: (ctx) => {
-        const commands = ctx.get(commandsCtx)
-        const codeBlock = codeBlockSchema.type(ctx)
+  if (config?.listGroup !== null) {
+    const listGroup = groupBuilder.addGroup(
+      'list',
+      config?.listGroup?.label ?? 'List'
+    )
+    if (config?.listGroup?.bulletList !== null) {
+      listGroup.addItem('bullet-list', {
+        label: config?.listGroup?.bulletList?.label ?? 'Bullet List',
+        icon: config?.listGroup?.bulletList?.icon ?? bulletListIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const bulletList = bulletListSchema.type(ctx)
 
-        commands.call(clearTextInCurrentBlockCommand.key)
-        commands.call(addBlockTypeCommand.key, {
-          nodeType: codeBlock,
-          attrs: { language: 'LaTex' },
-        })
-      },
-    })
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(wrapInBlockTypeCommand.key, {
+            nodeType: bulletList,
+          })
+        },
+      })
+    }
+
+    if (config?.listGroup?.orderedList !== null) {
+      listGroup.addItem('ordered-list', {
+        label: config?.listGroup?.orderedList?.label ?? 'Ordered List',
+        icon: config?.listGroup?.orderedList?.icon ?? orderedListIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const orderedList = orderedListSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(wrapInBlockTypeCommand.key, {
+            nodeType: orderedList,
+          })
+        },
+      })
+    }
+
+    if (config?.listGroup?.taskList !== null) {
+      listGroup.addItem('task-list', {
+        label: config?.listGroup?.taskList?.label ?? 'Task List',
+        icon: config?.listGroup?.taskList?.icon ?? todoListIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const listItem = listItemSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(wrapInBlockTypeCommand.key, {
+            nodeType: listItem,
+            attrs: { checked: false },
+          })
+        },
+      })
+    }
+  }
+
+  if (config?.advancedGroup !== null) {
+    const advancedGroup = groupBuilder.addGroup(
+      'advanced',
+      config?.advancedGroup?.label ?? 'Advanced'
+    )
+
+    if (config?.advancedGroup?.image !== null && isImageBlockEnabled) {
+      advancedGroup.addItem('image', {
+        label: config?.advancedGroup?.image?.label ?? 'Image',
+        icon: config?.advancedGroup?.image?.icon ?? imageIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const imageBlock = imageBlockSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(addBlockTypeCommand.key, {
+            nodeType: imageBlock,
+          })
+        },
+      })
+    }
+
+    if (config?.advancedGroup?.codeBlock !== null) {
+      advancedGroup.addItem('code', {
+        label: config?.advancedGroup?.codeBlock?.label ?? 'Code',
+        icon: config?.advancedGroup?.codeBlock?.icon ?? codeIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const codeBlock = codeBlockSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(setBlockTypeCommand.key, {
+            nodeType: codeBlock,
+          })
+        },
+      })
+    }
+
+    if (config?.advancedGroup?.table !== null && isTableEnabled) {
+      advancedGroup.addItem('table', {
+        label: config?.advancedGroup?.table?.label ?? 'Table',
+        icon: config?.advancedGroup?.table?.icon ?? tableIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const view = ctx.get(editorViewCtx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+
+          // record the position before the table is inserted
+          const { from } = view.state.selection
+          commands.call(addBlockTypeCommand.key, {
+            nodeType: createTable(ctx, 3, 3),
+          })
+
+          commands.call(selectTextNearPosCommand.key, {
+            pos: from,
+          })
+        },
+      })
+    }
+
+    if (config?.advancedGroup?.math !== null && isLatexEnabled) {
+      advancedGroup.addItem('math', {
+        label: config?.advancedGroup?.math?.label ?? 'Math',
+        icon: config?.advancedGroup?.math?.icon ?? functionsIcon,
+        onRun: (ctx) => {
+          const commands = ctx.get(commandsCtx)
+          const codeBlock = codeBlockSchema.type(ctx)
+
+          commands.call(clearTextInCurrentBlockCommand.key)
+          commands.call(addBlockTypeCommand.key, {
+            nodeType: codeBlock,
+            attrs: { language: 'LaTex' },
+          })
+        },
+      })
+    }
   }
 
   config?.buildMenu?.(groupBuilder)

--- a/packages/crepe/src/utils/index.ts
+++ b/packages/crepe/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './checker'
 export * from './group-builder'
+export * from './types'

--- a/packages/crepe/src/utils/types.ts
+++ b/packages/crepe/src/utils/types.ts
@@ -1,0 +1,9 @@
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends (...args: any[]) => any
+    ? T[K]
+    : T[K] extends Record<string, any>
+      ? DeepPartial<T[K]>
+      : T[K] extends Record<string, any> | null | undefined
+        ? DeepPartial<T[K]> | null | undefined
+        : T[K]
+}

--- a/storybook/stories/crepe/setup.ts
+++ b/storybook/stories/crepe/setup.ts
@@ -55,30 +55,63 @@ export function setup({ args, style, theme }: setupConfig) {
         blockConfirmButton: language === 'JA' ? '確認' : 'Confirm',
       },
       [Crepe.Feature.BlockEdit]: {
-        slashMenuTextGroupLabel: language === 'JA' ? 'テキスト' : 'Text',
-        slashMenuTextLabel: language === 'JA' ? 'テキスト' : 'Text',
-        slashMenuH1Label: language === 'JA' ? '見出し1' : 'Heading 1',
-        slashMenuH2Label: language === 'JA' ? '見出し2' : 'Heading 2',
-        slashMenuH3Label: language === 'JA' ? '見出し3' : 'Heading 3',
-        slashMenuH4Label: language === 'JA' ? '見出し4' : 'Heading 4',
-        slashMenuH5Label: language === 'JA' ? '見出し5' : 'Heading 5',
-        slashMenuH6Label: language === 'JA' ? '見出し6' : 'Heading 6',
-        slashMenuQuoteLabel: language === 'JA' ? '引用' : 'Quote',
-        slashMenuDividerLabel: language === 'JA' ? '区切り線' : 'Divider',
-
-        slashMenuListGroupLabel: language === 'JA' ? 'リスト' : 'List',
-        slashMenuBulletListLabel:
-          language === 'JA' ? '箇条書き' : 'Bullet List',
-        slashMenuOrderedListLabel:
-          language === 'JA' ? '番号付きリスト' : 'Ordered List',
-        slashMenuTaskListLabel:
-          language === 'JA' ? 'タスクリスト' : 'Task List',
-
-        slashMenuAdvancedGroupLabel:
-          language === 'JA' ? '高度な機能' : 'Advanced',
-        slashMenuImageLabel: language === 'JA' ? '画像' : 'Image',
-        slashMenuCodeBlockLabel: language === 'JA' ? 'コード' : 'Code',
-        slashMenuTableLabel: language === 'JA' ? '表' : 'Table',
+        textGroup: {
+          label: language === 'JA' ? 'テキスト' : 'Text',
+          text: {
+            label: language === 'JA' ? 'テキスト' : 'Text',
+          },
+          h1: {
+            label: language === 'JA' ? '見出し1' : 'Heading 1',
+          },
+          h2: {
+            label: language === 'JA' ? '見出し2' : 'Heading 2',
+          },
+          h3: {
+            label: language === 'JA' ? '見出し3' : 'Heading 3',
+          },
+          h4: {
+            label: language === 'JA' ? '見出し4' : 'Heading 4',
+          },
+          h5: {
+            label: language === 'JA' ? '見出し5' : 'Heading 5',
+          },
+          h6: {
+            label: language === 'JA' ? '見出し6' : 'Heading 6',
+          },
+          quote: {
+            label: language === 'JA' ? '引用' : 'Quote',
+          },
+          divider: {
+            label: language === 'JA' ? '区切り線' : 'Divider',
+          },
+        },
+        listGroup: {
+          label: language === 'JA' ? 'リスト' : 'List',
+          bulletList: {
+            label: language === 'JA' ? '箇条書き' : 'Bullet List',
+          },
+          orderedList: {
+            label: language === 'JA' ? '番号付きリスト' : 'Ordered List',
+          },
+          taskList: {
+            label: language === 'JA' ? 'タスクリスト' : 'Task List',
+          },
+        },
+        advancedGroup: {
+          label: language === 'JA' ? '高度な機能' : 'Advanced',
+          image: {
+            label: language === 'JA' ? '画像' : 'Image',
+          },
+          codeBlock: {
+            label: language === 'JA' ? 'コード' : 'Code',
+          },
+          table: {
+            label: language === 'JA' ? '表' : 'Table',
+          },
+          math: {
+            label: language === 'JA' ? '数式' : 'Math',
+          },
+        },
       },
       [Crepe.Feature.Placeholder]: {
         text:


### PR DESCRIPTION
✅ Closes: #1916

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Improve the block menu config api.

### 1. Restructured Configuration Interface

- Replaced flat configuration properties with nested group-based configuration
- Introduced three main configuration groups:
  - `textGroup`: For text-related blocks (paragraphs, headings, quotes, dividers)
  - `listGroup`: For list-related blocks (bullet, ordered, task lists)
  - `advancedGroup`: For advanced blocks (images, code blocks, tables, math)

### 2. Enhanced Type Safety

- Added `DeepPartial` utility type for better type inference
- Introduced nullable configuration options to allow disabling specific menu items
- Improved type definitions for menu item configurations

### 3. Improved Customization

- Each menu item can now be individually enabled/disabled by setting it to `null`
- Groups can be completely hidden by setting the entire group to `null`
- Maintained backward compatibility with default values

### 4. Code Organization

- Added new `types.ts` utility file for shared type definitions
- Refactored menu configuration logic to be more maintainable
- Improved conditional rendering of menu items based on feature flags

## Breaking Changes

The configuration interface has been significantly changed. Users will need to update their configurations to use the new nested structure. For example:

```typescript
// Old configuration
{
  slashMenuTextGroupLabel: 'Text Blocks',
  slashMenuH1Label: 'Large Heading'
}

// New configuration
{
  textGroup: {
    label: 'Text Blocks',
    h1: {
      label: 'Large Heading'
    }
  }
}
```

## Migration Guide

1. Group your existing configuration properties into the appropriate groups
2. Convert flat properties to nested objects
3. Use `null` to disable specific menu items or entire groups
4. Update any custom menu building logic to work with the new structure

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

CI, Manually.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `main` <!-- branch-stack -->
  - \#1953 :point\_left:
