### PR TITLE
ci(e2e): cache Playwright browsers and merge shard reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,34 @@ jobs:
           ./packages/kit
           ./packages/crepe
 
-  e2e:
+  cache-browsers:
+    # Download Playwright browser binaries once and populate the cache before the
+    # e2e shards start, so the shards restore instead of each downloading in parallel.
     runs-on: ubuntu-latest
     needs: install-deps
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      # Binaries only; system libraries are per-runner and re-installed in each shard.
+      - name: Download browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter=@milkdown/e2e exec playwright install
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: cache-browsers
     strategy:
       fail-fast: false
       matrix:
@@ -168,7 +193,7 @@ jobs:
 
   summary:
     if: ${{ always() }}
-    needs: [lint, unit, e2e, build]
+    needs: [install-deps, cache-browsers, lint, unit, e2e, build]
     runs-on: ubuntu-latest
     steps:
       - name: On error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,31 @@ jobs:
           pnpm --filter=@milkdown/prose run build
           pnpm --filter=@milkdown/e2e run build
 
-      - name: Install browsers
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install browsers and system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter=@milkdown/e2e test:install
+
+      - name: Install browser system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter=@milkdown/e2e exec playwright install-deps
 
       - name: Run playwright
         run: pnpm test:e2e --forbid-only --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: e2e/blob-report/
+          retention-days: 7
 
       - name: Upload test results
         if: ${{ failure() }}
@@ -114,6 +134,37 @@ jobs:
           name: test-results-e2e-${{ matrix.shard }}
           path: e2e/test-results/
           retention-days: 7
+
+  merge-reports:
+    # Merge shard blob reports into one HTML report. Runs even if some shards failed,
+    # but not on cancellation. Report-only: does not gate the `summary` status.
+    if: ${{ !cancelled() }}
+    needs: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Download blob reports
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: e2e/all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge blob reports into HTML report
+        run: pnpm --filter=@milkdown/e2e exec playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-html-report
+          path: e2e/playwright-report/
+          retention-days: 14
 
   summary:
     if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist
 dist-ssr
 coverage
 test-results
+blob-report
+all-blob-reports
+playwright-report
 .pnpm-store
 .npmrc
 tsconfig.tsbuildinfo

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -18,10 +18,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests */
-  workers: 1,
+  /* Use 2 workers per shard on CI to make use of multiple cores; keep serial locally */
+  workers: process.env.CI ? 2 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'dot' : 'list',
+  /* On CI: blob reports are merged into a single HTML report, github reporter adds inline annotations */
+  reporter: process.env.CI ? [['blob'], ['github']] : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Optimizes the Playwright e2e CI job, following the ideas in [this guide](https://endform.dev/blog/playwright-github-actions).

**Motivation:** every e2e run spawned 5 shards, and each shard re-downloaded Chromium/Firefox/WebKit from scratch, while each shard runner ran tests on a single worker leaving cores idle. There was also no unified test report across shards.

### What changed

- **Cache browser binaries** — Adds `actions/cache` for `~/.cache/ms-playwright`, keyed on `pnpm-lock.yaml`. A dedicated `cache-browsers` job (`needs: install-deps`) downloads the browser binaries **once** and populates the cache before the e2e shards start, so on a cache miss the 5 shards no longer each download browsers in parallel. Each shard then restores from the cache and only installs the per-runner system libraries (`playwright install-deps`); a full `--with-deps` install remains as a self-healing fallback if the cache is somehow absent.
- **Keep CI honest** — Adds `install-deps` and `cache-browsers` to the `summary` job's `needs`, so a failure in either propagates instead of skipping e2e and leaving the build green.
- **Use multiple cores** — Sets `workers: 2` per shard on CI (kept serial locally).
- **Better reports** — On CI, Playwright now emits `blob` + `github` reporters. Per-shard blob reports are uploaded, and a new `merge-reports` job combines them into a single HTML report. The `github` reporter also surfaces failures as inline PR annotations without downloading artifacts.
- **Ignore report output** — Adds `blob-report`, `all-blob-reports`, and `playwright-report` to `.gitignore`.

### Notes / trade-offs

- `merge-reports` runs with `if: !cancelled()` and does not gate the `summary` status — it is report-only, so a report-generation failure won't fail CI.
- `workers: 2` introduces some risk of parallel-execution flakiness (e.g. clipboard/focus). The existing `retries: 2` should absorb transient flakes; if a suite proves unstable it can be reverted to `workers: 1` independently of the other changes.
- PRs still run all three browsers (full coverage retained). Running Chromium-only on PRs was considered but left out for now.

## How did you test this change?

- `ci.yml` validated as well-formed YAML.
- Playwright config parsed in CI mode (`CI=1 playwright test --list`): 537 tests across 50 files in chromium/firefox/webkit, and the `github` reporter was confirmed active (emitted a `::notice` annotation).
- Pinned action SHAs verified against their tags: `actions/cache` `0057852…` = v4.3.0, `actions/download-artifact` `37930b1…` = v7.0.0.
- Full effect (cache hit/miss timing, merged HTML report) will be observable on this PR's CI run.
