### PR TITLE
fix: mount inner view in latex inline tooltip via reactive innerView.value

### DIFF
--- a/packages/crepe/src/feature/latex/inline-tooltip/component.tsx
+++ b/packages/crepe/src/feature/latex/inline-tooltip/component.tsx
@@ -48,7 +48,7 @@ export const LatexTooltip = defineComponent<LatexTooltipProps>({
     return () => {
       return (
         <div class="container">
-          {props.innerView && <div ref={innerViewRef} />}
+          {props.innerView.value && <div ref={innerViewRef} />}
           <button type="button" onPointerdown={onUpdate}>
             <Icon icon={props.config.inlineEditConfirm} />
           </button>


### PR DESCRIPTION
## Summary

Fixes the LaTeX inline tooltip not mounting its inner editing view, so selecting an inline math node showed only the confirm button.

In `inline-tooltip/component.tsx` the render condition checked `props.innerView` — the `ShallowRef` object itself, which is always truthy — instead of `props.innerView.value`. This caused two problems:

1. **Always-truthy condition:** the guard never actually reflected whether an inner `EditorView` existed.
2. **Missing reactive dependency:** because the render function only accessed the ref object and never `.value`, Vue never tracked `innerView.value` as a dependency. When `view.ts` set `this.#innerView.value` to the newly created inner `EditorView`, no re-render was triggered, the `ref` callback was never re-invoked, and the inner view's DOM was never appended.

Checking `.value` fixes both: the dependency is tracked, so the `<div>` is created (and the `ref` callback appends the inner view's DOM) when a math node is selected, and removed again when the tooltip hides.

## Reproduction (before this PR)

1. Enable the `CodeMirror` and `Latex` features in Crepe.
2. Insert an inline math node, e.g. `$a^2 + b^2 = c^2$`.
3. Click the node to open the inline tooltip.
4. Only the confirm button appears — the inline LaTeX editor is missing.

Fixes #2408
