### PR TITLE
fix(crepe): preserve marks in AI selection for single-paragraph ranges

### DIFF
--- a/packages/crepe/src/feature/ai/ai.spec.ts
+++ b/packages/crepe/src/feature/ai/ai.spec.ts
@@ -318,6 +318,58 @@ describe('AI onError', () => {
   })
 })
 
+describe('AI prompt context selection', () => {
+  // Regression: inline-only selections (e.g. selecting "bold" inside a
+  // single paragraph) used to fall through to `doc.textBetween` because
+  // `topNodeType.createAndFill` rejects inline content. That stripped
+  // marks before the selection ever reached the provider, so a single-
+  // paragraph translate would lose bold/italic/link formatting.
+  test('inline-only selection preserves marks in promptContext.selection', async () => {
+    const provider = vi.fn(async function* () {
+      yield 'unused'
+    })
+    const crepe = new Crepe({
+      defaultValue: '**bold** and *italic* text',
+      features: { [CrepeFeature.AI]: true },
+      featureConfigs: {
+        [CrepeFeature.AI]: { provider, diffReviewOnEnd: false },
+      },
+    })
+    await crepe.create()
+    try {
+      crepe.editor.action((ctx) => {
+        const view = ctx.get(editorViewCtx)
+        const doc = view.state.doc
+        let from = -1
+        let to = -1
+        doc.descendants((node, pos) => {
+          if (node.type.name === 'paragraph') {
+            from = pos + 1
+            to = pos + 1 + node.content.size
+            return false
+          }
+          return true
+        })
+        view.dispatch(
+          view.state.tr.setSelection(TextSelection.create(doc, from, to))
+        )
+      })
+
+      crepe.editor.action(callCommand(runAICmd.key, { instruction: 'go' }))
+      await waitForAsync()
+
+      expect(provider).toHaveBeenCalled()
+      const [promptContext] = provider.mock.calls[0] as unknown as [
+        AIPromptContext,
+      ]
+      expect(promptContext.selection).toContain('**bold**')
+      expect(promptContext.selection).toContain('*italic*')
+    } finally {
+      await crepe.destroy()
+    }
+  })
+})
+
 describe('AI session retry metadata', () => {
   async function makeCrepe() {
     const crepe = new Crepe({

--- a/packages/crepe/src/feature/ai/context.ts
+++ b/packages/crepe/src/feature/ai/context.ts
@@ -22,16 +22,23 @@ export function defaultBuildContext(
   // For block-level selections (whole paragraphs, list items, etc.)
   // we wrap the slice content in a doc node and serialize it. For
   // inline-only selections (text inside a single paragraph),
-  // createAndFill returns null because inline content isn't valid as
-  // direct doc children — fall back to plain text via textBetween.
+  // createAndFill on the doc type returns null because inline content
+  // isn't valid as direct doc children — wrap it in a paragraph first
+  // so marks (bold, italic, links) survive into the markdown output.
   let selection = ''
   if (!state.selection.empty) {
     const { from, to } = state.selection
     const slice = state.doc.slice(from, to)
-    const wrapper = state.doc.type.schema.topNodeType.createAndFill(
-      null,
-      slice.content
-    )
+    const { schema } = state.doc.type
+    let wrapper = schema.topNodeType.createAndFill(null, slice.content)
+    if (!wrapper) {
+      const paragraph = schema.nodes.paragraph?.createAndFill(
+        null,
+        slice.content
+      )
+      if (paragraph)
+        wrapper = schema.topNodeType.createAndFill(null, paragraph)
+    }
     selection = wrapper ? serializer(wrapper) : state.doc.textBetween(from, to)
   }
 

--- a/packages/crepe/src/feature/ai/context.ts
+++ b/packages/crepe/src/feature/ai/context.ts
@@ -36,8 +36,7 @@ export function defaultBuildContext(
         null,
         slice.content
       )
-      if (paragraph)
-        wrapper = schema.topNodeType.createAndFill(null, paragraph)
+      if (paragraph) wrapper = schema.topNodeType.createAndFill(null, paragraph)
     }
     selection = wrapper ? serializer(wrapper) : state.doc.textBetween(from, to)
   }


### PR DESCRIPTION
## Summary
- When the user selected text inside a single paragraph and ran an AI action (e.g. Translate), the selection passed to the provider lost its bold / italic / link marks. Multi-block selections were unaffected.
- Root cause: in `defaultBuildContext`, `schema.topNodeType.createAndFill(null, slice.content)` returns `null` for inline-only slices (doc nodes don't accept inline content as direct children), so the code fell through to `doc.textBetween`, which strips marks.
- Fix: when the doc-level wrap fails, wrap the slice content in a `paragraph` node first, then re-wrap in the doc node so the markdown serializer can emit `**bold**`, `*italic*`, links, etc.

## Test plan
- [x] Added a regression test in `packages/crepe/src/feature/ai/ai.spec.ts` (`AI prompt context selection`) that programmatically selects an inline range covering `**bold** and *italic* text` and asserts both `**bold**` and `*italic*` appear in `promptContext.selection`.
- [x] `pnpm vitest run packages/crepe/src/feature/ai/ai.spec.ts` — 19/19 passing.
- [x] `pnpm test:lint` — 0 warnings, 0 errors.