### PR TITLE
fix: 🐛 emoji crash if not available in twemoji

### DIFF
--- a/packages/plugins/plugin-emoji/package.json
+++ b/packages/plugins/plugin-emoji/package.json
@@ -50,5 +50,8 @@
     "tslib": "^2.8.1",
     "twemoji": "^14.0.2",
     "unist-util-visit": "^5.0.0"
+  },
+  "devDependencies": {
+    "@milkdown/preset-commonmark": "workspace:*"
   }
 }

--- a/packages/plugins/plugin-emoji/package.json
+++ b/packages/plugins/plugin-emoji/package.json
@@ -43,6 +43,7 @@
     "@milkdown/ctx": "workspace:*",
     "@milkdown/prose": "workspace:*",
     "@milkdown/transformer": "workspace:*",
+    "dompurify": "^3.2.5",
     "emoji-regex": "^10.0.0",
     "node-emoji": "^2.1.3",
     "remark-emoji": "^5.0.0",

--- a/packages/plugins/plugin-emoji/src/emoji-render.spec.ts
+++ b/packages/plugins/plugin-emoji/src/emoji-render.spec.ts
@@ -1,0 +1,38 @@
+import { defaultValueCtx, Editor, editorViewCtx } from '@milkdown/core'
+import { commonmark } from '@milkdown/preset-commonmark'
+import '@testing-library/jest-dom/vitest'
+import { test, expect } from 'vitest'
+
+import { emoji } from '.'
+
+test('show normal emoji', async () => {
+  const editor = Editor.make()
+    .config((ctx) => {
+      ctx.set(defaultValueCtx, 'Emoji :+1:')
+    })
+    .use(commonmark)
+    .use(emoji)
+
+  await editor.create()
+
+  const view = editor.ctx.get(editorViewCtx)
+  expect(view.dom.querySelector('[data-type="emoji"]')).toBeInTheDocument()
+})
+
+test('show emoji not in twemoji', async () => {
+  const editor = Editor.make()
+    .config((ctx) => {
+      ctx.set(
+        defaultValueCtx,
+        "HTML entities should render as symbols (™, ©, etc.) regardless of the emoji plugin's presence."
+      )
+    })
+    .use(commonmark)
+    .use(emoji)
+
+  await editor.create()
+
+  const view = editor.ctx.get(editorViewCtx)
+  // ™ and ©
+  expect(view.dom.querySelectorAll('[data-type="emoji"]')).toHaveLength(2)
+})

--- a/packages/plugins/plugin-emoji/src/index.ts
+++ b/packages/plugins/plugin-emoji/src/index.ts
@@ -48,6 +48,7 @@ export const emojiSchema = $nodeSchema('emoji', (ctx) => ({
 
     const firstChild = tmp.firstChild
     if (!firstChild) {
+      console.warn('Milkdown emoji plugin: emoji is not valid')
       return ['span', { ...attrs.container, 'data-type': 'emoji' }, tmp]
     }
 

--- a/packages/plugins/plugin-emoji/src/index.ts
+++ b/packages/plugins/plugin-emoji/src/index.ts
@@ -5,6 +5,7 @@ import type { RemarkEmojiOptions } from 'remark-emoji'
 import { expectDomTypeError } from '@milkdown/exception'
 import { InputRule } from '@milkdown/prose/inputrules'
 import { $inputRule, $nodeAttr, $nodeSchema, $remark } from '@milkdown/utils'
+import DOMPurify from 'dompurify'
 import { get } from 'node-emoji'
 import remarkEmoji from 'remark-emoji'
 
@@ -43,8 +44,14 @@ export const emojiSchema = $nodeSchema('emoji', (ctx) => ({
   toDOM: (node) => {
     const attrs = ctx.get(emojiAttr.key)(node)
     const tmp = document.createElement('span')
-    tmp.innerHTML = node.attrs.html
-    const dom = tmp.firstElementChild?.cloneNode()
+    tmp.innerHTML = DOMPurify.sanitize(node.attrs.html)
+
+    const firstChild = tmp.firstChild
+    if (!firstChild) {
+      return ['span', { ...attrs.container, 'data-type': 'emoji' }, tmp]
+    }
+
+    const dom = firstChild.cloneNode()
     tmp.remove()
     if (dom && dom instanceof HTMLElement)
       Object.entries<string>(attrs.img).forEach(([key, value]) =>

--- a/packages/plugins/plugin-emoji/vitest.config.ts
+++ b/packages/plugins/plugin-emoji/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,6 +713,9 @@ importers:
       '@milkdown/utils':
         specifier: workspace:*
         version: link:../../utils
+      dompurify:
+        specifier: ^3.2.5
+        version: 3.2.6
       emoji-regex:
         specifier: ^10.0.0
         version: 10.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,10 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+    devDependencies:
+      '@milkdown/preset-commonmark':
+        specifier: workspace:*
+        version: link:../preset-commonmark
 
   packages/plugins/plugin-history:
     dependencies:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Editor crash if the provided emoji is not available in twemoji

✅ Closes: #1834

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Unit Test

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `main` <!-- branch-stack -->
  - \#1999 :point\_left:
