### PR TITLE
fix: strikethrough matching on intra-word tilde

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview",
     "serve": "serve lib --listen 4173 -L",
     "test": "playwright test",
+    "test:debug": "playwright test --ui",
     "test:install": "playwright install --with-deps"
   },
   "dependencies": {

--- a/e2e/tests/input/strike-through.spec.ts
+++ b/e2e/tests/input/strike-through.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-import { focusEditor } from '../misc'
+import { focusEditor, getMarkdown } from '../misc'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/preset-gfm/')
@@ -11,4 +11,15 @@ test('strike through', async ({ page }) => {
   await focusEditor(page)
   await page.keyboard.type('The lunatic is ~~on the grass~~')
   await expect(editor.locator('del')).toHaveText('on the grass')
+})
+
+test('intra-word strike through', async ({ page }) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await page.keyboard.type('C:/the/~lunatic~/is/on/the/grass')
+  await expect(editor.locator('del')).toHaveCount(0)
+
+  const markdown = await getMarkdown(page)
+
+  expect(markdown).toBe('C:/the/\\~lunatic\\~/is/on/the/grass\n')
 })

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:lint": "oxlint -c .oxlintrc.json",
     "test:eslint": "eslint . --cache",
     "test:e2e": "pnpm --filter=@milkdown/e2e test",
+    "test:e2e:debug": "pnpm --filter=@milkdown/e2e run test:debug",
     "test:e2e:build": "pnpm --filter=@milkdown/e2e run build",
     "format": "lint-staged",
     "fix": "prettier . --write",

--- a/packages/plugins/preset-gfm/src/mark/strike-through.ts
+++ b/packages/plugins/preset-gfm/src/mark/strike-through.ts
@@ -70,7 +70,10 @@ withMeta(toggleStrikethroughCommand, {
 
 /// Input rule to create the strikethrough mark.
 export const strikethroughInputRule = $inputRule((ctx) => {
-  return markRule(/~([^~]+)~$/, strikethroughSchema.type(ctx))
+  return markRule(
+    /(?<![\w:/])(~{1,2})(.+?)\1(?!\w|\/)/,
+    strikethroughSchema.type(ctx)
+  )
 })
 
 withMeta(strikethroughInputRule, {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary
Fixes an issue where the strikethrough input rule matches intra word, making it impossible to type file paths: 

```
C:/test/~apple~/
```

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
- e2e test
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<img width="1647" height="351" alt="image" src="https://github.com/user-attachments/assets/cb1ccd65-f7c1-49c0-91db-1eda88230008" />
<!-- branch-stack -->
