### PR TITLE
feat: get editor before loaded for react and vue

### DIFF
--- a/packages/integrations/react/src/use-get-editor.ts
+++ b/packages/integrations/react/src/use-get-editor.ts
@@ -27,12 +27,15 @@ export function useGetEditor() {
     const editor = getEditor(div)
     if (!editor) return
 
+    if ('editor' in editor) {
+      editorRef.current = editor.editor
+    } else {
+      editorRef.current = editor
+    }
+
     setLoading(true)
     editor
       .create()
-      .then((editor) => {
-        editorRef.current = editor
-      })
       .finally(() => {
         setLoading(false)
       })

--- a/packages/integrations/vue/src/__tests__/crepe-builder.test.tsx
+++ b/packages/integrations/vue/src/__tests__/crepe-builder.test.tsx
@@ -24,11 +24,7 @@ const TestEditor = defineComponent({
 
 const TestApp = defineComponent({
   setup() {
-    return () => (
-      <MilkdownProvider>
-        <TestEditor />
-      </MilkdownProvider>
-    )
+    return () => <MilkdownProvider>{() => <TestEditor />}</MilkdownProvider>
   },
 })
 

--- a/packages/integrations/vue/src/__tests__/crepe.test.tsx
+++ b/packages/integrations/vue/src/__tests__/crepe.test.tsx
@@ -20,11 +20,7 @@ const TestEditor = defineComponent({
 
 const TestApp = defineComponent({
   setup() {
-    return () => (
-      <MilkdownProvider>
-        <TestEditor />
-      </MilkdownProvider>
-    )
+    return () => <MilkdownProvider>{() => <TestEditor />}</MilkdownProvider>
   },
 })
 

--- a/packages/integrations/vue/src/__tests__/milkdown.test.tsx
+++ b/packages/integrations/vue/src/__tests__/milkdown.test.tsx
@@ -28,11 +28,7 @@ const TestEditor = defineComponent({
 
 const TestApp = defineComponent({
   setup() {
-    return () => (
-      <MilkdownProvider>
-        <TestEditor />
-      </MilkdownProvider>
-    )
+    return () => <MilkdownProvider>{() => <TestEditor />}</MilkdownProvider>
   },
 })
 

--- a/packages/integrations/vue/src/use-get-editor.ts
+++ b/packages/integrations/vue/src/use-get-editor.ts
@@ -22,13 +22,16 @@ export function useGetEditor() {
     const editor = getEditor.value!(dom.value)
     if (!editor) return
 
+    if ('editor' in editor) {
+      editorRef.value = editor.editor
+    } else {
+      editorRef.value = editor
+    }
+
     loading.value = true
     currentEditorRef.value = editor
     editor
       .create()
-      .then((editor) => {
-        editorRef.value = editor
-      })
       .finally(() => {
         loading.value = false
       })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Get editor instance before loaded for react and vue.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

CI

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `main` <!-- branch-stack -->
  - \#1978 :point\_left:
