### PR TITLE
Fix extra spacing and incorrect vertical alignment.

### DIFF
--- a/packages/crepe/src/theme/common/latex.css
+++ b/packages/crepe/src/theme/common/latex.css
@@ -2,9 +2,7 @@
 
 .milkdown {
   span[data-type='math_inline'] {
-    padding: 0 4px;
     display: inline-block;
-    vertical-align: bottom;
     color: var(--crepe-color-primary);
   }
 


### PR DESCRIPTION
For math expression like $\ell_2$-norm. There should not be spacing between the inline math and `-norm`. Also, you can see that the math symbol α is a little above the normal text. You can see it from the screenshot below. (Sorry for small text in the screenshot, but you can still see it by zooming in.) This is due to wrong css.

<img width="2559" height="1078" alt="image" src="https://github.com/user-attachments/assets/8c266057-7e0e-459f-a037-44b243ab321d" />

<img width="2432" height="806" alt="image" src="https://github.com/user-attachments/assets/1f11711b-61c5-4821-aff6-73a33af55ee6" />
<img width="2070" height="755" alt="image" src="https://github.com/user-attachments/assets/db93a7a4-5df7-467e-99ca-a92473624801" />
This PR modifies latex.css to remove this two css rule.