### PR TITLE
fix: link tooltip empty-selection insert and outside-click dismiss

### DIFF
--- a/packages/components/src/link-tooltip/edit/edit-view.ts
+++ b/packages/components/src/link-tooltip/edit/edit-view.ts
@@ -71,12 +71,32 @@ export class LinkEditTooltip implements PluginView {
   }
 
   #reset = () => {
+    this.#stopOutsideClickListener()
     this.#provider.hide()
     this.ctx.update(linkTooltipState.key, (state) => ({
       ...state,
       mode: 'preview' as const,
     }))
     this.#data = { ...defaultData }
+  }
+
+  #onOutsidePointerDown = (e: PointerEvent) => {
+    const target = e.target as Node | null
+    if (!target) return
+    if (this.#content.contains(target)) return
+    this.#reset()
+  }
+
+  #startOutsideClickListener = () => {
+    document.addEventListener('pointerdown', this.#onOutsidePointerDown, true)
+  }
+
+  #stopOutsideClickListener = () => {
+    document.removeEventListener(
+      'pointerdown',
+      this.#onOutsidePointerDown,
+      true
+    )
   }
 
   #confirmEdit = (href: string) => {
@@ -92,7 +112,17 @@ export class LinkEditTooltip implements PluginView {
     const tr = view.state.tr
     if (mark) tr.removeMark(from, to, mark)
 
-    tr.addMark(from, to, type.create({ href: link }))
+    if (from === to) {
+      if (!link) {
+        this.#reset()
+        return
+      }
+      const linkMark = type.create({ href: link })
+      tr.insertText(link, from)
+      tr.addMark(from, from + link.length, linkMark)
+    } else {
+      tr.addMark(from, to, type.create({ href: link }))
+    }
     view.dispatch(tr)
 
     this.#reset()
@@ -114,6 +144,7 @@ export class LinkEditTooltip implements PluginView {
       { getBoundingClientRect: () => posToDOMRect(view, from, to) },
       view
     )
+    this.#startOutsideClickListener()
     requestAnimationFrame(() => {
       this.#content.querySelector('input')?.focus()
     })
@@ -130,6 +161,7 @@ export class LinkEditTooltip implements PluginView {
   }
 
   destroy = () => {
+    this.#stopOutsideClickListener()
     this.#app.unmount()
     this.#provider.destroy()
     this.#content.remove()

--- a/packages/crepe/src/feature/link-tooltip/link-tooltip.spec.ts
+++ b/packages/crepe/src/feature/link-tooltip/link-tooltip.spec.ts
@@ -37,7 +37,6 @@ describe('link tooltip edit', () => {
     await crepe.create()
     await waitForAsync()
 
-    const view = crepe.editor.ctx.get(editorViewCtx)
     // Cursor between "h" and "ello" — empty selection.
     const cursorPos = 2
     crepe.editor.ctx.get(linkTooltipAPI.key).addLink(cursorPos, cursorPos)

--- a/packages/crepe/src/feature/link-tooltip/link-tooltip.spec.ts
+++ b/packages/crepe/src/feature/link-tooltip/link-tooltip.spec.ts
@@ -1,0 +1,133 @@
+import '@testing-library/jest-dom/vitest'
+import { linkTooltipAPI } from '@milkdown/kit/component/link-tooltip'
+import { editorViewCtx } from '@milkdown/kit/core'
+import { linkSchema } from '@milkdown/kit/preset/commonmark'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { Crepe } from '../../core'
+import { CrepeFeature } from '../index'
+
+function waitForAsync() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0))
+}
+
+function getEditTooltip() {
+  return document.body.querySelector<HTMLElement>('.milkdown-link-edit')
+}
+
+function createCrepe(defaultValue: string) {
+  // Disable Cursor feature: prosemirror-virtual-cursor uses Range.getClientRects
+  // which jsdom does not implement.
+  return new Crepe({
+    defaultValue,
+    features: {
+      [CrepeFeature.Cursor]: false,
+    },
+  })
+}
+
+describe('link tooltip edit', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  test('inserts URL as linked text when selection is empty', async () => {
+    const crepe = createCrepe('hello')
+
+    await crepe.create()
+    await waitForAsync()
+
+    const view = crepe.editor.ctx.get(editorViewCtx)
+    // Cursor between "h" and "ello" — empty selection.
+    const cursorPos = 2
+    crepe.editor.ctx.get(linkTooltipAPI.key).addLink(cursorPos, cursorPos)
+    await waitForAsync()
+
+    const tooltip = getEditTooltip()
+    expect(tooltip).toHaveAttribute('data-show', 'true')
+
+    const input = tooltip!.querySelector('input') as HTMLInputElement
+    input.value = 'https://example.com'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    )
+    await waitForAsync()
+
+    const linkType = linkSchema.type(crepe.editor.ctx)
+    const updated = crepe.editor.ctx.get(editorViewCtx).state.doc
+    let foundHref: string | null = null
+    let linkedText = ''
+    updated.descendants((node) => {
+      const linkMark = node.marks.find((m) => m.type === linkType)
+      if (linkMark) {
+        foundHref = linkMark.attrs.href
+        linkedText = node.text ?? ''
+      }
+      return true
+    })
+
+    expect(foundHref).toBe('https://example.com')
+    expect(linkedText).toBe('https://example.com')
+    expect(getEditTooltip()).toHaveAttribute('data-show', 'false')
+  })
+
+  test('does nothing when confirming an empty URL on empty selection', async () => {
+    const crepe = createCrepe('hello')
+
+    await crepe.create()
+    await waitForAsync()
+
+    const before = crepe.editor.ctx.get(editorViewCtx).state.doc.toJSON()
+    crepe.editor.ctx.get(linkTooltipAPI.key).addLink(2, 2)
+    await waitForAsync()
+
+    const input = getEditTooltip()!.querySelector('input') as HTMLInputElement
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    )
+    await waitForAsync()
+
+    const after = crepe.editor.ctx.get(editorViewCtx).state.doc.toJSON()
+    expect(after).toEqual(before)
+    expect(getEditTooltip()).toHaveAttribute('data-show', 'false')
+  })
+
+  test('closes the edit tooltip when clicking outside', async () => {
+    const crepe = createCrepe('hello world')
+
+    await crepe.create()
+    await waitForAsync()
+
+    crepe.editor.ctx.get(linkTooltipAPI.key).addLink(1, 6)
+    await waitForAsync()
+
+    expect(getEditTooltip()).toHaveAttribute('data-show', 'true')
+
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await waitForAsync()
+
+    expect(getEditTooltip()).toHaveAttribute('data-show', 'false')
+  })
+
+  test('keeps the edit tooltip open when clicking inside it', async () => {
+    const crepe = createCrepe('hello world')
+
+    await crepe.create()
+    await waitForAsync()
+
+    crepe.editor.ctx.get(linkTooltipAPI.key).addLink(1, 6)
+    await waitForAsync()
+
+    const tooltip = getEditTooltip()!
+    expect(tooltip).toHaveAttribute('data-show', 'true')
+
+    const input = tooltip.querySelector('input') as HTMLInputElement
+    input.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await waitForAsync()
+
+    expect(getEditTooltip()).toHaveAttribute('data-show', 'true')
+  })
+})


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Closes #2341.

