### PR TITLE
fix: emphasis matching on intra-word underscores

### DIFF
--- a/e2e/tests/input/italic.spec.ts
+++ b/e2e/tests/input/italic.spec.ts
@@ -24,6 +24,15 @@ test('italic with *', async ({ page }) => {
   expect(markdown).toBe('The lunatic is *on the grass*\n')
 })
 
+test('italics with intra-word _', async ({ page }) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await page.keyboard.type('the_lunatic_is_on_the_grass')
+  await expect(editor.locator('em')).toHaveCount(0)
+  const markdown = await getMarkdown(page)
+  expect(markdown).toBe('the\\_lunatic\\_is\\_on\\_the\\_grass\n')
+})
+
 test('italic with a single character', async ({ page }) => {
   const editor = page.locator('.editor')
   await focusEditor(page)

--- a/packages/plugins/preset-commonmark/src/mark/emphasis.ts
+++ b/packages/plugins/preset-commonmark/src/mark/emphasis.ts
@@ -91,7 +91,7 @@ withMeta(emphasisStarInputRule, {
 
 /// Input rule for use `_` to create emphasis mark.
 export const emphasisUnderscoreInputRule = $inputRule((ctx) => {
-  return markRule(/(?:^|[^_])_([^_]+)_$/, emphasisSchema.type(ctx), {
+  return markRule(/\b_(?![_\s])(.*?[^_\s])_\b/, emphasisSchema.type(ctx), {
     getAttr: () => ({
       marker: '_',
     }),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary
Fixes an issue where the emphasis input rule allows for matching to occur on intra-word underscores.

*Before*
```
the_lunatic_is_on_the_grass => Match
```

*After*
```
the_lunatic_is_on_the_grass => No match
```

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

See: https://spec.commonmark.org/0.31.2/#example-374

## How did you test this change?
- Manual 
- Included e2e test

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!-- branch-stack -->

Before:

https://github.com/user-attachments/assets/c87c570c-10f4-46ed-b4f3-e679ebfd2d40

After:

https://github.com/user-attachments/assets/145e7a5d-7d7b-4e2c-9ef8-3d4215cc6792


