### PR TITLE
fix: 🐛 overflow codemirror scroll to top

### DIFF
--- a/packages/components/src/code-block/view/node-view.ts
+++ b/packages/components/src/code-block/view/node-view.ts
@@ -8,6 +8,7 @@ import {
   type KeyBinding,
   type ViewUpdate,
   keymap as cmKeymap,
+  drawSelection,
 } from '@codemirror/view'
 import { exitCode } from '@milkdown/prose/commands'
 import { redo, undo } from '@milkdown/prose/history'
@@ -50,6 +51,7 @@ export class CodeMirrorBlock implements NodeView {
       root: this.view.root,
       extensions: [
         this.readOnlyConf.of(EditorState.readOnly.of(!this.view.editable)),
+        drawSelection(),
         cmKeymap.of(this.codeMirrorKeymap()),
         this.languageConf.of([]),
         EditorState.changeFilter.of(() => this.view.editable),
@@ -238,6 +240,7 @@ export class CodeMirrorBlock implements NodeView {
       this.updating = true
       this.cm.dispatch({
         changes: { from: change.from, to: change.to, insert: change.text },
+        scrollIntoView: true,
       })
       this.updating = false
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Closes: #1963
Fix the issue that execute undo history(ctrl-z) in a code block will scroll to code block's top.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Manually

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `main` <!-- branch-stack -->
  - \#1967 :point\_left:
