### PR TITLE
fix: 🐛 improve input rule of strong mark

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -32,7 +32,7 @@
     "@milkdown/prose": "workspace:*",
     "@milkdown/theme-nord": "workspace:*",
     "@milkdown/utils": "workspace:*",
-    "@playwright/test": "^1.53.0",
+    "@playwright/test": "^1.54.1",
     "@types/node": "^22.0.0",
     "katex": "^0.16.0",
     "serve": "^14.2.3",

--- a/e2e/tests/input/bold.spec.ts
+++ b/e2e/tests/input/bold.spec.ts
@@ -32,3 +32,29 @@ test('bold with a single character', async ({ page }) => {
   const markdown = await getMarkdown(page)
   expect(markdown).toBe('The lunatic is **o**n the grass\n')
 })
+
+test('should not parse when preceded by word and followed by quote', async ({
+  page,
+}) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await page.keyboard.type('a**"foo"**')
+
+  // Expect no <strong> element created.
+  await expect(editor.locator('strong')).toHaveCount(0)
+
+  const markdown = await getMarkdown(page)
+  // The markdown should remain unchanged (with newline appended by Milkdown serializer).
+  expect(markdown).toBe('a\\*\\*"foo"\\*\\*\n')
+})
+
+test('should not parse double underscore inside word', async ({ page }) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await page.keyboard.type('foo__bar__baz')
+
+  await expect(editor.locator('strong')).toHaveCount(0)
+
+  const markdown = await getMarkdown(page)
+  expect(markdown).toBe('foo\\_\\_bar\\_\\_baz\n')
+})

--- a/packages/plugins/preset-commonmark/src/mark/strong.ts
+++ b/packages/plugins/preset-commonmark/src/mark/strong.ts
@@ -86,13 +86,20 @@ withMeta(toggleStrongCommand, {
 
 /// A input rule that will capture the strong mark.
 export const strongInputRule = $inputRule((ctx) => {
-  return markRule(/(?:\*\*|__)([^*_]+)(?:\*\*|__)$/, strongSchema.type(ctx), {
-    getAttr: (match) => {
-      return {
-        marker: match[0].startsWith('*') ? '*' : '_',
-      }
-    },
-  })
+  // Avoid matching when the opening delimiter is directly adjacent to alphanumeric characters,
+  // colon or slash (to prevent matches inside file paths, URLs, or intra-word like `a**b**c`).
+  // Also ensure the closing delimiter is not followed by such characters (mirrors strike-through rule).
+  return markRule(
+    /(?<![\w:/])(?:\*\*|__)([^*_]+?)(?:\*\*|__)(?![\w/])$/,
+    strongSchema.type(ctx),
+    {
+      getAttr: (match) => {
+        return {
+          marker: match[0].startsWith('*') ? '*' : '_',
+        }
+      },
+    }
+  )
 })
 
 withMeta(strongInputRule, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/utils
       '@playwright/test':
-        specifier: ^1.53.0
+        specifier: ^1.54.1
         version: 1.54.1
       '@types/node':
         specifier: ^22.0.0


### PR DESCRIPTION
✅ Closes: #2032

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Improve strong inputrule to match cases like: `a**"foo"**`

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `main` <!-- branch-stack -->
  - \#2036 :point\_left:
