### PR TITLE
fix: clipboard - clamp slice on paste to keep table header

### DIFF
--- a/.changeset/great-buckets-remember.md
+++ b/.changeset/great-buckets-remember.md
@@ -1,5 +1,5 @@
 ---
-"@milkdown/plugin-clipboard": patch
+'@milkdown/plugin-clipboard': patch
 ---
 
 fix: clipboard - clamp slice on paste to keep table header

--- a/.changeset/great-buckets-remember.md
+++ b/.changeset/great-buckets-remember.md
@@ -1,0 +1,5 @@
+---
+"@milkdown/plugin-clipboard": patch
+---
+
+fix: clipboard - clamp slice on paste to keep table header


### PR DESCRIPTION
<!-- Pull Request Draft for fix/clipboard-slice-clamp -->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

When the clipboard plugin parsed plain-text content it preserved non-zero `openStart` / `openEnd` values on the resulting ProseMirror slice. That left the fragment “open” at both ends, so pasting into an editor merged the pasted block with the surrounding paragraph. In practice the first row of an ASCII table was lifted out into the host paragraph (e.g. `Table Headings` rendered above the grid) and later columns shifted left. Clamping the slice to zero open depth keeps the pasted fragment self-contained, so structural wrappers such as table headers, lists, and other block boundaries stay intact for any plugin that consumes structured plain-text pastes.

## How did you test this change?

- `pnpm test` (`pnpm test:lint` + `pnpm test:unit`)
- While developing a grid-tables plugin I reproduced the bug with the following ASCII example:

  ```text
  +-------------------+------+
  | Table Headings    | Here |
  +===================+======+
  | cell              | more |
  +-------------------+------+
  ```

  Before this fix the clipboard produced an open slice, so pasting yielded:

  ```text
  Table Headings
  +------+------+
  | Here |      |
  +======+======+
  | cell | more |
  +------+------+
  ```

  After clamping, the paste stays self-contained and the grid-table parser receives the intact ASCII block shown in the input snippet.

<!-- branch-stack -->
