### PR TITLE
feat: add getMarkRange and selection snapshot test DSL to prose toolkit

### DIFF
--- a/e2e/shim.d.ts
+++ b/e2e/shim.d.ts
@@ -18,6 +18,9 @@ declare global {
 
   var __inspect__: () => Telemetry[]
 
+  var __getSelectionSnapshot__: () => string
+  var __setCaretByTextOffset__: (offset: number) => void
+
   var __crepe__: Crepe
 
   var __beforeCrepeCreate__: (crepe: Crepe) => void

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -6,7 +6,9 @@ import {
   serializerCtx,
   commandsCtx,
 } from '@milkdown/core'
+import { getSelectionSnapshot, textOffsetToPos } from '@milkdown/prose'
 import { Slice } from '@milkdown/prose/model'
+import { TextSelection } from '@milkdown/prose/state'
 import { insert } from '@milkdown/utils'
 
 export async function setup(createEditor: () => Promise<Editor>) {
@@ -35,6 +37,19 @@ export async function setup(createEditor: () => Promise<Editor>) {
       const view = ctx.get(editorViewCtx)
       const serializer = ctx.get(serializerCtx)
       return serializer(view.state.doc)
+    })
+  globalThis.__getSelectionSnapshot__ = () =>
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx)
+      return getSelectionSnapshot(view.state)
+    })
+  globalThis.__setCaretByTextOffset__ = (offset: number) =>
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx)
+      const pos = textOffsetToPos(view.state.doc, offset)
+      const selection = TextSelection.near(view.state.doc.resolve(pos))
+      view.dispatch(view.state.tr.setSelection(selection))
+      view.focus()
     })
   globalThis.__inspect__ = () => editor.inspect()
   globalThis.__commandsCtx__ = commandsCtx

--- a/e2e/tests/misc/index.ts
+++ b/e2e/tests/misc/index.ts
@@ -59,6 +59,32 @@ export async function paste(
   )
 }
 
