### PR TITLE
fix: store list spread attribute as boolean (#2419)

### DIFF
--- a/packages/plugins/preset-commonmark/src/__test__/list-spread-roundtrip.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/list-spread-roundtrip.spec.ts
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/vitest'
+import {
+  defaultValueCtx,
+  Editor,
+  editorViewCtx,
+  parserCtx,
+  schemaCtx,
+} from '@milkdown/core'
+import { getMarkdown } from '@milkdown/utils'
+import { describe, expect, it } from 'vitest'
+
+import { commonmark } from '..'
+
+async function createEditor(defaultValue: string) {
+  const editor = Editor.make()
+  editor.config((ctx) => {
+    ctx.set(defaultValueCtx, defaultValue)
+  })
+  editor.use(commonmark)
+  await editor.create()
+  return editor
+}
+
+async function roundTrip(markdown: string) {
+  const editor = await createEditor(markdown)
+  return editor.action(getMarkdown())
+}
+
+// https://github.com/Milkdown/milkdown/issues/2419
+// The `spread` attribute is parsed into a stringified boolean ("true"/"false").
+// The bullet_list and list_item toMarkdown runners used to forward that string
+// straight to mdast, where the *string* "false" is truthy — so every tight list
+// was serialized as loose (blank lines between the items).
+describe('list spread round-trip (#2419)', () => {
+  // Exact-string checks for the tight/loose distinction. The serializer
+  // normalizes bullet markers to `*`, so the inputs use `*` to keep the
+  // assertions about spread (blank lines) rather than the marker character.
+  const cases = [
+    '* a\n* b\n',
+    '* a\n  * b\n* c\n',
+    '* a\n\n* b\n',
+    '1. a\n2. b\n',
+    '1. a\n\n2. b\n',
+  ]
+
+  cases.forEach((markdown) => {
+    it(`should preserve tightness for ${JSON.stringify(markdown)}`, async () => {
+      const output = await roundTrip(markdown)
+      expect(output).toBe(markdown)
+    })
+  })
+
+  // Structural invariant: parse(serialize(parse(md))) must equal parse(md).
+  cases.forEach((markdown) => {
+    it(`should keep the document stable for ${JSON.stringify(markdown)}`, async () => {
+      const editor = await createEditor(markdown)
+      const doc = editor.ctx.get(editorViewCtx).state.doc
+      const output = editor.action(getMarkdown())
+      const parser = editor.ctx.get(parserCtx)
+      const reparsed = parser(output)
+      expect(reparsed.eq(doc), `serialized to ${JSON.stringify(output)}`).toBe(
+        true
+      )
+    })
+  })
+
+  // `spread` must be stored as a real boolean so it satisfies the schema's
+  // `validate: 'boolean'` declaration. When it was a stringified boolean,
+  // schema.nodeFromJSON() threw a RangeError on any document with a list.
+  cases.forEach((markdown) => {
+    it(`should round-trip through nodeFromJSON for ${JSON.stringify(markdown)}`, async () => {
+      const editor = await createEditor(markdown)
+      const doc = editor.ctx.get(editorViewCtx).state.doc
+      const schema = editor.ctx.get(schemaCtx)
+      const json = doc.toJSON()
+      expect(() => schema.nodeFromJSON(json)).not.toThrow()
+      expect(schema.nodeFromJSON(json).eq(doc)).toBe(true)
+    })
+  })
+})

--- a/packages/plugins/preset-commonmark/src/node/bullet-list.ts
+++ b/packages/plugins/preset-commonmark/src/node/bullet-list.ts
@@ -56,7 +56,7 @@ export const bulletListSchema = $nodeSchema('bullet_list', (ctx) => {
     parseMarkdown: {
       match: ({ type, ordered }) => type === 'list' && !ordered,
       runner: (state, node, type) => {
-        const spread = node.spread != null ? `${node.spread}` : 'false'
+        const spread = node.spread ?? false
         state.openNode(type, { spread }).next(node.children).closeNode()
       },
     },

--- a/packages/plugins/preset-commonmark/src/node/list-item.ts
+++ b/packages/plugins/preset-commonmark/src/node/list-item.ts
@@ -69,7 +69,7 @@ export const listItemSchema = $nodeSchema('list_item', (ctx) => ({
     runner: (state, node, type) => {
       const label = node.label != null ? `${node.label}.` : '•'
       const listType = node.label != null ? 'ordered' : 'bullet'
-      const spread = node.spread != null ? `${node.spread}` : 'true'
+      const spread = node.spread ?? true
       state.openNode(type, { label, listType, spread })
       state.next(node.children)
       state.closeNode()

--- a/packages/plugins/preset-commonmark/src/node/ordered-list.ts
+++ b/packages/plugins/preset-commonmark/src/node/ordered-list.ts
@@ -41,7 +41,7 @@ export const orderedListSchema = $nodeSchema('ordered_list', (ctx) => ({
         if (!(dom instanceof HTMLElement)) throw expectDomTypeError(dom)
 
         return {
-          spread: dom.dataset.spread,
+          spread: dom.dataset.spread === 'true',
           order: dom.hasAttribute('start')
             ? Number(dom.getAttribute('start'))
             : 1,
@@ -61,7 +61,7 @@ export const orderedListSchema = $nodeSchema('ordered_list', (ctx) => ({
   parseMarkdown: {
     match: ({ type, ordered }) => type === 'list' && !!ordered,
     runner: (state, node, type) => {
-      const spread = node.spread != null ? `${node.spread}` : 'true'
+      const spread = node.spread ?? true
       state
         .openNode(type, { spread, order: node.start ?? 1 })
         .next(node.children)
@@ -74,7 +74,7 @@ export const orderedListSchema = $nodeSchema('ordered_list', (ctx) => ({
       state.openNode('list', undefined, {
         ordered: true,
         start: node.attrs.order ?? 1,
-        spread: node.attrs.spread === 'true',
+        spread: node.attrs.spread,
       })
       state.next(node.content)
       state.closeNode()

--- a/packages/plugins/preset-commonmark/src/plugin/sync-list-order-plugin.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/sync-list-order-plugin.ts
@@ -56,7 +56,7 @@ export const syncListOrderPlugin = $prose((ctx) => {
             base.attrs.listType === 'ordered'
           ) {
             needDispatch = true
-            tr.setNodeMarkup(pos, orderedListType, { spread: 'true' })
+            tr.setNodeMarkup(pos, orderedListType, { spread: true })
 
             node.descendants(
               (

--- a/packages/plugins/preset-gfm/src/__test__/task-list-spread-roundtrip.spec.ts
+++ b/packages/plugins/preset-gfm/src/__test__/task-list-spread-roundtrip.spec.ts
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom/vitest'
+import {
+  defaultValueCtx,
+  Editor,
+  editorViewCtx,
+  schemaCtx,
+} from '@milkdown/core'
+import { commonmark } from '@milkdown/preset-commonmark'
+import { getMarkdown } from '@milkdown/utils'
+import { describe, expect, it } from 'vitest'
+
+import { gfm } from '..'
+
+async function createEditor(defaultValue: string) {
+  const editor = Editor.make()
+  editor.config((ctx) => {
+    ctx.set(defaultValueCtx, defaultValue)
+  })
+  editor.use(commonmark)
+  editor.use(gfm)
+  await editor.create()
+  return editor
+}
+
+async function roundTrip(markdown: string) {
+  const editor = await createEditor(markdown)
+  return editor.action(getMarkdown())
+}
+
+// https://github.com/Milkdown/milkdown/issues/2419
+// Tight task lists must round-trip as tight, and the checkbox syntax
+// (`- [ ]` / `- [x]`) must survive. The list_item toMarkdown fix must be
+// applied *in place*: preset-gfm delegates unchecked items to the base
+// list_item runner, so replacing the whole runner would drop checkboxes.
+describe('task list spread round-trip (#2419)', () => {
+  // The serializer normalizes bullet markers to `*`, so the inputs use `*`
+  // to keep the assertions about spread (blank lines) and the surviving
+  // checkbox rather than the marker character.
+  const cases = [
+    '* [ ] a\n* [x] b\n',
+    '* [ ] a\n  * [ ] b\n* [x] c\n',
+    '* [ ] a\n\n* [x] b\n',
+  ]
+
+  cases.forEach((markdown) => {
+    it(`should round-trip ${JSON.stringify(markdown)}`, async () => {
+      const output = await roundTrip(markdown)
+      expect(output).toBe(markdown)
+    })
+  })
+
+  it('should keep the checkbox on a tight unchecked task item', async () => {
+    const output = await roundTrip('* [ ] todo\n')
+    expect(output).toBe('* [ ] todo\n')
+    expect(output).not.toBe('* todo\n')
+  })
+
+  // The `spread` attribute must be a real boolean so schema.nodeFromJSON()
+  // does not throw on documents containing task lists.
+  cases.forEach((markdown) => {
+    it(`should round-trip through nodeFromJSON for ${JSON.stringify(markdown)}`, async () => {
+      const editor = await createEditor(markdown)
+      const doc = editor.ctx.get(editorViewCtx).state.doc
+      const schema = editor.ctx.get(schemaCtx)
+      const json = doc.toJSON()
+      expect(() => schema.nodeFromJSON(json)).not.toThrow()
+      expect(schema.nodeFromJSON(json).eq(doc)).toBe(true)
+    })
+  })
+})

--- a/packages/plugins/preset-gfm/src/node/task-list-item.ts
+++ b/packages/plugins/preset-gfm/src/node/task-list-item.ts
@@ -28,7 +28,7 @@ export const extendListItemSchemaForTask = listItemSchema.extendSchema(
               return {
                 label: dom.dataset.label,
                 listType: dom.dataset.listType,
-                spread: dom.dataset.spread,
+                spread: dom.dataset.spread === 'true',
                 checked: dom.dataset.checked
                   ? dom.dataset.checked === 'true'
                   : null,
@@ -64,7 +64,7 @@ export const extendListItemSchemaForTask = listItemSchema.extendSchema(
             const label = node.label != null ? `${node.label}.` : '•'
             const checked = node.checked != null ? Boolean(node.checked) : null
             const listType = node.label != null ? 'ordered' : 'bullet'
-            const spread = node.spread != null ? `${node.spread}` : 'true'
+            const spread = node.spread ?? true
 
             state.openNode(type, { label, listType, spread, checked })
             state.next(node.children)
@@ -81,7 +81,7 @@ export const extendListItemSchemaForTask = listItemSchema.extendSchema(
 
             const label = node.attrs.label
             const listType = node.attrs.listType
-            const spread = node.attrs.spread === 'true'
+            const spread = node.attrs.spread
             const checked = node.attrs.checked
 
             state.openNode('listItem', undefined, {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Closes: #2419

The `spread` attribute on list nodes is declared `validate: 'boolean'` in the schema, but `parseMarkdown` stored it as a stringified boolean. This caused two symptoms:

- Two `toMarkdown` runners forwarded the string to mdast, where the string "false" is truthy, so every tight list serialized as loose.
- `schema.nodeFromJSON()` threw a RangeError on any document containing a list, because the string failed boolean attribute validation.

Normalize `spread` to a real boolean across the whole pipeline: parse it as a boolean with the correct per-node default, coerce it in every `parseDOM`, and pass it through unchanged in every `toMarkdown`. Also fix the ordered-list renumbering command, which set `spread: 'true'`.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!-- branch-stack -->
