### PR TITLE
fix: serialize marks spanning multiple nodes
  as one continuous span

### DIFF
--- a/packages/plugins/preset-commonmark/src/__test__/mark-roundtrip.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/mark-roundtrip.spec.ts
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom/vitest'
+import {
+  defaultValueCtx,
+  Editor,
+  editorViewCtx,
+  parserCtx,
+} from '@milkdown/core'
+import { getMarkdown } from '@milkdown/utils'
+import { describe, expect, it } from 'vitest'
+
+import { commonmark } from '..'
+
+async function createEditor(defaultValue: string) {
+  const editor = Editor.make()
+  editor.config((ctx) => {
+    ctx.set(defaultValueCtx, defaultValue)
+  })
+  editor.use(commonmark)
+  await editor.create()
+  return editor
+}
+
+async function roundTrip(markdown: string) {
+  const editor = await createEditor(markdown)
+  return editor.action(getMarkdown())
+}
+
+// https://github.com/Milkdown/milkdown/issues/2403
+// A mark spanning multiple text leaves (because a nested mark splits it)
+// must be serialized as one continuous span, not split into pieces.
+// Splitting is not only verbose: when the split lands next to punctuation,
+// remark-stringify has to escape the delimiters and the output gains
+// literal asterisks while losing the original formatting.
+describe('nested mark round-trip (#2403)', () => {
+  const cases = [
+    '**a *b* c**',
+    '**a *b*c**',
+    '**a, *b* c**',
+    '**a *b*, c**',
+    '**(better: *proportionate*), mostly-autonomous gate**',
+    '*a **b** c*',
+    '_a **b** c_',
+    '**a `code` b**',
+    '[a **b** c](https://example.com)',
+    '*a **b*** and `code`',
+  ]
+
+  cases.forEach((markdown) => {
+    it(`should round-trip ${JSON.stringify(markdown)}`, async () => {
+      const output = await roundTrip(markdown)
+      expect(output).toBe(`${markdown}\n`)
+    })
+  })
+
+  // The structural invariant behind the string checks above:
+  // parse(serialize(parse(md))) must equal parse(md).
+  // This tolerates cosmetic reflow but catches any corruption.
+  cases.forEach((markdown) => {
+    it(`should keep the document stable for ${JSON.stringify(markdown)}`, async () => {
+      const editor = await createEditor(markdown)
+      const doc = editor.ctx.get(editorViewCtx).state.doc
+      const output = editor.action(getMarkdown())
+      const parser = editor.ctx.get(parserCtx)
+      const reparsed = parser(output)
+      expect(reparsed.eq(doc), `serialized to ${JSON.stringify(output)}`).toBe(
+        true
+      )
+    })
+  })
+})

--- a/packages/transformer/src/serializer/state.spec.ts
+++ b/packages/transformer/src/serializer/state.spec.ts
@@ -1,32 +1,19 @@
-import type { Mark, Schema } from '@milkdown/prose/model'
+import type { Fragment, Mark, Node, Schema } from '@milkdown/prose/model'
 
 import { describe, expect, it } from 'vitest'
 
 import { SerializerState } from './state'
 
-const boldMark = {
-  isInSet: (arr: string[]) => arr.includes('bold'),
-  addToSet: (arr: string[]) => arr.concat('bold'),
-  type: {
-    removeFromSet: (arr: string[]) => arr.filter((x) => x !== 'bold'),
-  },
-} as unknown as Mark
+const createMockMark = (name: string, priority?: number) =>
+  ({
+    name,
+    eq: (other: { name: string }) => other.name === name,
+    type: { spec: { priority } },
+  }) as unknown as Mark
 
-const italicMark = {
-  isInSet: (arr: string[]) => arr.includes('italic'),
-  addToSet: (arr: string[]) => arr.concat('italic'),
-  type: {
-    removeFromSet: (arr: string[]) => arr.filter((x) => x !== 'italic'),
-  },
-} as unknown as Mark
-
-const inlineCodeMark = {
-  isInSet: (arr: string[]) => arr.includes('inlineCode'),
-  addToSet: (arr: string[]) => arr.concat('inlineCode'),
-  type: {
-    removeFromSet: (arr: string[]) => arr.filter((x) => x !== 'inlineCode'),
-  },
-} as unknown as Mark
+const boldMark = createMockMark('bold')
+const italicMark = createMockMark('italic')
+const inlineCodeMark = createMockMark('inlineCode', 100)
 
 const schema = {
   nodes: {
@@ -52,10 +39,67 @@ const schema = {
         },
       },
     },
+    text: {
+      spec: {
+        toMarkdown: {
+          match: (node: { type: string }) => node.type === 'text',
+          runner: (state: SerializerState, node: { value: string }) => {
+            state.addNode('text', undefined, node.value)
+          },
+        },
+      },
+    },
   },
-  marks: {},
-  text: (text: string, marks: string[]) => ({ text, marks, isText: true }),
+  marks: {
+    bold: {
+      spec: {
+        toMarkdown: {
+          match: (mark: { name: string }) => mark.name === 'bold',
+          runner: (state: SerializerState, mark: Mark) => {
+            state.withMark(mark, 'bold')
+          },
+        },
+      },
+    },
+    italic: {
+      spec: {
+        toMarkdown: {
+          match: (mark: { name: string }) => mark.name === 'italic',
+          runner: (state: SerializerState, mark: Mark) => {
+            state.withMark(mark, 'italic')
+          },
+        },
+      },
+    },
+    inlineCode: {
+      spec: {
+        toMarkdown: {
+          match: (mark: { name: string }) => mark.name === 'inlineCode',
+          runner: (state: SerializerState, mark: Mark, node: Node) => {
+            state.withMark(
+              mark,
+              'inlineCode',
+              (node as never as { value: string }).value
+            )
+            return true
+          },
+        },
+      },
+    },
+  },
 } as unknown as Schema
+
+const text = (value: string, marks: Mark[] = []) =>
+  ({ type: 'text', value, marks }) as unknown as Node
+
+const fragment = (...nodes: Node[]) =>
+  ({
+    size: nodes.length,
+    forEach: (fn: (node: Node, offset: number, index: number) => void) => {
+      nodes.forEach((node, index) => fn(node, 0, index))
+    },
+    maybeChild: (index: number) => nodes[index] ?? null,
+  }) as unknown as Fragment
 
 describe('serializer-state', () => {
   it('node', () => {
@@ -219,7 +263,7 @@ describe('serializer-state', () => {
     state.closeNode()
 
     // The bold wrapper around inlineCode should be preserved,
-    // not restructured by searchType
+    // not restructured by the merge.
     expect(state.top()).toMatchObject({
       type: 'doc',
       children: [
@@ -277,6 +321,160 @@ describe('serializer-state', () => {
                   children: [{ type: 'text', value: 'hello' }],
                 },
                 { type: 'text', value: 'world' },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps a mark open across nodes that share it', () => {
+    const state = new SerializerState(schema)
+
+    // **a *b* c** — the strong mark spans all three text nodes.
+    state.openNode('doc')
+    state.openNode('paragraph')
+    state.next(
+      fragment(
+        text('a ', [boldMark]),
+        text('b', [boldMark, italicMark]),
+        text(' c', [boldMark])
+      )
+    )
+    state.closeNode()
+
+    expect(state.top()).toMatchObject({
+      type: 'doc',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'bold',
+              isMark: true,
+              children: [
+                { type: 'text', value: 'a ' },
+                {
+                  type: 'italic',
+                  isMark: true,
+                  children: [{ type: 'text', value: 'b' }],
+                },
+                { type: 'text', value: ' c' },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('keeps continuing marks outside of newly opened marks', () => {
+    const state = new SerializerState(schema)
+
+    // *a **b** c* — the italic mark opens first and must stay the
+    // outer mark when bold opens on the second text node, even if the
+    // mark set of that node lists bold first.
+    state.openNode('doc')
+    state.openNode('paragraph')
+    state.next(
+      fragment(
+        text('a ', [italicMark]),
+        text('b', [boldMark, italicMark]),
+        text(' c', [italicMark])
+      )
+    )
+    state.closeNode()
+
+    expect(state.top()).toMatchObject({
+      type: 'doc',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'italic',
+              isMark: true,
+              children: [
+                { type: 'text', value: 'a ' },
+                {
+                  type: 'bold',
+                  isMark: true,
+                  children: [{ type: 'text', value: 'b' }],
+                },
+                { type: 'text', value: ' c' },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('closes value-based marks after the node that carries them', () => {
+    const state = new SerializerState(schema)
+
+    // **`code` b** — inlineCode holds its content as a value and must not
+    // stay open, while the bold mark spans both text nodes.
+    state.openNode('doc')
+    state.openNode('paragraph')
+    state.next(
+      fragment(text('code', [boldMark, inlineCodeMark]), text(' b', [boldMark]))
+    )
+    state.closeNode()
+
+    expect(state.top()).toMatchObject({
+      type: 'doc',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'bold',
+              isMark: true,
+              children: [
+                {
+                  type: 'inlineCode',
+                  isMark: true,
+                  value: 'code',
+                },
+                { type: 'text', value: ' b' },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('does not trim spaces inside a mark spanning multiple nodes', () => {
+    const state = new SerializerState(schema)
+
+    // **a *b*** — the space between "a" and the italic node is internal
+    // and must be preserved when the bold mark closes.
+    state.openNode('doc')
+    state.openNode('paragraph')
+    state.next(
+      fragment(text('a ', [boldMark]), text('b', [boldMark, italicMark]))
+    )
+    state.closeNode()
+
+    expect(state.top()).toMatchObject({
+      type: 'doc',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'bold',
+              isMark: true,
+              children: [
+                { type: 'text', value: 'a ' },
+                {
+                  type: 'italic',
+                  isMark: true,
+                  children: [{ type: 'text', value: 'b' }],
+                },
               ],
             },
           ],

--- a/packages/transformer/src/serializer/state.ts
+++ b/packages/transformer/src/serializer/state.ts
@@ -1,5 +1,6 @@
 import type {
   Fragment,
+  Mark,
   MarkType,
   Node,
   NodeType,
@@ -7,7 +8,6 @@ import type {
 } from '@milkdown/prose/model'
 
 import { serializerMatchError } from '@milkdown/exception'
-import { Mark } from '@milkdown/prose/model'
 
 import type {
   JSONRecord,
@@ -25,6 +25,14 @@ import { SerializerStackElement } from './stack-element'
 const isFragment = (x: Node | Fragment): x is Fragment =>
   Object.prototype.hasOwnProperty.call(x, 'size')
 
+interface OpenMark {
+  mark: Mark
+  /// Whether the mark node can span multiple prosemirror nodes.
+  /// Value based marks (e.g. inlineCode) hold their content as a single
+  /// value and must be closed after the node that carries them.
+  spanning: boolean
+}
+
 /// State for serializer.
 /// Transform prosemirror state into remark AST.
 export class SerializerState extends Stack<
@@ -32,7 +40,7 @@ export class SerializerState extends Stack<
   SerializerStackElement
 > {
   /// @internal
-  #marks: readonly Mark[] = Mark.none
+  #openMarks: OpenMark[] = []
   /// Get the schema of state.
   readonly schema: Schema
 
@@ -86,43 +94,44 @@ export class SerializerState extends Stack<
   }
 
   /// @internal
-  #runNode = (node: Node) => {
-    const { marks } = node
+  /// Order the marks of a node so that marks which are already open keep
+  /// their current nesting order and can stay open, followed by the newly
+  /// opened marks sorted by priority.
+  #orderMarks = (marks: readonly Mark[]): Mark[] => {
     const getPriority = (x: Mark) => x.type.spec.priority ?? 50
-    const tmp = [...marks].sort((a, b) => getPriority(a) - getPriority(b))
-    const unPreventNext = tmp.every((mark) => !this.#runProseMark(mark, node))
-    if (unPreventNext) this.#runProseNode(node)
-
-    marks.forEach((mark) => this.#closeMark(mark))
+    const rest = [...marks].sort((a, b) => getPriority(a) - getPriority(b))
+    const continuing: Mark[] = []
+    this.#openMarks.forEach(({ mark }) => {
+      const index = rest.findIndex((x) => x.eq(mark))
+      if (index >= 0) continuing.push(...rest.splice(index, 1))
+    })
+    return continuing.concat(rest)
   }
 
   /// @internal
-  #searchType = (child: MarkdownNode, type: string): MarkdownNode => {
-    if (child.type === type) return child
-
-    if (child.children?.length !== 1) return child
-
-    const searchNode = (node: MarkdownNode): MarkdownNode | null => {
-      if (node.type === type) return node.value != null ? null : node
-
-      if (node.children?.length !== 1) return null
-
-      const [firstChild] = node.children
-      if (!firstChild) return null
-
-      return searchNode(firstChild)
+  /// Close open marks that do not continue into the next node.
+  /// A mark can only stay open if every mark outside of it also stays open,
+  /// so scan from the outermost mark and close everything starting at the
+  /// first mark that ends here.
+  #closeEndedMarks = (next?: Node) => {
+    const nextMarks = next?.marks
+    let keep = 0
+    while (keep < this.#openMarks.length) {
+      const { mark, spanning } = this.#openMarks[keep] as OpenMark
+      if (spanning && nextMarks?.some((x) => x.eq(mark))) keep++
+      else break
     }
+    for (let i = this.#openMarks.length - 1; i >= keep; i--)
+      this.#closeMark((this.#openMarks[i] as OpenMark).mark)
+  }
 
-    const target = searchNode(child)
+  /// @internal
+  #runNode = (node: Node, next?: Node) => {
+    const marks = this.#orderMarks(node.marks)
+    const unPreventNext = marks.every((mark) => !this.#runProseMark(mark, node))
+    if (unPreventNext) this.#runProseNode(node)
 
-    if (!target) return child
-
-    const tmp = target.children ? [...target.children] : undefined
-    const node = { ...child, children: tmp }
-    node.children = tmp
-    target.children = [node]
-
-    return target
+    this.#closeEndedMarks(next)
   }
 
   /// @internal
@@ -135,7 +144,6 @@ export class SerializerState extends Stack<
 
       const last = nextChildren.at(-1)
       if (last && last.isMark && child.isMark) {
-        child = this.#searchType(child, last.type)
         const { children: currChildren, ...currRest } = child
         const { children: prevChildren, ...prevRest } = last
         if (
@@ -187,34 +195,29 @@ export class SerializerState extends Stack<
     let startSpaces = ''
     let endSpaces = ''
     const children = element.children
-    let first = -1
-    let last = -1
-    const findIndex = (node: MarkdownNode[]) => {
-      if (!node) return
-      node.forEach((child, index) => {
-        if (child.type === 'text' && child.value) {
-          if (first < 0) first = index
-
-          last = index
-        }
-      })
-    }
 
     if (children) {
-      findIndex(children)
-      const lastChild = children?.[last] as
+      const firstChild = children[0] as
         | (MarkdownNode & { value: string })
         | undefined
-      const firstChild = children?.[first] as
+      const lastChild = children.at(-1) as
         | (MarkdownNode & { value: string })
         | undefined
-      if (lastChild && lastChild.value.endsWith(' ')) {
+      if (
+        lastChild &&
+        lastChild.type === 'text' &&
+        lastChild.value.endsWith(' ')
+      ) {
         const text = lastChild.value
         const trimmed = text.trimEnd()
         endSpaces = text.slice(trimmed.length)
         lastChild.value = trimmed
       }
-      if (firstChild && firstChild.value.startsWith(' ')) {
+      if (
+        firstChild &&
+        firstChild.type === 'text' &&
+        firstChild.value.startsWith(' ')
+      ) {
         const text = firstChild.value
         const trimmed = text.trimStart()
         startSpaces = text.slice(0, text.length - trimmed.length)
@@ -287,26 +290,33 @@ export class SerializerState extends Stack<
     value?: string,
     props?: JSONRecord
   ) => {
-    const isIn = mark.isInSet(this.#marks)
+    const isIn = this.#openMarks.some((x) => x.mark.eq(mark))
 
     if (isIn) return this
 
-    this.#marks = mark.addToSet(this.#marks)
+    this.#openMarks.push({ mark, spanning: value == null })
     return this.openNode(type, value, { ...props, isMark: true })
   }
 
   /// @internal
   #closeMark = (mark: Mark): void => {
-    const isIn = mark.isInSet(this.#marks)
+    let index = -1
+    for (let i = this.#openMarks.length - 1; i >= 0; i--) {
+      if ((this.#openMarks[i] as OpenMark).mark.eq(mark)) {
+        index = i
+        break
+      }
+    }
 
-    if (!isIn) return
+    if (index < 0) return
 
-    this.#marks = mark.type.removeFromSet(this.#marks)
+    this.#openMarks.splice(index, 1)
     this.#closeNodeAndPush(true)
   }
 
   /// Open a new mark, the next nodes added will have that mark.
-  /// The mark will be closed automatically.
+  /// The mark will be kept open across nodes that share it and
+  /// closed automatically when it no longer applies.
   withMark = (mark: Mark, type: string, value?: string, props?: JSONRecord) => {
     this.#openMark(mark, type, value, props)
     return this
@@ -331,10 +341,12 @@ export class SerializerState extends Stack<
 
   /// Give the node or node list back to the state and
   /// the state will find a proper runner (by `match` method in serializer spec) to handle it.
+  /// When a node list is given, marks shared between adjacent nodes are kept
+  /// open across them so that they are serialized as one continuous span.
   next = (nodes: Node | Fragment) => {
     if (isFragment(nodes)) {
-      nodes.forEach((node) => {
-        this.#runNode(node)
+      nodes.forEach((node, _offset, index) => {
+        this.#runNode(node, nodes.maybeChild(index + 1) ?? undefined)
       })
       return this
     }
@@ -348,6 +360,7 @@ export class SerializerState extends Stack<
 
   /// Transform a prosemirror node tree into remark AST.
   run = (tree: Node) => {
+    this.#openMarks = []
     this.next(tree)
 
     return this


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2403, fixes #704.

A mark spanning multiple text leaves (because a nested mark splits it, e.g. `**a *b* c**`) was serialized as separate spans instead of one continuous span. This was not just cosmetic: when a split landed next to punctuation (`**a *b*, c**`), remark-stringify had to escape the now-ambiguous delimiters, so the round-trip **silently lost the bold formatting and injected literal backslash-escaped asterisks** into the visible text. Links were affected too: `[a **b** c](url)` came back as three separate links.

### Root cause

`SerializerState#runNode` closed every mark after each text leaf and relied on a post-hoc re-merge pass (`#maybeMergeChildren`, added for #704) to recombine them. That pass never fired in practice: the space-trimming pass (`#moveSpaces`) moves boundary spaces out of mark nodes as plain `text` siblings, which land exactly between the mark nodes the merge pass requires to be adjacent. Two individually-correct fix-up passes cancelled each other out.

### Fix

Rewrite inline mark handling with a lookahead algorithm (the same structural approach as prosemirror-markdown's `renderInline`), so marks are emitted continuous by construction instead of split-then-repaired:

- When iterating a fragment, `next()` passes the following sibling to the node runner; marks shared with the next node are kept open instead of closed and reopened.
- Marks of each node are ordered so that already-open marks keep their nesting order (continuing marks stay outside newly opened ones), falling back to `priority` for new marks.
- Value-based marks (e.g. `inlineCode`, which holds its content as a mdast `value`) are never kept open across nodes.
- `#moveSpaces` now only trims boundary spaces when the actual first/last child of the mark node is a text node, so internal spaces survive multi-node spans.
- The `#searchType` restructuring pass is removed; the shallow adjacent merge is kept as a fallback for plugins driving `withMark`/`closeMark` manually.

`withMark`/`closeMark` public API signatures are unchanged; no mark runner in the repo needed modification.

As a bonus, the "verbose but valid" outputs from the #2403 repro matrix are gone as well: `**a *b* c**` now round-trips byte-identical instead of becoming `**a** ***b*** **c**`.

## How did you test this change?

New regression tests, written first and confirmed failing (20/20) on current `main`:

- `packages/plugins/preset-commonmark/src/__test__/mark-roundtrip.spec.ts` — the #2403 repro matrix plus bold-in-italic, code-in-bold, and link-spanning-styled-text cases; asserts both exact string round-trip and the structural invariant `parse(serialize(parse(md))).eq(parse(md))`.
- `packages/transformer/src/serializer/state.spec.ts` — unit tests for the lookahead behavior (marks kept open across nodes, continuing marks stay outermost, value-based marks close immediately, internal spaces preserved). All pre-existing expectations are unchanged.
