### PR TITLE
fix: 🐛 image proxy time sequence

### DIFF
--- a/packages/components/src/image-block/view/index.ts
+++ b/packages/components/src/image-block/view/index.ts
@@ -43,7 +43,6 @@ export const imageBlockView = $view(
       })
       const dom = document.createElement('div')
       dom.className = 'milkdown-image-block'
-      app.mount(dom)
       const disposeSelectedWatcher = watchEffect(() => {
         const isSelected = selected.value
         if (isSelected) {
@@ -75,6 +74,8 @@ export const imageBlockView = $view(
       }
 
       bindAttrs(initialNode)
+      app.mount(dom)
+
       return {
         dom,
         update: (updatedNode) => {

--- a/packages/components/src/image-inline/view.ts
+++ b/packages/components/src/image-inline/view.ts
@@ -44,7 +44,6 @@ export const inlineImageView = $view(
       })
       const dom = document.createElement('span')
       dom.className = 'milkdown-image-inline'
-      app.mount(dom)
       const disposeSelectedWatcher = watchEffect(() => {
         const isSelected = selected.value
         if (isSelected) {
@@ -73,6 +72,8 @@ export const inlineImageView = $view(
         title.value = node.attrs.title
       }
       bindAttrs(initialNode)
+      app.mount(dom)
+
       return {
         dom,
         update: (updatedNode) => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Should not load image before setup the proxy.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Manually.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `main` <!-- branch-stack -->
  - \#2110 :point\_left:
