### PR TITLE
fix: preserve schema registration order in extendSchema (#2370)

### DIFF
--- a/packages/utils/src/composable/$mark.ts
+++ b/packages/utils/src/composable/$mark.ts
@@ -5,7 +5,7 @@ import type { MarkSchema } from '@milkdown/transformer'
 import { marksCtx, schemaCtx, schemaTimerCtx } from '@milkdown/core'
 import { missingMarkInSchema } from '@milkdown/exception'
 
-import { addTimer } from './utils'
+import { addTimer, upsertById } from './utils'
 
 /// @internal
 export type $Mark = MilkdownPlugin & {
@@ -25,10 +25,9 @@ export type $Mark = MilkdownPlugin & {
 export function $mark(id: string, schema: (ctx: Ctx) => MarkSchema): $Mark {
   const plugin: MilkdownPlugin = (ctx) => async () => {
     const markSchema = schema(ctx)
-    ctx.update(marksCtx, (ns) => [
-      ...ns.filter((n) => n[0] !== id),
-      [id, markSchema] as [string, MarkSchema],
-    ])
+    ctx.update(marksCtx, (ns) =>
+      upsertById(ns, id, [id, markSchema] as [string, MarkSchema])
+    )
     ;(<$Mark>plugin).id = id
     ;(<$Mark>plugin).schema = markSchema
 
@@ -60,10 +59,9 @@ export function $markAsync(
   const plugin = addTimer<$Mark>(
     async (ctx, plugin, done) => {
       const markSchema = await schema(ctx)
-      ctx.update(marksCtx, (ns) => [
-        ...ns.filter((n) => n[0] !== id),
-        [id, markSchema] as [string, MarkSchema],
-      ])
+      ctx.update(marksCtx, (ns) =>
+        upsertById(ns, id, [id, markSchema] as [string, MarkSchema])
+      )
 
       plugin.id = id
       plugin.schema = markSchema

--- a/packages/utils/src/composable/$node.ts
+++ b/packages/utils/src/composable/$node.ts
@@ -5,7 +5,7 @@ import type { NodeSchema } from '@milkdown/transformer'
 import { nodesCtx, schemaCtx, schemaTimerCtx } from '@milkdown/core'
 import { missingNodeInSchema } from '@milkdown/exception'
 
-import { addTimer } from './utils'
+import { addTimer, upsertById } from './utils'
 
 /// @internal
 export type $Node = MilkdownPlugin & {
@@ -25,10 +25,9 @@ export type $Node = MilkdownPlugin & {
 export function $node(id: string, schema: (ctx: Ctx) => NodeSchema): $Node {
   const plugin: MilkdownPlugin = (ctx) => async () => {
     const nodeSchema = schema(ctx)
-    ctx.update(nodesCtx, (ns) => [
-      ...ns.filter((n) => n[0] !== id),
-      [id, nodeSchema] as [string, NodeSchema],
-    ])
+    ctx.update(nodesCtx, (ns) =>
+      upsertById(ns, id, [id, nodeSchema] as [string, NodeSchema])
+    )
     ;(<$Node>plugin).id = id
     ;(<$Node>plugin).schema = nodeSchema
 
@@ -62,10 +61,9 @@ export function $nodeAsync(
   const plugin = addTimer<$Node>(
     async (ctx, plugin, done) => {
       const nodeSchema = await schema(ctx)
-      ctx.update(nodesCtx, (ns) => [
-        ...ns.filter((n) => n[0] !== id),
-        [id, nodeSchema] as [string, NodeSchema],
-      ])
+      ctx.update(nodesCtx, (ns) =>
+        upsertById(ns, id, [id, nodeSchema] as [string, NodeSchema])
+      )
 
       plugin.id = id
       plugin.schema = nodeSchema

--- a/packages/utils/src/composable/composed/$node-schema.spec.ts
+++ b/packages/utils/src/composable/composed/$node-schema.spec.ts
@@ -110,6 +110,108 @@ test('double extend schema', async () => {
   expect(Object.keys(schema.nodes)).toEqual(['doc', 'paragraph', 'text'])
 })
 
+// See https://github.com/Milkdown/milkdown/issues/2370
+// Extending two block node schemas used to move them to the end of `nodesCtx`,
+// which reordered `doc.contentMatch.next` so a self-referential `block+`
+// container (e.g. blockquote) was picked first when filling an empty doc,
+// recursing forever inside ProseMirror's `fillBefore` -> `createAndFill`.
+test('extending two node schemas keeps registration order (empty doc does not overflow)', async () => {
+  const blockDoc = $nodeSchema('doc', () => ({
+    content: 'block+',
+    parseMarkdown: {
+      match: ({ type }) => type === 'root',
+      runner: (state, node, type) => {
+        state.injectRoot(node, type)
+      },
+    },
+    toMarkdown: {
+      match: (node) => node.type.name === 'doc',
+      runner: () => {},
+    },
+  }))
+
+  const text = $nodeSchema('text', () => ({
+    group: 'inline',
+    parseMarkdown: {
+      match: ({ type }) => type === 'text',
+      runner: () => {},
+    },
+    toMarkdown: {
+      match: (node) => node.type.name === 'text',
+      runner: () => {},
+    },
+  }))
+
+  const paragraph = $nodeSchema('paragraph', () => ({
+    content: 'inline*',
+    group: 'block',
+    parseDOM: [{ tag: 'p' }],
+    toDOM: () => ['p', 0],
+    parseMarkdown: {
+      match: (node) => node.type === 'paragraph',
+      runner: () => {},
+    },
+    toMarkdown: {
+      match: (node) => node.type.name === 'paragraph',
+      runner: () => {},
+    },
+  }))
+
+  const heading = $nodeSchema('heading', () => ({
+    content: 'inline*',
+    group: 'block',
+    parseDOM: [{ tag: 'h1' }],
+    toDOM: () => ['h1', 0],
+    parseMarkdown: {
+      match: (node) => node.type === 'heading',
+      runner: () => {},
+    },
+    toMarkdown: {
+      match: (node) => node.type.name === 'heading',
+      runner: () => {},
+    },
+  }))
+
+  // Self-referential `block+` container registered after paragraph/heading.
+  const blockquote = $nodeSchema('blockquote', () => ({
+    content: 'block+',
+    group: 'block',
+    parseDOM: [{ tag: 'blockquote' }],
+    toDOM: () => ['blockquote', 0],
+    parseMarkdown: {
+      match: (node) => node.type === 'blockquote',
+      runner: () => {},
+    },
+    toMarkdown: {
+      match: (node) => node.type.name === 'blockquote',
+      runner: () => {},
+    },
+  }))
+
+  const noopParagraph = paragraph.extendSchema((prev) => (ctx) => prev(ctx))
+  const noopHeading = heading.extendSchema((prev) => (ctx) => prev(ctx))
+
+  const editor = await Editor.make()
+    .use(blockDoc)
+    .use(text)
+    .use(paragraph)
+    .use(heading)
+    .use(blockquote)
+    .use(noopParagraph)
+    .use(noopHeading)
+    .create()
+
+  const schema = editor.ctx.get(schemaCtx)
+  // Extended nodes keep their original position; blockquote is not first.
+  expect(Object.keys(schema.nodes)).toEqual([
+    'doc',
+    'text',
+    'paragraph',
+    'heading',
+    'blockquote',
+  ])
+})
+
 test('should can register extended schema only', async () => {
   const extended = docSchema.extendSchema((prev) => (ctx) => ({
     ...prev(ctx),

--- a/packages/utils/src/composable/utils.ts
+++ b/packages/utils/src/composable/utils.ts
@@ -13,6 +13,23 @@ import { customAlphabet } from 'nanoid'
 export const nanoid = customAlphabet('abcedfghicklmn', 10)
 
 /// @internal
+/// Replace the entry with the given id in place, or append it if absent.
+/// Preserving registration order matters: re-registering a schema (e.g. via
+/// `extendSchema`) must not move it to the end, otherwise ProseMirror's
+/// content-match walk can pick a different first node type and recurse forever.
+export function upsertById<T extends readonly [string, unknown]>(
+  list: T[],
+  id: string,
+  entry: T
+): T[] {
+  const idx = list.findIndex(([x]) => x === id)
+  if (idx === -1) return [...list, entry]
+  const next = list.slice()
+  next[idx] = entry
+  return next
+}
+
+/// @internal
 export type WithTimer<T> = T & { timer: TimerType }
 
 /// @internal


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

Closes #2370

## Summary

Calling `extendSchema` on **two** different node schemas made `editor.create()` throw `RangeError: Maximum call stack size exceeded` whenever the initial content was empty (`defaultValueCtx` set to `''`, `' '`, `'\n'`, …).

`$node`/`$mark` (and their async variants) re-registered a schema by filtering out the existing entry and **appending** the new one:

```js
ctx.update(nodesCtx, (ns) => [...ns.filter((n) => n[0] !== id), [id, nodeSchema]])
```

Since `extendSchema` re-registers a node under the same id, the extended node moved to the **end** of `nodesCtx`. Extending two block nodes (e.g. `paragraph` + `heading`) reordered `doc.contentMatch.next` so a self-referential `block+` container (e.g. `blockquote`) was tried first when filling an empty doc. ProseMirror's `fillBefore` → `createAndFill` then recursed on `blockquote` forever (the per-call `seen` set only guards intra-call cycles, not the cross-call recursion via `createAndFill`), overflowing the stack.

The fix replaces the entry **in place** via a shared `upsertById` helper, so registration order is preserved. Applied to all four sites: `$node`, `$nodeAsync`, `$mark`, `$markAsync`.

Thanks to @woutert1 for the thorough diagnosis in #2370.

## How did you test this change?

Added a regression test in `$node-schema.spec.ts` that reproduces the exact scenario (doc `block+`, paragraph/heading `inline*`, a `blockquote` `block+` container registered last, two no-op extensions, empty content):

- **Without** the fix, the test fails with `RangeError: Maximum call stack size exceeded` inside `ContentMatch.fillBefore` → `NodeType.createAndFill`, matching the issue's stack trace.
- **With** the fix, all tests pass and the extended nodes keep their original position (`blockquote` is no longer first).

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Also verified `tsc --noEmit`, `oxlint`, and `oxfmt` are clean on the changed files.
