### PR TITLE
fix(crepe): avoid importing katex in toolbar when latex feature is disabled

### DIFF
--- a/packages/crepe/src/feature/latex/constants.ts
+++ b/packages/crepe/src/feature/latex/constants.ts
@@ -1,0 +1,3 @@
+export const mathInlineId = 'math_inline'
+
+export const toggleLatexCommandName = 'ToggleLatex'

--- a/packages/crepe/src/feature/latex/inline-latex.ts
+++ b/packages/crepe/src/feature/latex/inline-latex.ts
@@ -1,7 +1,9 @@
 import { $nodeSchema } from '@milkdown/kit/utils'
 import katex from 'katex'
 
-export const mathInlineId = 'math_inline'
+import { mathInlineId } from './constants'
+
+export { mathInlineId }
 
 /// Schema for inline math node.
 /// Add support for:

--- a/packages/crepe/src/feature/toolbar/config.ts
+++ b/packages/crepe/src/feature/toolbar/config.ts
@@ -1,7 +1,7 @@
 import type { Ctx } from '@milkdown/kit/ctx'
 
 import { toggleLinkCommand } from '@milkdown/kit/component/link-tooltip'
-import { commandsCtx, editorViewCtx } from '@milkdown/kit/core'
+import { commandsCtx, editorViewCtx, schemaCtx } from '@milkdown/kit/core'
 import {
   emphasisSchema,
   inlineCodeSchema,
@@ -34,8 +34,7 @@ import {
 import { GroupBuilder } from '../../utils/group-builder'
 import { aiProviderConfig } from '../ai/commands'
 import { aiInstructionTooltipAPI } from '../ai/instruction-tooltip'
-import { toggleLatexCommand } from '../latex/command'
-import { mathInlineSchema } from '../latex/inline-latex'
+import { mathInlineId, toggleLatexCommandName } from '../latex/constants'
 
 export type ToolbarItem = {
   active: (ctx: Ctx) => boolean
@@ -110,14 +109,12 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
       icon: config?.latexIcon ?? functionsIcon,
       active: (ctx) => {
         const commands = ctx.get(commandsCtx)
-        return commands.call(
-          isNodeSelectedCommand.key,
-          mathInlineSchema.type(ctx)
-        )
+        const nodeType = ctx.get(schemaCtx).nodes[mathInlineId]
+        return commands.call(isNodeSelectedCommand.key, nodeType)
       },
       onRun: (ctx) => {
         const commands = ctx.get(commandsCtx)
-        commands.call(toggleLatexCommand.key)
+        commands.call(toggleLatexCommandName)
       },
     })
   }


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2368.

The toolbar feature's `config.ts` statically imported `toggleLatexCommand` from `../latex/command` and `mathInlineSchema` from `../latex/inline-latex`. Both of those modules pull in `katex` at the top level, so `katex` ended up in the bundle whenever the toolbar feature was used — even if the `latex` feature flag was off.

This PR removes those static imports:

- Adds a new leaf module `packages/crepe/src/feature/latex/constants.ts` exporting the `math_inline` node id and the `ToggleLatex` command name (no katex on this path).
- `toolbar/config.ts` now imports only those string constants and looks up the node type via `ctx.get(schemaCtx).nodes[mathInlineId]` and calls the command by string name through `commandsCtx`.

The result: when a consumer enables the toolbar feature but not the latex feature, katex is no longer reachable from the toolbar's import graph and gets tree-shaken out.

## How did you test this change?

- Built the crepe package (`pnpm --filter @milkdown/crepe run build`) successfully.
- Verified the toolbar's built bundle no longer contains `katex`:
  ```sh
  grep -n "katex\|import.*latex/\(inline-latex\|command\)" packages/crepe/lib/esm/feature/toolbar/index.js
  # (no matches)
  ```
- Ran `pnpm exec oxlint` on the changed directories — 0 warnings, 0 errors.
- The latex toolbar item still only renders when the `latex` feature flag is enabled, and behaves identically (active state uses the same `isNodeSelectedCommand` + `math_inline` node type; the click handler still triggers `ToggleLatex`).

<!-- branch-stack -->