### PR TITLE
fix: use TextSelection.between for list item cursor placement

### DIFF
--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -57,7 +57,9 @@ export const listItemBlockView = $view(
           if (anchor > docSize || head > docSize) return
           const anchorPos = state.doc.resolve(anchor)
           const headPos = state.doc.resolve(head)
-          const selection = new TextSelection(anchorPos, headPos)
+          // Use `between` so we fall back to the nearest valid selection when
+          // the resolved positions no longer sit inside a textblock.
+          const selection = TextSelection.between(anchorPos, headPos)
           view.dispatch(state.tr.setSelection(selection))
         })
       }


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Follow-up hardening for the list item block cursor placement fixed in #2412.

When the deferred `requestAnimationFrame` callback restores the saved selection, it resolves the captured `anchor`/`head` offsets against the *current* document and builds a `TextSelection` from them. Constructing `new TextSelection($anchor, $head)` assumes both resolved positions still sit inside a textblock. If the document shifted between mount and the next frame so that a position no longer lands in inline content, that assumption breaks and we can produce an invalid selection.

This PR swaps `new TextSelection(...)` for `TextSelection.between(...)`, ProseMirror's recommended factory:

- In the normal case (cursor inside the newly created list item's paragraph) it returns the exact same selection — no behavior change.
- When a resolved position no longer sits inside a textblock, it falls back to the nearest valid selection instead of constructing an invalid one.

No changeset is added — it is generated by the release tooling.

## How did you test this change?

- `pnpm --filter @milkdown/components test` — 22 passed
- `tsc --noEmit` on `@milkdown/components` — no type errors
- `pnpm test:lint` (oxlint) — 0 warnings / 0 errors
