### PR TITLE
fix: give internal input elements a unique id (#2416)

### DIFF
--- a/packages/components/src/__internal__/components/image-input.tsx
+++ b/packages/components/src/__internal__/components/image-input.tsx
@@ -1,13 +1,11 @@
 import clsx from 'clsx'
-import { customAlphabet } from 'nanoid'
 import { defineComponent, ref, h, Fragment, type Ref } from 'vue'
 
 import { keepAlive } from '../keep-alive'
+import { inputId } from '../unique-id'
 import { Icon } from './icon'
 
 keepAlive(h, Fragment)
-
-const nanoid = customAlphabet('abcdefg', 8)
 
 type ImageInputProps = {
   src: Ref<string | undefined>
@@ -84,7 +82,8 @@ export const ImageInput = defineComponent<ImageInputProps>({
     const focusLinkInput = ref(false)
     const linkInputRef = ref<HTMLInputElement>()
     const currentLink = ref(src.value ?? '')
-    const uuid = ref(nanoid())
+    const linkId = inputId('milkdown-image-link')
+    const fileInputId = inputId('milkdown-image-upload')
     const hidePlaceholder = ref(src.value?.length !== 0)
     const onEditLink = (e: Event) => {
       const target = e.target as HTMLInputElement
@@ -126,6 +125,7 @@ export const ImageInput = defineComponent<ImageInputProps>({
           <Icon icon={imageIcon} class="image-icon" />
           <div class={clsx('link-importer', focusLinkInput.value && 'focus')}>
             <input
+              id={linkId}
               ref={linkInputRef}
               draggable="true"
               onDragstart={(e) => {
@@ -134,7 +134,6 @@ export const ImageInput = defineComponent<ImageInputProps>({
               }}
               disabled={readonly.value}
               class="link-input-area"
-              name="milkdown-image-link"
               value={currentLink.value}
               onInput={onEditLink}
               onKeydown={onKeydown}
@@ -146,12 +145,12 @@ export const ImageInput = defineComponent<ImageInputProps>({
                 <input
                   disabled={readonly.value}
                   class="hidden"
-                  id={uuid.value}
+                  id={fileInputId}
                   type="file"
                   accept="image/*"
                   onChange={onUploadFile}
                 />
-                <label class="uploader" for={uuid.value}>
+                <label class="uploader" for={fileInputId}>
                   <Icon icon={uploadButton} />
                 </label>
                 <span class="text" onClick={() => linkInputRef.value?.focus()}>

--- a/packages/components/src/__internal__/components/image-input.tsx
+++ b/packages/components/src/__internal__/components/image-input.tsx
@@ -134,6 +134,7 @@ export const ImageInput = defineComponent<ImageInputProps>({
               }}
               disabled={readonly.value}
               class="link-input-area"
+              name="milkdown-image-link"
               value={currentLink.value}
               onInput={onEditLink}
               onKeydown={onKeydown}

--- a/packages/components/src/__internal__/unique-id.ts
+++ b/packages/components/src/__internal__/unique-id.ts
@@ -1,0 +1,13 @@
+import { customAlphabet } from 'nanoid'
+
+// DOM-id-safe random suffix. Kept short since it only needs to
+// disambiguate internal inputs within a single page.
+const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 8)
+
+// Create a unique id for an internal input element, so host pages pass
+// Chrome's "A form field element should have an id or name attribute"
+// audit. We use `id` rather than a shared `name` so these inputs do not
+// leak into host `<form>` submissions when the editor is embedded.
+export function inputId(prefix: string): string {
+  return `${prefix}-${nanoid()}`
+}

--- a/packages/components/src/code-block/view/components/language-picker.tsx
+++ b/packages/components/src/code-block/view/components/language-picker.tsx
@@ -168,6 +168,7 @@ export const LanguagePicker = defineComponent<LanguagePickerProps>({
                   <input
                     ref={searchRef}
                     class="search-input"
+                    name="milkdown-code-language-search"
                     placeholder={config.searchPlaceholder}
                     value={filter.value}
                     onInput={changeFilter}

--- a/packages/components/src/code-block/view/components/language-picker.tsx
+++ b/packages/components/src/code-block/view/components/language-picker.tsx
@@ -15,6 +15,7 @@ import type { CodeBlockProps } from './code-block'
 
 import { Icon } from '../../../__internal__/components/icon'
 import { keepAlive } from '../../../__internal__/keep-alive'
+import { inputId } from '../../../__internal__/unique-id'
 
 keepAlive(h, Fragment)
 
@@ -50,6 +51,7 @@ export const LanguagePicker = defineComponent<LanguagePickerProps>({
     const triggerRef = ref<HTMLButtonElement>()
     const showPicker = ref(false)
     const searchRef = ref<HTMLInputElement>()
+    const searchId = inputId('milkdown-code-language-search')
     const pickerRef = ref<HTMLDivElement>()
     const filter = ref('')
 
@@ -166,9 +168,9 @@ export const LanguagePicker = defineComponent<LanguagePickerProps>({
                     <Icon icon={config.searchIcon} />
                   </div>
                   <input
+                    id={searchId}
                     ref={searchRef}
                     class="search-input"
-                    name="milkdown-code-language-search"
                     placeholder={config.searchPlaceholder}
                     value={filter.value}
                     onInput={changeFilter}

--- a/packages/components/src/image-block/view/components/image-viewer.tsx
+++ b/packages/components/src/image-block/view/components/image-viewer.tsx
@@ -4,6 +4,7 @@ import type { MilkdownImageBlockProps } from './image-block'
 
 import { Icon } from '../../../__internal__/components/icon'
 import { keepAlive } from '../../../__internal__/keep-alive'
+import { inputId } from '../../../__internal__/unique-id'
 import { IMAGE_DATA_TYPE } from '../../schema'
 
 keepAlive(h, Fragment)
@@ -43,6 +44,7 @@ export const ImageViewer = defineComponent<MilkdownImageBlockProps>({
     const imageRef = ref<HTMLImageElement>()
     const resizeHandle = ref<HTMLDivElement>()
     const showCaption = ref(Boolean(caption.value?.length))
+    const captionId = inputId('milkdown-image-caption')
     const timer = ref(0)
 
     const onImageLoad = () => {
@@ -167,13 +169,13 @@ export const ImageViewer = defineComponent<MilkdownImageBlockProps>({
           </div>
           {showCaption.value && (
             <input
+              id={captionId}
               draggable="true"
               onDragstart={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
               }}
               class="caption-input"
-              name="milkdown-image-caption"
               placeholder={config?.captionPlaceholderText}
               onInput={onInputCaption}
               onBlur={onBlurCaption}

--- a/packages/components/src/image-block/view/components/image-viewer.tsx
+++ b/packages/components/src/image-block/view/components/image-viewer.tsx
@@ -173,6 +173,7 @@ export const ImageViewer = defineComponent<MilkdownImageBlockProps>({
                 e.stopPropagation()
               }}
               class="caption-input"
+              name="milkdown-image-caption"
               placeholder={config?.captionPlaceholderText}
               onInput={onInputCaption}
               onBlur={onBlurCaption}

--- a/packages/components/src/link-tooltip/edit/component.tsx
+++ b/packages/components/src/link-tooltip/edit/component.tsx
@@ -4,6 +4,7 @@ import type { LinkTooltipConfig } from '../slices'
 
 import { Icon } from '../../__internal__/components/icon'
 import { keepAlive } from '../../__internal__/keep-alive'
+import { inputId } from '../../__internal__/unique-id'
 
 keepAlive(h)
 
@@ -35,6 +36,7 @@ export const EditLink = defineComponent<EditLinkProps>({
   },
   setup({ config, src, onConfirm, onCancel }) {
     const link = ref(src)
+    const id = inputId('milkdown-link-edit')
 
     watch(src, (value) => {
       link.value = value
@@ -60,8 +62,8 @@ export const EditLink = defineComponent<EditLinkProps>({
       return (
         <div class="link-edit">
           <input
+            id={id}
             class="input-area"
-            name="milkdown-link-edit"
             placeholder={config.value.inputPlaceholder}
             onKeydown={onKeydown}
             onInput={(e: Event) => {

--- a/packages/components/src/link-tooltip/edit/component.tsx
+++ b/packages/components/src/link-tooltip/edit/component.tsx
@@ -61,6 +61,7 @@ export const EditLink = defineComponent<EditLinkProps>({
         <div class="link-edit">
           <input
             class="input-area"
+            name="milkdown-link-edit"
             placeholder={config.value.inputPlaceholder}
             onKeydown={onKeydown}
             onInput={(e: Event) => {

--- a/packages/crepe/src/feature/ai/instruction-tooltip/component.tsx
+++ b/packages/crepe/src/feature/ai/instruction-tooltip/component.tsx
@@ -95,6 +95,9 @@ export const AIInstructionInput = defineComponent<AIInstructionInputProps>({
     // through the suggestions with the arrow keys.
     const listboxId = `ai-instruction-list-${Math.random().toString(36).slice(2, 9)}`
     const optionId = (idx: number) => `${listboxId}-opt-${idx}`
+    // Unique id so host pages pass Chrome's "form field should have an id or
+    // name" audit, without a shared `name` leaking into host form submissions.
+    const inputId = `ai-instruction-input-${Math.random().toString(36).slice(2, 9)}`
 
     watch(resetSignal, () => {
       inputValue.value = ''
@@ -280,8 +283,8 @@ export const AIInstructionInput = defineComponent<AIInstructionInputProps>({
             </span>
             <input
               ref={inputRef}
+              id={inputId}
               class="ai-instruction-input-field"
-              name="milkdown-ai-instruction"
               role="combobox"
               aria-expanded="true"
               aria-autocomplete="list"

--- a/packages/crepe/src/feature/ai/instruction-tooltip/component.tsx
+++ b/packages/crepe/src/feature/ai/instruction-tooltip/component.tsx
@@ -281,6 +281,7 @@ export const AIInstructionInput = defineComponent<AIInstructionInputProps>({
             <input
               ref={inputRef}
               class="ai-instruction-input-field"
+              name="milkdown-ai-instruction"
               role="combobox"
               aria-expanded="true"
               aria-autocomplete="list"


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2416.

Chrome DevTools reports **"A form field element should have an id or name attribute"** for Crepe's internal input elements. The issue calls out the link-edit input (`.input-area`, placeholder "Paste link...") and the image caption input (`.caption-input`), which are created at editor startup without an `id` or `name`.

This gives every internal text input a **per-instance unique `id`** so host pages pass Chrome's form-field audit without needing the `MutationObserver` workaround described in the issue.

Why `id` and not `name`: a shared `name` would make these internal inputs participate in a host `<form>`'s submission (`FormData`) when the editor is embedded in a form, leaking unexpected fields to integrators (raised in review). Chrome's audit is satisfied by an `id` alone, so `id` avoids that side effect. A *static* `id` isn't safe either — inputs such as the image caption and image link render once per image block, and multiple editors can coexist on a page, so a fixed id would produce duplicates. Ids are therefore generated per component instance as `prefix-<random>`.

Generation is centralized in a small `inputId(prefix)` helper (`packages/components/src/__internal__/unique-id.ts`) using `nanoid`, matching the pattern already used by the image upload `<input type="file">`. The Crepe AI-instruction input reuses the `Math.random()` random-suffix convention already present in that file (no new dependency for `@milkdown/crepe`).

| File | Input | id prefix |
|------|-------|-----------|
| `components/link-tooltip/edit/component.tsx` | link edit (issue) | `milkdown-link-edit` |
| `components/image-block/view/components/image-viewer.tsx` | image caption (issue) | `milkdown-image-caption` |
| `components/__internal__/components/image-input.tsx` | image link | `milkdown-image-link` |
| `components/__internal__/components/image-input.tsx` | image upload (file input) | `milkdown-image-upload` |
| `components/code-block/view/components/language-picker.tsx` | code language search | `milkdown-code-language-search` |
| `crepe/feature/ai/instruction-tooltip/component.tsx` | AI instruction | `ai-instruction-input` |

The image upload `<input type="file">` already had a random `id` (paired with its `<label for>`); that pairing is preserved, with its id generation moved onto the shared `inputId` helper so the whole file uses one mechanism.

## How did you test this change?

- `pnpm test:lint` — 0 warnings / 0 errors
- `tsc --noEmit` on `@milkdown/components` and `@milkdown/crepe` — both exit 0
- pre-commit `oxlint` + `oxfmt` pass
