### PR TITLE
fix: cancel list item RAF on destroy

### DIFF
--- a/.changeset/fix-list-item-raf-destroy.md
+++ b/.changeset/fix-list-item-raf-destroy.md
@@ -2,4 +2,4 @@
 '@milkdown/components': patch
 ---
 
-Cancel pending list item block animation frames on destroy.
+Cancel pending list item block animation frames on destroy and skip dispatch after editor teardown.

--- a/.changeset/fix-list-item-raf-destroy.md
+++ b/.changeset/fix-list-item-raf-destroy.md
@@ -1,0 +1,5 @@
+---
+'@milkdown/components': patch
+---
+
+Cancel pending list item block animation frames on destroy.

--- a/.changeset/fix-list-item-raf-destroy.md
+++ b/.changeset/fix-list-item-raf-destroy.md
@@ -1,5 +1,0 @@
----
-'@milkdown/components': patch
----
-
-Cancel pending list item block animation frames on destroy and skip dispatch after editor teardown.

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -53,6 +53,7 @@ export const listItemBlockView = $view(
         const headPos = view.state.doc.resolve(head)
         raf = requestAnimationFrame(() => {
           raf = 0
+          if (view.isDestroyed) return
           if (!anchorPos.doc.eq(view.state.doc)) return
           const selection = new TextSelection(anchorPos, headPos)
           view.dispatch(view.state.tr.setSelection(selection))

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -52,7 +52,7 @@ export const listItemBlockView = $view(
         const anchorPos = view.state.doc.resolve(anchor)
         const headPos = view.state.doc.resolve(head)
         raf = requestAnimationFrame(() => {
-          cancelAnimationFrame(raf)
+          raf = 0
           if (!anchorPos.doc.eq(view.state.doc)) return
           const selection = new TextSelection(anchorPos, headPos)
           view.dispatch(view.state.tr.setSelection(selection))
@@ -114,6 +114,7 @@ export const listItemBlockView = $view(
           selected.value = false
         },
         destroy: () => {
+          cancelAnimationFrame(raf)
           disposeSelectedWatcher()
           app.unmount()
           dom.remove()


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes highestop/milkdown#1.
Additional context: https://github.com/highestop/milkdown/issues/1#issuecomment-4932883086.

- Cancel the pending `requestAnimationFrame` when the list item block NodeView is destroyed.
- Clear the RAF handle after the callback runs, so later destruction does not refer to a stale frame.
- Skip the deferred selection dispatch when `view.isDestroyed` is true, covering teardown ordering where the editor view is gone before the NodeView destroy hook cancels the frame.
- Add a patch changeset for `@milkdown/components`.

## How did you test this change?

- `pnpm --filter @milkdown/components test`
- `pnpm build:tsc`
- `pnpm test:lint`
- `pnpm test`
- `pnpm build`