### PR TITLE
fix: resolve list item selection against current doc

### DIFF
--- a/.changeset/fix-list-item-stale-positions.md
+++ b/.changeset/fix-list-item-stale-positions.md
@@ -1,0 +1,5 @@
+---
+'@milkdown/components': patch
+---
+
+Resolve deferred list item block selections against the current document.

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -49,14 +49,16 @@ export const listItemBlockView = $view(
         const { anchor, head } = view.state.selection
         div.appendChild(contentDOM)
         // put the cursor to the new created list item
-        const anchorPos = view.state.doc.resolve(anchor)
-        const headPos = view.state.doc.resolve(head)
         raf = requestAnimationFrame(() => {
           raf = 0
           if (view.isDestroyed) return
-          if (!anchorPos.doc.eq(view.state.doc)) return
+          const { state } = view
+          const docSize = state.doc.content.size
+          if (anchor > docSize || head > docSize) return
+          const anchorPos = state.doc.resolve(anchor)
+          const headPos = state.doc.resolve(head)
           const selection = new TextSelection(anchorPos, headPos)
-          view.dispatch(view.state.tr.setSelection(selection))
+          view.dispatch(state.tr.setSelection(selection))
         })
       }
 


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes highestop/milkdown#2.

- Resolve the saved selection offsets against the current document inside the RAF callback.
- Replace the content-equality guard with a bounds check before resolving positions.
- Dispatch a transaction from the same current editor state used to build the selection.
- Add a patch changeset for `@milkdown/components`.

## How did you test this change?

- `pnpm install --frozen-lockfile`
- `pnpm --filter @milkdown/components test`
- `pnpm build:tsc`
- `pnpm test:lint`
- `pnpm test`
- `pnpm build`