### PR TITLE
refactor(crepe): forward block handle options explicitly

### DIFF
--- a/packages/crepe/src/feature/block-edit/handle/index.ts
+++ b/packages/crepe/src/feature/block-edit/handle/index.ts
@@ -37,31 +37,38 @@ class BlockHandleView implements PluginView {
     app.mount(content)
     this.#app = app
     this.#content = content
-    const blockProviderOptions = config?.blockHandle ?? {}
+    const blockProviderOptions = (config?.blockHandle ??
+      {}) as Partial<BlockProviderOptions>
     this.#provider = new BlockProvider({
       ctx,
       content,
-      getOffset: () => 16,
-      getPlacement: ({ active, blockDom }) => {
-        if (active.node.type.name === 'heading') return 'left'
+      getOffset: blockProviderOptions.getOffset ?? (() => 16),
+      getPlacement:
+        blockProviderOptions.getPlacement ??
+        (({ active, blockDom }) => {
+          if (active.node.type.name === 'heading') return 'left'
 
-        let totalDescendant = 0
-        active.node.descendants((node) => {
-          totalDescendant += node.childCount
-        })
-        const dom = active.el
-        const domRect = dom.getBoundingClientRect()
-        const handleRect = blockDom.getBoundingClientRect()
-        const style = window.getComputedStyle(dom)
-        const paddingTop = Number.parseInt(style.paddingTop, 10) || 0
-        const paddingBottom = Number.parseInt(style.paddingBottom, 10) || 0
-        const height = domRect.height - paddingTop - paddingBottom
-        const handleHeight = handleRect.height
-        return totalDescendant > 2 || handleHeight < height
-          ? 'left-start'
-          : 'left'
-      },
-      ...(blockProviderOptions as Partial<BlockProviderOptions>),
+          let totalDescendant = 0
+          active.node.descendants((node) => {
+            totalDescendant += node.childCount
+          })
+          const dom = active.el
+          const domRect = dom.getBoundingClientRect()
+          const handleRect = blockDom.getBoundingClientRect()
+          const style = window.getComputedStyle(dom)
+          const paddingTop = Number.parseInt(style.paddingTop, 10) || 0
+          const paddingBottom = Number.parseInt(style.paddingBottom, 10) || 0
+          const height = domRect.height - paddingTop - paddingBottom
+          const handleHeight = handleRect.height
+          return totalDescendant > 2 || handleHeight < height
+            ? 'left-start'
+            : 'left'
+        }),
+      shouldShow: blockProviderOptions.shouldShow,
+      getPosition: blockProviderOptions.getPosition,
+      middleware: blockProviderOptions.middleware,
+      floatingUIOptions: blockProviderOptions.floatingUIOptions,
+      root: blockProviderOptions.root,
     })
     this.update()
   }


### PR DESCRIPTION
## Summary

Follow-up to the review discussion on #2426.

The `blockHandle` config was spread wholesale into `BlockProvider`:

```ts
const blockProviderOptions = config?.blockHandle ?? {}
new BlockProvider({
  ctx,
  content,
  getOffset: () => 16,
  getPlacement: (...) => { ... },
  ...(blockProviderOptions as Partial<BlockProviderOptions>),
})
```

Even though `BlockEditConfig` only types `blockHandle` as `Pick<BlockProviderOptions, 'shouldShow' | 'getOffset' | 'getPosition' | 'getPlacement' | 'middleware' | 'floatingUIOptions' | 'root'>`, the spread offers no runtime protection: a JS consumer (or `as any`) could pass e.g. `ctx` or `content` and clobber the required internal options.

This PR forwards only the intended fields explicitly, matching the approach used by the slash menu in #2426. `ctx` and `content` are now locked to their internal values, and the default `getOffset` / `getPlacement` are preserved unless the user provides their own.

## Behavior

No behavior change for existing consumers:
- Fields not supplied by the user fall back exactly as before (`getOffset` → `() => 16`, `getPlacement` → the internal heuristic).
- User-supplied `getOffset` / `getPlacement` still override the defaults via `??`.
- `BlockProvider` already normalizes `undefined` for every optional field (`middleware ?? []`, `floatingUIOptions ?? {}`, etc.), so passing `undefined` is equivalent to omitting.

## Verification

- `tsc -b packages/crepe/tsconfig.json` passes with no errors.
- `oxlint` clean on the changed file.