### PR TITLE
chore: config renovate to pin github actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":preserveSemverRanges", "group:all", "helpers:pinGitHubActionDigestsToSemver"],
+  "extends": [
+    "config:recommended",
+    ":preserveSemverRanges",
+    "group:all",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
   "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":preserveSemverRanges", "group:all"],
+  "extends": ["config:recommended", ":preserveSemverRanges", "group:all", "helpers:pinGitHubActionDigestsToSemver"],
   "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CI: true
-
 jobs:
   install-deps:
     runs-on: ubuntu-latest

--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-env:
-  CI: true
-
 jobs:
   fix:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-env:
-  CI: true
-
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Update renovate config to pin github actions to digests. Renovate will send pull requests including changes like below:

```diff
- uses: actions/checkout@v6
+ uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```

Part of supply chain hardening in response to the [TanStack/Mini Shai-Hulud compromise](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack).

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!-- branch-stack -->

Let's merged and ask renovate to test the new config.
