### PR TITLE
fix: import Fragment in image-input to fix paste link error (#2325)

### DIFF
--- a/packages/components/src/__internal__/components/image-input.tsx
+++ b/packages/components/src/__internal__/components/image-input.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx'
 import { customAlphabet } from 'nanoid'
-import { defineComponent, ref, h, type Ref } from 'vue'
+import { defineComponent, ref, h, Fragment, type Ref } from 'vue'
 
 import { keepAlive } from '../keep-alive'
 import { Icon } from './icon'
 
-keepAlive(h)
+keepAlive(h, Fragment)
 
 const nanoid = customAlphabet('abcdefg', 8)
 


### PR DESCRIPTION
## Summary

- Fix `ReferenceError: Fragment is not defined` thrown when pasting/typing an image URL into the upload plugin's input (closes #2325).
- `image-input.tsx` renders a JSX fragment (`<>...</>`) in its preview/confirm branch but only imported `h` from `vue`. The package's tsconfig uses classic JSX (`jsxFactory: "h"`, `jsxFragmentFactory: "Fragment"`) with `jsx: "preserve"`, so esbuild emits a bare `Fragment` reference at bundle time. As soon as the link input had a value, the fragment branch rendered and threw.
- Imported `Fragment` and added it to the `keepAlive` call (matching the convention already used in `image-block.tsx` / `image-viewer.tsx`).

## Test plan

- [x] `pnpm --filter @milkdown/components build` — bundled `lib/image-block/index.js` now imports `Fragment` and the `h(Fragment, null, ...)` call site is reachable.
- [x] Manual: open the Crepe upload input and paste an image URL — no runtime error, preview + confirm render.

Note: a vitest regression test isn't useful here — vitest uses `@vitejs/plugin-vue-jsx` (automatic runtime), which compiles `<>` to a `_Fragment` import from `vue/jsx-runtime` and would mask the rollup/esbuild bundling bug.