### PR TITLE
fix(inline-latex): should not show edit tooltip for readonly mode

### DIFF
--- a/packages/crepe/src/feature/latex/inline-tooltip/inline-tooltip.spec.ts
+++ b/packages/crepe/src/feature/latex/inline-tooltip/inline-tooltip.spec.ts
@@ -1,0 +1,81 @@
+import '@testing-library/jest-dom/vitest'
+import type { Node } from '@milkdown/kit/prose/model'
+
+import { editorViewCtx } from '@milkdown/kit/core'
+import { NodeSelection } from '@milkdown/kit/prose/state'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { Crepe } from '../../../core'
+import { mathInlineId } from '../inline-latex'
+
+function waitForAsync() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0))
+}
+
+function findMathInlinePos(doc: Node) {
+  let pos: number | undefined
+  doc.descendants((node, currentPos) => {
+    if (node.type.name === mathInlineId) {
+      pos = currentPos
+      return false
+    }
+    return true
+  })
+  return pos
+}
+
+describe('latex inline tooltip', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  test('should show in edit mode', async () => {
+    const crepe = new Crepe({
+      defaultValue: '$x$',
+    })
+
+    await crepe.create()
+
+    const view = crepe.editor.ctx.get(editorViewCtx)
+    const pos = findMathInlinePos(view.state.doc)
+    expect(pos).toBeTypeOf('number')
+
+    view.dispatch(
+      view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos!))
+    )
+    await waitForAsync()
+
+    expect(view.state.selection).toBeInstanceOf(NodeSelection)
+    expect((view.state.selection as NodeSelection).node.type.name).toBe(
+      mathInlineId
+    )
+    expect(
+      document.body.querySelector('.milkdown-latex-inline-edit')
+    ).toHaveAttribute('data-show', 'true')
+  })
+
+  test('should not show in readonly editor', async () => {
+    const crepe = new Crepe({
+      defaultValue: '$x$',
+    }).setReadonly(true)
+
+    await crepe.create()
+
+    const view = crepe.editor.ctx.get(editorViewCtx)
+    const pos = findMathInlinePos(view.state.doc)
+    expect(pos).toBeTypeOf('number')
+
+    view.dispatch(
+      view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos!))
+    )
+    await waitForAsync()
+
+    expect(view.state.selection).toBeInstanceOf(NodeSelection)
+    expect((view.state.selection as NodeSelection).node.type.name).toBe(
+      mathInlineId
+    )
+    expect(
+      document.body.querySelector('.milkdown-latex-inline-edit')
+    ).toHaveAttribute('data-show', 'false')
+  })
+})

--- a/packages/crepe/src/feature/latex/inline-tooltip/view.ts
+++ b/packages/crepe/src/feature/latex/inline-tooltip/view.ts
@@ -58,6 +58,8 @@ export class LatexInlineTooltip implements PluginView {
 
   #shouldShow = (view: EditorView) => {
     const shouldShow = () => {
+      if (!view.editable) return false
+
       const { selection, schema } = view.state
       if (selection.empty) return false
       if (!(selection instanceof NodeSelection)) return false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [X] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [X] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Fix inline-latex is still editable when readonly

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Test cases are added

<!-- branch-stack -->
