### PR TITLE
fix(image-block): preserve real alt-text instead of overwriting with …

### DIFF
--- a/.changeset/image-block-preserve-alt-text.md
+++ b/.changeset/image-block-preserve-alt-text.md
@@ -1,4 +1,5 @@
 ---
-"@milkdown/components": patch
+'@milkdown/components': patch
 ---
+
 Fix image-block plugin overwriting existing alt-text with resize ratio on every round-trip.

--- a/.changeset/image-block-preserve-alt-text.md
+++ b/.changeset/image-block-preserve-alt-text.md
@@ -1,0 +1,4 @@
+---
+"@milkdown/components": patch
+---
+Fix image-block plugin overwriting existing alt-text with resize ratio on every round-trip.

--- a/packages/components/src/image-block/schema.ts
+++ b/packages/components/src/image-block/schema.ts
@@ -19,6 +19,7 @@ export const imageBlockSchema = $nodeSchema('image-block', () => {
       src: { default: '', validate: 'string' },
       caption: { default: '', validate: 'string' },
       ratio: { default: 1, validate: 'number' },
+      alt: { default: '', validate: 'string' },
     },
     parseDOM: [
       {
@@ -30,6 +31,7 @@ export const imageBlockSchema = $nodeSchema('image-block', () => {
             src: dom.getAttribute('src') || '',
             caption: dom.getAttribute('caption') || '',
             ratio: Number(dom.getAttribute('ratio') ?? 1),
+            alt: dom.getAttribute('alt') || '',
           }
         },
       },
@@ -40,24 +42,39 @@ export const imageBlockSchema = $nodeSchema('image-block', () => {
       runner: (state, node, type) => {
         const src = node.url as string
         const caption = node.title as string
-        let ratio = Number((node.alt as string) || 1)
+        const rawAlt = (node.alt as string) || ''
+
+        // Parse ratio from alt-text for backward compatibility
+        let ratio = Number(rawAlt || 1)
         if (Number.isNaN(ratio) || ratio === 0) ratio = 1
 
         state.addNode(type, {
           src,
           caption,
           ratio,
+          alt: rawAlt,
         })
       },
     },
     toMarkdown: {
       match: (node) => node.type.name === 'image-block',
       runner: (state, node) => {
+        const alt = node.attrs.alt as string
+        const ratio = node.attrs.ratio as number
+
+        // Preserve real alt-text if it exists and is non-numeric.
+        // If alt-text is numeric or empty, fall back to ratio (backward compatible).
+        const isNumericAlt = alt !== '' && !Number.isNaN(Number(alt))
+        const altText =
+          alt !== '' && !isNumericAlt
+            ? alt
+            : `${Number.parseFloat(String(ratio)).toFixed(2)}`
+
         state.openNode('paragraph')
         state.addNode('image', undefined, undefined, {
           title: node.attrs.caption,
           url: node.attrs.src,
-          alt: `${Number.parseFloat(node.attrs.ratio).toFixed(2)}`,
+          alt: altText,
         })
         state.closeNode()
       },


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct
## Summary
The `image-block` plugin overwrites existing Markdown alt-text with the resize ratio on every round-trip. `![screenshot of dashboard](url)` silently becomes `![1.00](url)`, destroying accessibility information.
Root cause: `parseMarkdown` casts alt-text to a number (`Number(node.alt || 1)`), discarding non-numeric values. `toMarkdown` then writes `ratio.toFixed(2)` as alt-text unconditionally.
**Fix:** Add a separate `alt` attribute to the ProseMirror node schema that stores the original alt-text alongside the existing `ratio` attribute.
- **parseMarkdown:** preserves the raw alt-text in the new `alt` attr while still parsing the ratio for backward compatibility
- **toMarkdown:** emits the real alt-text if it's non-numeric; falls back to `ratio.toFixed(2)` for numeric/empty alt-text (no behavior change for existing content)
### Known limitation: resize ratio not persisted for images with alt-text
Since Markdown only has a single alt-text field, there is no standard way to store both real alt-text and the resize ratio. This fix prioritizes alt-text preservation over ratio persistence: if an image has non-numeric alt-text, the ratio is applied visually in the editor but lost on the next round-trip (serialized back to ratio 1).
This is the same fundamental conflict as before — just inverted. Before this fix, alt-text was *always* destroyed, even when nobody resized. After this fix, the ratio is lost only for images that have real alt-text *and* were resized, which is a much narrower edge case.
A proper solution would require storing the ratio outside the alt-text field (e.g. via a Markdown directive, HTML attribute, or custom syntax like `![alt|0.75](url)`). We consider that a separate concern and a larger design decision for the Milkdown maintainers.
## How did you test this change?
We've been running this fix in production via a `ctx.update(imageBlockSchema.key, ...)` override that wraps the original schema factory for several months. The override is identical to the changes in this PR. Verified with:
1. **Round-trip preservation:** `![screenshot of dashboard](url)` survives WYSIWYG edit → serialize → re-parse without losing the alt-text
2. **Backward compatibility:** Images with empty alt-text still produce `![1.00](url)` — no behavior change
3. **Numeric alt-text:** `![0.75](url)` is treated as ratio 0.75 AND preserved as alt-text `"0.75"` — round-trip safe
4. **Resize functionality:** The ratio slider still works correctly; resizing updates `ratio` without affecting `alt`