### PR TITLE
fix(components): lazy-init SVG sanitizer to keep preview-panel SSR-safe

### DIFF
--- a/packages/components/src/code-block/view/components/preview-panel.tsx
+++ b/packages/components/src/code-block/view/components/preview-panel.tsx
@@ -39,7 +39,13 @@ function createSvgAwareSanitizer() {
   return (dirty: string | Node) => purify.sanitize(dirty, config)
 }
 
-const sanitizeSvg = createSvgAwareSanitizer()
+// Lazily initialize the sanitizer so that importing this module under SSR
+// (where `DOMPurify()` returns a stub without `.addHook`) does not throw.
+let cachedSanitizer: ReturnType<typeof createSvgAwareSanitizer> | undefined
+function sanitizeSvg(dirty: string | Node) {
+  cachedSanitizer ??= createSvgAwareSanitizer()
+  return cachedSanitizer(dirty)
+}
 
 type PreviewPanelProps = Pick<
   CodeBlockProps,


### PR DESCRIPTION
## Summary

Calling `createSvgAwareSanitizer()` at the **module top-level** of `preview-panel.tsx` breaks any server-side import of the module:

- On Node, `DOMPurify` (the default export) is a factory. Calling `DOMPurify()` with no `window` returns a stub that has a no-op `.sanitize` but **no `.addHook`**.
- So the moment the module is loaded under SSR, `purify.addHook('uponSanitizeElement', ...)` throws:

```
TypeError: purify.addHook is not a function
```

This bites any downstream consumer that statically imports `@milkdown/crepe` and runs `next build` (Next.js page-data collection step). E.g. the Milkdown website was failing CI with:

```
TypeError: purify.addHook is not a function
Failed to collect page data for /docs/[scope]/[id]
```
(see https://github.com/Milkdown/website/actions/runs/25771553209)

## Fix

Defer construction of the sanitizer until the first call to `sanitizeSvg(...)`. The only caller is inside `watchEffect` in the `setup()` of the `PreviewPanel` Vue component, which only runs in the browser — so under SSR the module just loads, no `DOMPurify()` call, no throw. In the browser the behavior is unchanged: the sanitizer is built lazily on first preview render and then cached for subsequent calls.

## Repro (without the fix)

```js
const DOMPurify = require('dompurify');
const purify = DOMPurify();
purify.addHook('uponSanitizeElement', () => {});
// → TypeError: purify.addHook is not a function
```

## Test plan

- [x] `pnpm test:lint` passes
- [x] `pnpm build:tsc --force` passes
- [x] Verified Node repro above throws on the unfixed code path
- [x] Verify Milkdown website `next build` succeeds against this branch
