### PR TITLE
fix: cancel pending listener debounce on editor destroy

### DIFF
--- a/packages/plugins/plugin-listener/src/index.ts
+++ b/packages/plugins/plugin-listener/src/index.ts
@@ -189,6 +189,7 @@ export const listener: MilkdownPlugin = (ctx) => {
       view: () => {
         return {
           destroy: () => {
+            debouncedHandler.cancel()
             listeners.destroy.forEach((fn) => fn(ctx))
           },
         }


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2356.

When a `markdownUpdated` listener is registered and the editor is destroyed within the 200ms debounce window after an edit, an uncaught `MilkdownError: Context "editorView" not found` is thrown.

The listener plugin schedules a debounced handler from `state.apply` that calls `serializer(doc)`. Several node serializers reach into `editorViewCtx` via `ctx.get(editorViewCtx)`. If the editor is disposed before the debounce fires, the cleanup in the `editorView` internal plugin removes `editorViewCtx` from the context — and 200ms later the timer fires against a torn-down ctx, blowing up inside the serializer.

The fix cancels any pending debounced invocation from the prosemirror plugin's `view.destroy` callback, which runs while the editor view (and ctx slots) are still valid. No pending listener will fire after destroy.

## How did you test this change?

- Built the package: `pnpm --filter @milkdown/plugin-listener build` — succeeds.
- Reviewed the destroy/teardown order in `packages/core/src/internal-plugin/editor-view.ts`: the prosemirror `view.destroy()` (which fires our plugin's destroy callback) runs *before* `ctx.remove(editorViewCtx)`, so `debouncedHandler.cancel()` runs at a point when the ctx is still intact, and once cancelled the timer can no longer fire after teardown.
- Reproduction in the issue (edit then immediately destroy the Crepe editor) can no longer trigger the deferred `serializer(doc)` call.