The Crepe TopBar's link button is always reachable, including when the editor's selection is empty — but the link tooltip code was originally written assuming a non-empty selection coming from the floating Toolbar. That assumption left two reachable bugs:

1. **Empty-selection link insert was a no-op.** `LinkEditTooltip.#confirmEdit` called `tr.addMark(from, to, ...)` with `from === to`, and ProseMirror cannot add a mark to a zero-width range. Now, when the range is empty we insert the URL as text and apply the link mark over the inserted range (matching Google Docs / Notion). An empty URL on an empty selection resets without dispatching.
2. **Edit tooltip didn't dismiss on outside click.** It only closed on Escape or selection change. Added a capture-phase `document` `pointerdown` listener registered in `#enterEditMode` and removed in `#reset` / `destroy` — symmetrical to the TopBar heading dropdown's outside-click handler. Clicks inside `#content` are ignored so the input and confirm icon still work.

## How did you test this change?

Added `packages/crepe/src/feature/link-tooltip/link-tooltip.spec.ts` with four cases driving real DOM events through a Crepe instance:

- `inserts URL as linked text when selection is empty` — confirms the URL is inserted with the link mark, and the tooltip hides.
- `does nothing when confirming an empty URL on empty selection` — guards against `schema.text('')` throws and confirms the doc is unchanged.
- `closes the edit tooltip when clicking outside` — dispatches `pointerdown` on an element outside `#content` and asserts `data-show="false"`.
- `keeps the edit tooltip open when clicking inside it` — dispatches `pointerdown` on the input and asserts the tooltip stays open.

I verified the two load-bearing tests (#1 and #3) fail without the source fix and pass with it.

Local commands run:

- `pnpm test:lint` — 0 warnings / 0 errors on 684 files
- `pnpm test:unit` — 34 files / 242 tests pass (4 new)
- `pnpm build:tsc` — clean type build