+export async function getSelectionSnapshot(page: Page) {
+  return await page.evaluate(() => {
+    return window.__getSelectionSnapshot__()
+  })
+}
+
+export async function setCaretByTextOffset(page: Page, offset: number) {
+  await page.evaluate((offset: number) => {
+    window.__setCaretByTextOffset__(offset)
+  }, offset)
+}
+
+/// Press a key repeatedly and collect a selection snapshot before the first
+/// press and after every press, so a whole caret walk asserts as one array.
+/// Waits a frame after each press: native caret motion reaches ProseMirror
+/// through the asynchronous selectionchange event.
+export async function traceKey(page: Page, key: string, times: number) {
+  const snapshots: string[] = [await getSelectionSnapshot(page)]
+  for (let i = 0; i < times; i += 1) {
+    await page.keyboard.press(key)
+    await waitNextFrame(page)
+    snapshots.push(await getSelectionSnapshot(page))
+  }
+  return snapshots
+}
+
 export async function waitNextFrame(page: Page) {
   await page.evaluate(() => {
     return new Promise<void>((resolve) => {

--- a/e2e/tests/misc/selection-snapshot.spec.ts
+++ b/e2e/tests/misc/selection-snapshot.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  focusEditor,
+  getSelectionSnapshot,
+  selectAll,
+  setCaretByTextOffset,
+  setMarkdown,
+  traceKey,
+} from '.'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/preset-commonmark/')
+})
+
+test('selection snapshot renders caret walks', async ({ page }) => {
+  await focusEditor(page)
+  await setMarkdown(page, '**bold** text')
+  await setCaretByTextOffset(page, 0)
+
+  const snapshots = await traceKey(page, 'ArrowRight', 3)
+  expect(snapshots).toEqual([
+    '┃bold text',
+    'b┃old text',
+    'bo┃ld text',
+    'bol┃d text',
+  ])
+})
+
+test('selection snapshot renders ranges and blocks', async ({ page }) => {
+  await focusEditor(page)
+  await setMarkdown(page, 'one\n\ntwo')
+
+  await selectAll(page)
+  expect(await getSelectionSnapshot(page)).toBe('❰one\ntwo❱')
+
+  await setCaretByTextOffset(page, 4)
+  expect(await getSelectionSnapshot(page)).toBe('one\n┃two')
+})

--- a/packages/prose/src/__test__/mark.spec.ts
+++ b/packages/prose/src/__test__/mark.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Mark, Node as ProseNode } from '../model'
+
+import { Schema } from '../model'
+import { getMarkRange } from '../toolkit/prose/mark'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    text: { group: 'inline' },
+  },
+  marks: {
+    strong: {},
+    em: {},
+    link: { attrs: { href: {} } },
+  },
+})
+
+const { strong, em, link } = schema.marks
+
+function paragraph(...children: ProseNode[]) {
+  return schema.node('doc', null, [schema.node('paragraph', null, children)])
+}
+
+function text(content: string, ...marks: Mark[]) {
+  return schema.text(content, marks)
+}
+
+describe('getMarkRange', () => {
+  it('should find the whole run from a caret inside it', () => {
+    // <p>[strong "bold"] "text"</p> -> strong covers [1, 5)
+    const doc = paragraph(text('bold', strong.create()), text('text'))
+    const range = getMarkRange(doc.resolve(3), strong)
+    expect(range).toMatchObject({ from: 1, to: 5 })
+    expect(range?.mark.type).toBe(strong)
+  })
+
+  it('should include both edges of the run', () => {
+    const doc = paragraph(text('ab'), text('cd', strong.create()), text('ef'))
+    // strong covers [3, 5): caret at the left edge and the right edge both hit
+    expect(getMarkRange(doc.resolve(3), strong)).toMatchObject({
+      from: 3,
+      to: 5,
+    })
+    expect(getMarkRange(doc.resolve(5), strong)).toMatchObject({
+      from: 3,
+      to: 5,
+    })
+  })
+
+  it('should find a run ending at the parent boundary', () => {
+    const doc = paragraph(text('ab'), text('cd', strong.create()))
+    // caret at the very end of the paragraph, run before it
+    expect(getMarkRange(doc.resolve(5), strong)).toMatchObject({
+      from: 3,
+      to: 5,
+    })
+  })
+
+  it('should return undefined when the position carries no such mark', () => {
+    const doc = paragraph(text('ab', strong.create()), text('cd'))
+    expect(getMarkRange(doc.resolve(5), strong)).toBeUndefined()
+    expect(getMarkRange(doc.resolve(2), em)).toBeUndefined()
+  })
+
+  it('should span text nodes split by a nested mark', () => {
+    // **a *b* c** -> [strong "a "][strong+em "b"][strong " c"]
+    const doc = paragraph(
+      text('a ', strong.create()),
+      text('b', strong.create(), em.create()),
+      text(' c', strong.create())
+    )
+    expect(getMarkRange(doc.resolve(4), strong)).toMatchObject({
+      from: 1,
+      to: 6,
+    })
+    // while the em run stays confined to its own segment
+    expect(getMarkRange(doc.resolve(4), em)).toMatchObject({ from: 3, to: 4 })
+  })
+
+  it('should keep adjacent same-type marks with different attrs apart', () => {
+    // [a](x)[b](y) -> two link runs touching at position 2
+    const doc = paragraph(
+      text('a', link.create({ href: 'x' })),
+      text('b', link.create({ href: 'y' }))
+    )
+    // tie-break goes to the run after the caret
+    const range = getMarkRange(doc.resolve(2), link)
+    expect(range).toMatchObject({ from: 2, to: 3 })
+    expect(range?.mark.attrs.href).toBe('y')
+    // and the runs never merge from an interior position either
+    expect(getMarkRange(doc.resolve(1), link)).toMatchObject({
+      from: 1,
+      to: 2,
+    })
+  })
+
+  it('should merge adjacent runs of equal marks', () => {
+    const doc = paragraph(
+      text('a', link.create({ href: 'x' })),
+      text('b', link.create({ href: 'x' }), em.create()),
+      text('c', link.create({ href: 'x' }))
+    )
+    expect(getMarkRange(doc.resolve(2), link)).toMatchObject({
+      from: 1,
+      to: 4,
+    })
+  })
+})

--- a/packages/prose/src/__test__/snapshot.spec.ts
+++ b/packages/prose/src/__test__/snapshot.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Node as ProseNode } from '../model'
+import type { Selection } from '../state'
+
+import { Schema } from '../model'
+import {
+  AllSelection,
+  EditorState,
+  NodeSelection,
+  TextSelection,
+} from '../state'
+import {
+  getSelectionSnapshot,
+  posToTextOffset,
+  textOffsetToPos,
+} from '../toolkit/prose/snapshot'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    blockquote: { group: 'block', content: 'block+' },
+    hr: { group: 'block' },
+    image: { group: 'inline', inline: true, atom: true },
+    text: { group: 'inline' },
+  },
+  marks: {},
+})
+
+function doc(...children: ProseNode[]) {
+  return schema.node('doc', null, children)
+}
+
+function p(...children: (ProseNode | string)[]) {
+  return schema.node(
+    'paragraph',
+    null,
+    children.map((child) =>
+      typeof child === 'string' ? schema.text(child) : child
+    )
+  )
+}
+
+function snapshot(docNode: ProseNode, selection: Selection) {
+  return getSelectionSnapshot(EditorState.create({ doc: docNode, selection }))
+}
+
+describe('getSelectionSnapshot', () => {
+  it('should draw a caret inside a paragraph', () => {
+    const d = doc(p('abcd'))
+    expect(snapshot(d, TextSelection.create(d, 3))).toBe('ab┃cd')
+  })
+
+  it('should draw a range across paragraphs', () => {
+    const d = doc(p('ab'), p('cd'))
+    expect(snapshot(d, TextSelection.create(d, 2, 6))).toBe('a❰b\nc❱d')
+  })
+
+  it('should draw a caret in an empty paragraph', () => {
+    const d = doc(p('a'), p(), p('b'))
+    expect(snapshot(d, TextSelection.create(d, 4))).toBe('a\n┃\nb')
+  })
+
+  it('should draw a node selection around an inline atom', () => {
+    const d = doc(p('a', schema.node('image'), 'b'))
+    expect(snapshot(d, NodeSelection.create(d, 2))).toBe('a❰□❱b')
+  })
+
+  it('should render a leaf block with separators', () => {
+    const d = doc(p('a'), schema.node('hr'), p('b'))
+    expect(snapshot(d, TextSelection.create(d, 5))).toBe('a\n□\n┃b')
+  })
+
+  it('should separate nested textblocks', () => {
+    const d = doc(schema.node('blockquote', null, [p('a'), p('b')]), p('c'))
+    expect(snapshot(d, TextSelection.create(d, 3))).toBe('a┃\nb\nc')
+  })
+
+  it('should draw a whole-document selection', () => {
+    const d = doc(p('ab'))
+    expect(snapshot(d, new AllSelection(d))).toBe('❰ab❱')
+  })
+
+  it('should honor custom separator and leaf text', () => {
+    const d = doc(p('a', schema.node('image')), p('b'))
+    const state = EditorState.create({
+      doc: d,
+      selection: TextSelection.create(d, 2),
+    })
+    expect(
+      getSelectionSnapshot(state, { blockSeparator: '¶', leafText: '<img>' })
+    ).toBe('a┃<img>¶b')
+  })
+})
+
+describe('text offset mapping', () => {
+  it('should round-trip offsets and positions inside text', () => {
+    const d = doc(p('ab'), p('cd'))
+    // string: 'ab\ncd'
+    expect(textOffsetToPos(d, 0)).toBe(1)
+    expect(textOffsetToPos(d, 1)).toBe(2)
+    expect(textOffsetToPos(d, 2)).toBe(3)
+    expect(textOffsetToPos(d, 3)).toBe(5)
+    expect(textOffsetToPos(d, 5)).toBe(7)
+
+    expect(posToTextOffset(d, 1)).toBe(0)
+    expect(posToTextOffset(d, 3)).toBe(2)
+    expect(posToTextOffset(d, 5)).toBe(3)
+    expect(posToTextOffset(d, 7)).toBe(5)
+  })
+
+  it('should resolve an offset at a separator into the empty block', () => {
+    const d = doc(p('a'), p(), p('b'))
+    // string: 'a\n\nb', offset 2 sits between the separators
+    expect(textOffsetToPos(d, 2)).toBe(4)
+    expect(posToTextOffset(d, 4)).toBe(2)
+  })
+
+  it('should resolve offsets around a leaf placeholder', () => {
+    const d = doc(p('a', schema.node('image'), 'b'))
+    // string: 'a□b'; the placeholder maps to the position before the atom
+    expect(textOffsetToPos(d, 1)).toBe(2)
+    expect(textOffsetToPos(d, 2)).toBe(3)
+    expect(posToTextOffset(d, 2)).toBe(1)
+    expect(posToTextOffset(d, 3)).toBe(2)
+  })
+})

--- a/packages/prose/src/toolkit/prose/index.ts
+++ b/packages/prose/src/toolkit/prose/index.ts
@@ -1,4 +1,6 @@
 export * from './helper'
+export * from './mark'
 export * from './node'
 export * from './schema'
 export * from './selection'
+export * from './snapshot'

--- a/packages/prose/src/toolkit/prose/mark.ts
+++ b/packages/prose/src/toolkit/prose/mark.ts
@@ -1,0 +1,50 @@
+import type { Mark, MarkType, ResolvedPos } from '../../model'
+
+export interface MarkRange {
+  mark: Mark
+  from: number
+  to: number
+}
+
+/// Find the extent of a mark of the given type around a resolved position.
+///
+/// The lookup is boundary-inclusive on both edges: a caret sitting right
+/// before or right after a marked run still resolves to it. When marked runs
+/// touch the position on both sides, the run after the position wins.
+///
+/// The run is extended by mark equality (`Mark.eq`, type + attrs), so two
+/// adjacent links with different hrefs resolve as two separate ranges.
+export function getMarkRange(
+  $pos: ResolvedPos,
+  type: MarkType
+): MarkRange | undefined {
+  const parent = $pos.parent
+
+  let cursor = parent.childAfter($pos.parentOffset)
+  if (!cursor.node || !type.isInSet(cursor.node.marks))
+    cursor = parent.childBefore($pos.parentOffset)
+  if (!cursor.node) return undefined
+
+  const mark = type.isInSet(cursor.node.marks)
+  if (!mark) return undefined
+
+  let index = cursor.index
+  let from = $pos.start() + cursor.offset
+  let to = from + cursor.node.nodeSize
+
+  while (index > 0 && mark.isInSet(parent.child(index - 1).marks)) {
+    index -= 1
+    from -= parent.child(index).nodeSize
+  }
+
+  let endIndex = cursor.index + 1
+  while (
+    endIndex < parent.childCount &&
+    mark.isInSet(parent.child(endIndex).marks)
+  ) {
+    to += parent.child(endIndex).nodeSize
+    endIndex += 1
+  }
+
+  return { mark, from, to }
+}

--- a/packages/prose/src/toolkit/prose/snapshot.ts
+++ b/packages/prose/src/toolkit/prose/snapshot.ts
@@ -1,0 +1,149 @@
+import type { Node as ProseNode } from '../../model'
+import type { EditorState } from '../../state'
+
+export const CARET_MARKER = '┃'
+export const RANGE_OPEN_MARKER = '❰'
+export const RANGE_CLOSE_MARKER = '❱'
+
+export interface TextIndexOptions {
+  blockSeparator?: string
+  leafText?: string
+}
+
+interface Emission {
+  text: string
+  kind: 'text' | 'leaf' | 'separator'
+  /// Doc range covered by the emitted text. For separators the range is
+  /// empty and anchored at the position of the block node they precede.
+  from: number
+  to: number
+}
+
+function walkText(doc: ProseNode, options?: TextIndexOptions): Emission[] {
+  const { blockSeparator = '\n', leafText = '□' } = options ?? {}
+  const emissions: Emission[] = []
+  let firstBlock = true
+
+  const pushSeparator = (pos: number) => {
+    if (firstBlock) {
+      firstBlock = false
+      return
+    }
+    emissions.push({
+      text: blockSeparator,
+      kind: 'separator',
+      from: pos,
+      to: pos,
+    })
+  }
+
+  doc.descendants((node, pos) => {
+    if (node.isText) {
+      emissions.push({
+        text: node.text ?? '',
+        kind: 'text',
+        from: pos,
+        to: pos + node.nodeSize,
+      })
+      return false
+    }
+    if (node.isInline && node.isLeaf) {
+      emissions.push({
+        text: leafText,
+        kind: 'leaf',
+        from: pos,
+        to: pos + node.nodeSize,
+      })
+      return false
+    }
+    if (node.isTextblock) {
+      pushSeparator(pos)
+      return true
+    }
+    if (node.isLeaf) {
+      pushSeparator(pos)
+      emissions.push({
+        text: leafText,
+        kind: 'leaf',
+        from: pos,
+        to: pos + node.nodeSize,
+      })
+      return false
+    }
+    return true
+  })
+
+  return emissions
+}
+
+/// Map a document position to an offset in the flattened text produced by
+/// `getSelectionSnapshot` (without markers).
+export function posToTextOffset(
+  doc: ProseNode,
+  pos: number,
+  options?: TextIndexOptions
+): number {
+  let offset = 0
+  for (const emission of walkText(doc, options)) {
+    if (emission.kind === 'text' || emission.kind === 'leaf') {
+      if (pos < emission.from) return offset
+      if (pos <= emission.to) {
+        if (emission.kind === 'leaf')
+          return pos <= emission.from ? offset : offset + emission.text.length
+        return offset + (pos - emission.from)
+      }
+    } else if (pos <= emission.from) {
+      return offset
+    }
+    offset += emission.text.length
+  }
+  return offset
+}
+
+/// Map an offset in the flattened text back to a document position. Offsets
+/// pointing at a block separator resolve to the end of the previous block;
+/// offsets inside a leaf placeholder resolve to the position before the leaf.
+export function textOffsetToPos(
+  doc: ProseNode,
+  offset: number,
+  options?: TextIndexOptions
+): number {
+  let current = 0
+  let lastPos = 0
+  for (const emission of walkText(doc, options)) {
+    const end = current + emission.text.length
+    if (offset < end || (offset === end && emission.kind === 'text')) {
+      if (emission.kind === 'text') return emission.from + (offset - current)
+      if (emission.kind === 'leaf') return emission.from
+      return emission.from - 1
+    }
+    current = end
+    lastPos = emission.to
+  }
+  return lastPos
+}
+
+/// Render the document text with the selection drawn in: `┃` for a caret,
+/// `❰…❱` for a range. Blocks are joined with `blockSeparator` and leaf nodes
+/// render as `leafText`. Made for inline snapshot assertions in tests.
+export function getSelectionSnapshot(
+  state: EditorState,
+  options?: TextIndexOptions
+): string {
+  const { doc, selection } = state
+  const text = walkText(doc, options)
+    .map((emission) => emission.text)
+    .join('')
+
+  if (selection.empty) {
+    const index = posToTextOffset(doc, selection.head, options)
+    return `${text.slice(0, index)}${CARET_MARKER}${text.slice(index)}`
+  }
+
+  const from = posToTextOffset(doc, selection.from, options)
+  const to = posToTextOffset(doc, selection.to, options)
+  return `${text.slice(0, from)}${RANGE_OPEN_MARKER}${text.slice(
+    from,
+    to
+  )}${RANGE_CLOSE_MARKER}${text.slice(to)}`
+}

--- a/packages/prose/vitest.config.ts
+++ b/packages/prose/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## What

Two additions to the `@milkdown/prose` toolkit, plus e2e harness support. Groundwork for the upcoming syntax-reveal (hybrid) mode, and generally useful on their own.

### `getMarkRange($pos, markType)`

Finds the extent of a mark run around a resolved position:

- Boundary-inclusive on both edges — a caret right before or right after a run still resolves to it; when runs touch the position on both sides, the run after wins.
- Extends by mark equality (`Mark.eq`, type + attrs), so two adjacent links with different `href`s resolve as two separate ranges, while runs split by a nested mark (`**a *b* c**`) resolve as one continuous range.

ProseMirror does not ship this helper (prosekit/tiptap each carry their own); we need it for cursor-based inline syntax reveal.

### Selection snapshot test DSL

- `getSelectionSnapshot(state)` renders the document text with the selection drawn in: `┃` for a caret, `❰…❱` for a range, blocks joined with `\n`, leaf nodes as `□`. Made for one-line inline snapshot assertions.
- `textOffsetToPos` / `posToTextOffset` map between document positions and offsets in that flattened text. All three share one text walker so the mappings always agree with the snapshot output.
- e2e harness: `__getSelectionSnapshot__` / `__setCaretByTextOffset__` page globals and `getSelectionSnapshot` / `setCaretByTextOffset` / `traceKey` Playwright helpers, with a spec covering the wiring. `traceKey` waits a frame after each key press because native caret motion reaches ProseMirror through the asynchronous `selectionchange` event.

## Test plan

- 18 new unit tests (`packages/prose/src/__test__/`): edge inclusion, right-hand tie-break, attr-aware run separation, nested-mark spans; snapshot rendering for empty paragraphs, inline atoms, leaf blocks, nested blockquotes, custom separators; offset↔pos round-trips.
- New e2e spec (`e2e/tests/misc/selection-snapshot.spec.ts`) exercising the harness against a real editor.
- `pnpm test:lint`, `pnpm build:tsc`, `pnpm test:unit` (284 tests), and the new Playwright spec all pass.
