### PR TITLE
feat(crepe): allow configuring slash menu root and floating options

### DIFF
--- a/packages/crepe/src/feature/block-edit/index.ts
+++ b/packages/crepe/src/feature/block-edit/index.ts
@@ -1,3 +1,5 @@
+import type { SlashProviderOptions } from '@milkdown/kit/plugin/slash'
+
 import { block, type BlockProviderOptions } from '@milkdown/kit/plugin/block'
 
 import type { DeepPartial } from '../../utils'
@@ -24,6 +26,11 @@ interface BlockEditConfig {
     | 'middleware'
     | 'floatingUIOptions'
     | 'root'
+  >
+
+  slashMenu: Pick<
+    SlashProviderOptions,
+    'root' | 'offset' | 'middleware' | 'floatingUIOptions'
   >
 
   textGroup: {

--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -1,7 +1,11 @@
 import type { Ctx } from '@milkdown/kit/ctx'
 import type { EditorView } from '@milkdown/kit/prose/view'
 
-import { SlashProvider, slashFactory } from '@milkdown/kit/plugin/slash'
+import {
+  SlashProvider,
+  slashFactory,
+  type SlashProviderOptions,
+} from '@milkdown/kit/plugin/slash'
 import {
   TextSelection,
   type PluginView,
@@ -112,6 +116,7 @@ class MenuView implements PluginView {
         return true
       },
       offset: 10,
+      ...((config?.slashMenu ?? {}) as Partial<SlashProviderOptions>),
     })
 
     this.#slashProvider.onShow = () => {

--- a/packages/crepe/src/feature/block-edit/menu/index.ts
+++ b/packages/crepe/src/feature/block-edit/menu/index.ts
@@ -70,6 +70,8 @@ class MenuView implements PluginView {
     this.#content = content
     // oxlint-disable-next-line ts/no-this-alias
     const self = this
+    const slashMenuOptions = (config?.slashMenu ??
+      {}) as Partial<SlashProviderOptions>
     this.#slashProvider = new SlashProvider({
       content: this.#content,
       debounce: 20,
@@ -115,8 +117,10 @@ class MenuView implements PluginView {
 
         return true
       },
-      offset: 10,
-      ...((config?.slashMenu ?? {}) as Partial<SlashProviderOptions>),
+      offset: slashMenuOptions.offset ?? 10,
+      middleware: slashMenuOptions.middleware,
+      floatingUIOptions: slashMenuOptions.floatingUIOptions,
+      root: slashMenuOptions.root,
     })
 
     this.#slashProvider.onShow = () => {


### PR DESCRIPTION
## Summary

Fixes #2401.

When a Crepe editor is placed inside a `position: fixed` container (e.g. a sidebar drawer), the slash (`/`) menu gets trapped in that CSS stacking context and can render **behind** other fixed elements such as a top navigation bar.

The underlying `SlashProvider` (`@milkdown/plugin-slash`) already accepts a `root` option and appends the menu to `root ?? view.dom.parentElement ?? document.body`. However, the Crepe `block-edit` feature never forwarded any option to it — unlike `blockHandle`, which already exposes `root` and other floating options.

This PR exposes a `slashMenu` config on the block-edit feature that forwards `root`, `offset`, `middleware` and `floatingUIOptions` to the `SlashProvider`, mirroring the existing `blockHandle` option. Users can now teleport the slash menu to `document.body` (or any element) so it always renders on top.

## Changes

- `packages/crepe/src/feature/block-edit/index.ts`: add a `slashMenu` field to `BlockEditConfig`, picking `root | offset | middleware | floatingUIOptions` from `SlashProviderOptions` (parallel to the existing `blockHandle` pick).
- `packages/crepe/src/feature/block-edit/menu/index.ts`: forward `config.slashMenu` into the `new SlashProvider({ ... })` call.

No changes needed in `@milkdown/plugin-slash` — the `root` plumbing already exists there.

## Usage

```ts
new Crepe({
  root,
  features: { [Crepe.Feature.BlockEdit]: true },
  featureConfigs: {
    [Crepe.Feature.BlockEdit]: {
      slashMenu: {
        root: document.body,
      },
    },
  },
})
```

## Verification

- `tsc -b packages/crepe/tsconfig.json` passes with no errors.
- `oxlint` clean on both changed files.