### PR TITLE
chore: hold renovate updates until they pass pnpm minimum release age

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,8 @@
     "group:all",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {


### PR DESCRIPTION
## Problem

Renovate PRs intermittently fail CI at the `pnpm install` step, not because the lockfile is stale but because pnpm 11's `minimumReleaseAge` supply-chain policy rejects entries for versions published too recently.

Example from #2407 (`install-deps` job):

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  pkg-pr-new@0.0.82 was published at 2026-07-28T16:44:40.509Z,
  within the minimumReleaseAge cutoff (2026-07-27T19:40:43.925Z)
```

pnpm's cutoff is 24h. Renovate opens PRs as soon as a new version is published, so it can propose a version that is still "too fresh" for pnpm, and CI (`pnpm install` runs frozen in CI) rejects the resulting lockfile.

## Fix

Gate Renovate on release age so it never proposes a version younger than pnpm's policy:

- `minimumReleaseAge: "3 days"` — comfortably above pnpm's 24h cutoff (margin for the fact that Renovate measures age at branch-creation time while pnpm measures at CI-run time).
- `internalChecksFilter: "strict"` — actually holds young updates out of branches. With `group:all`, only the too-fresh member (e.g. `pkg-pr-new`) is deferred to a later run while the rest of the group proceeds.

Fast-moving dev tooling like `pkg-pr-new` is the usual offender; this makes it self-resolve without per-package rules.