### PR TITLE
feat(crepe): add --crepe-base-font-size theme variable

### DIFF
--- a/docs/api/crepe.md
+++ b/docs/api/crepe.md
@@ -1050,6 +1050,21 @@ import '@milkdown/crepe/theme/nord-dark.css'
 import '@milkdown/crepe/theme/frame-dark.css'
 ```
 
+### Customizing theme variables
+
+Every theme exposes CSS custom properties on the `.milkdown` element, so you can
+override them without touching the source. For example, to scale the whole editor's
+font size (default `16px`) in a single line:
+
+```css
+.milkdown {
+  --crepe-base-font-size: 14px;
+}
+```
+
+Other variables follow the same pattern, e.g. `--crepe-font-default`,
+`--crepe-font-title`, `--crepe-font-code` and the `--crepe-color-*` palette.
+
 ## API Reference
 
 @CrepeFeature

--- a/packages/crepe/src/theme/common/ai.css
+++ b/packages/crepe/src/theme/common/ai.css
@@ -19,7 +19,7 @@
   border-radius: 12px;
   box-shadow: var(--crepe-shadow-2);
   font-family: var(--crepe-font-default);
-  font-size: 14px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
   color: var(--crepe-color-on-background);
   overflow: hidden;
 }
@@ -57,7 +57,7 @@
   border: none;
   background: transparent;
   font-family: inherit;
-  font-size: 14px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
   line-height: 20px;
   color: var(--crepe-color-on-background);
   padding: 4px 0;
@@ -120,7 +120,7 @@
   padding: 6px 12px 4px;
   cursor: pointer;
   color: var(--crepe-color-outline);
-  font-size: 12px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.75);
   font-weight: 500;
   user-select: none;
 }
@@ -146,7 +146,7 @@
 
 .milkdown .ai-instruction-section-header {
   padding: 6px 16px 4px;
-  font-size: 11px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.6875);
   font-weight: 600;
   letter-spacing: 0.08em;
   color: var(--crepe-color-outline);
@@ -187,7 +187,7 @@
 
 .milkdown .ai-instruction-item-label {
   flex: 1;
-  font-size: 14px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
   line-height: 20px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -277,14 +277,14 @@
 }
 
 .milkdown .milkdown-ai-streaming-label {
-  font-size: 13px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.8125);
   line-height: 18px;
   color: var(--crepe-color-on-background);
 }
 
 .milkdown .milkdown-ai-streaming-esc {
   font-family: var(--crepe-font-code, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.6875);
   line-height: 1;
   padding: 4px 8px;
   border-radius: 999px;
@@ -327,7 +327,7 @@
   border-radius: 999px;
   background: transparent;
   font-family: inherit;
-  font-size: 13px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.8125);
   font-weight: 500;
   line-height: 1;
   color: var(--crepe-color-on-background);
@@ -414,7 +414,7 @@
     transparent
   );
   font-family: var(--crepe-font-code, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: calc(var(--crepe-base-font-size, 16px) * 0.6875);
   color: inherit;
 }
 

--- a/packages/crepe/src/theme/common/block-edit.css
+++ b/packages/crepe/src/theme/common/block-edit.css
@@ -68,7 +68,7 @@
 
         li {
           padding: 6px 10px;
-          font-size: 14px;
+          font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
           font-style: normal;
           font-weight: 600;
           line-height: 20px;
@@ -91,7 +91,7 @@
 
       .menu-group {
         h6 {
-          font-size: 14px;
+          font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
           font-style: normal;
           font-weight: 600;
           line-height: 20px;
@@ -125,7 +125,7 @@
             fill: var(--crepe-color-outline);
           }
           & > span {
-            font-size: 14px;
+            font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
             font-style: normal;
             font-weight: 600;
             line-height: 20px;

--- a/packages/crepe/src/theme/common/code-mirror.css
+++ b/packages/crepe/src/theme/common/code-mirror.css
@@ -25,7 +25,7 @@
       margin: 0;
       padding: 4px 0;
       font-family: var(--crepe-font-code, monospace);
-      font-size: 14px;
+      font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
       line-height: 1.5;
       white-space: pre-wrap;
       word-break: break-all;
@@ -125,7 +125,7 @@
           opacity: 0;
           cursor: pointer;
           border-radius: 4px;
-          font-size: 12px;
+          font-size: calc(var(--crepe-base-font-size, 16px) * 0.75);
           line-height: 16px;
           font-weight: 600;
           font-family: var(--crepe-font-default);
@@ -162,7 +162,7 @@
         background: var(--crepe-color-surface-low);
         color: var(--crepe-color-on-surface-variant);
         border-radius: 4px;
-        font-size: 12px;
+        font-size: calc(var(--crepe-base-font-size, 16px) * 0.75);
         font-weight: 600;
         line-height: 16px;
         margin-bottom: 8px;
@@ -231,7 +231,7 @@
       align-items: center;
       gap: 8px;
       padding: 4px 22px;
-      font-size: 14px;
+      font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
       font-weight: 600;
       line-height: 20px;
 
@@ -298,7 +298,7 @@
 
       input {
         font-family: var(--crepe-font-default);
-        font-size: 14px;
+        font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
         line-height: 20px;
         background: transparent;
       }
@@ -318,7 +318,7 @@
 
       .preview-label {
         margin: 6px 0;
-        font-size: 12px;
+        font-size: calc(var(--crepe-base-font-size, 16px) * 0.75);
         color: color-mix(
           in srgb,
           var(--crepe-color-on-surface),

--- a/packages/crepe/src/theme/common/diff.css
+++ b/packages/crepe/src/theme/common/diff.css
@@ -116,7 +116,7 @@
       border-radius: 4px;
       padding: 8px 12px;
       font-family: var(--crepe-font-code);
-      font-size: 13px;
+      font-size: calc(var(--crepe-base-font-size, 16px) * 0.8125);
       overflow-x: auto;
       display: block;
       white-space: pre;
@@ -133,7 +133,7 @@
 
     button {
       font-family: var(--crepe-font-default);
-      font-size: 11px;
+      font-size: calc(var(--crepe-base-font-size, 16px) * 0.6875);
       line-height: 1;
       padding: 2px 6px;
       border-radius: 3px;

--- a/packages/crepe/src/theme/common/image-block.css
+++ b/packages/crepe/src/theme/common/image-block.css
@@ -72,7 +72,7 @@
       background: var(--crepe-color-surface);
       font-family: var(--crepe-font-default);
       border-radius: 8px;
-      font-size: 16px;
+      font-size: var(--crepe-base-font-size, 16px);
     }
 
     .empty-image-inline .image-icon {
@@ -385,7 +385,7 @@
       line-height: 40px;
       padding: 0 24px;
       border-radius: 100px;
-      font-size: 14px;
+      font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
       font-weight: 600;
       &:hover {
         background:

--- a/packages/crepe/src/theme/common/link-tooltip.css
+++ b/packages/crepe/src/theme/common/link-tooltip.css
@@ -45,7 +45,7 @@
         line-height: 24px;
         overflow: hidden;
         text-overflow: ellipsis;
-        font-size: 14px;
+        font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
         white-space: nowrap;
         &:hover {
           text-decoration: underline;
@@ -89,7 +89,7 @@
         outline: none;
         background: transparent;
         width: 200px;
-        font-size: 14px;
+        font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
         color: var(--crepe-color-on-background);
       }
 
@@ -103,7 +103,7 @@
         padding: 3px;
         cursor: pointer;
         border-radius: 8px;
-        font-size: 12px;
+        font-size: calc(var(--crepe-base-font-size, 16px) * 0.75);
         line-height: 24px;
         &:hover {
           background: var(--crepe-color-hover);

--- a/packages/crepe/src/theme/common/reset.css
+++ b/packages/crepe/src/theme/common/reset.css
@@ -22,6 +22,7 @@
   }
 
   font-family: var(--crepe-font-default);
+  font-size: var(--crepe-base-font-size, 16px);
   color: var(--crepe-color-on-background);
   background: var(--crepe-color-background);
 
@@ -106,45 +107,45 @@
     }
 
     h1 {
-      font-size: 42px;
-      line-height: 50px;
+      font-size: 2.625em;
+      line-height: 1.1905;
       margin-top: 32px;
     }
 
     h2 {
-      font-size: 36px;
-      line-height: 44px;
+      font-size: 2.25em;
+      line-height: 1.2222;
       margin-top: 28px;
     }
 
     h3 {
-      font-size: 32px;
-      line-height: 40px;
+      font-size: 2em;
+      line-height: 1.25;
       margin-top: 24px;
     }
 
     h4 {
-      font-size: 28px;
-      line-height: 36px;
+      font-size: 1.75em;
+      line-height: 1.2857;
       margin-top: 20px;
     }
 
     h5 {
-      font-size: 24px;
-      line-height: 32px;
+      font-size: 1.5em;
+      line-height: 1.3333;
       margin-top: 16px;
     }
 
     h6 {
-      font-size: 18px;
+      font-size: 1.125em;
       font-weight: 700;
-      line-height: 28px;
+      line-height: 1.5556;
       margin-top: 16px;
     }
 
     p {
-      font-size: 16px;
-      line-height: 24px;
+      font-size: 1em;
+      line-height: 1.5;
       padding: 4px 0;
     }
 

--- a/packages/crepe/src/theme/common/table.css
+++ b/packages/crepe/src/theme/common/table.css
@@ -52,7 +52,7 @@
 
     .handle {
       position: absolute;
-      font-size: 14px;
+      font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
       transition: opacity ease-in-out 0.2s;
     }
 

--- a/packages/crepe/src/theme/common/top-bar.css
+++ b/packages/crepe/src/theme/common/top-bar.css
@@ -53,7 +53,7 @@
 
       .top-bar-heading-label {
         font-family: var(--crepe-font-default);
-        font-size: 14px;
+        font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
         font-weight: 600;
         line-height: 20px;
         letter-spacing: 0.1px;
@@ -102,7 +102,7 @@
       border-radius: 4px;
       cursor: pointer;
       font-family: var(--crepe-font-default);
-      font-size: 14px;
+      font-size: calc(var(--crepe-base-font-size, 16px) * 0.875);
       font-weight: 400;
       line-height: 20px;
       color: var(--crepe-color-on-surface);

--- a/packages/crepe/src/theme/crepe-dark/style.css
+++ b/packages/crepe/src/theme/crepe-dark/style.css
@@ -17,6 +17,7 @@
   --crepe-color-selected: #3b342b;
   --crepe-color-inline-area: #3f3830;
 
+  --crepe-base-font-size: 16px;
   --crepe-font-title: Georgia, Cambria, 'Times New Roman', Times, serif;
   --crepe-font-default: 'Open Sans', Arial, Helvetica, sans-serif;
   --crepe-font-code:

--- a/packages/crepe/src/theme/crepe/style.css
+++ b/packages/crepe/src/theme/crepe/style.css
@@ -17,6 +17,7 @@
   --crepe-color-selected: #ede0d4;
   --crepe-color-inline-area: #e4d8cc;
 
+  --crepe-base-font-size: 16px;
   --crepe-font-title: Georgia, Cambria, 'Times New Roman', Times, serif;
   --crepe-font-default: 'Open Sans', Arial, Helvetica, sans-serif;
   --crepe-font-code:

--- a/packages/crepe/src/theme/frame-dark/style.css
+++ b/packages/crepe/src/theme/frame-dark/style.css
@@ -17,6 +17,7 @@
   --crepe-color-selected: #2f2f2f;
   --crepe-color-inline-area: #2b2b2b;
 
+  --crepe-base-font-size: 16px;
   --crepe-font-title: 'Noto Serif', Cambria, 'Times New Roman', Times, serif;
   --crepe-font-default: 'Noto Sans', Arial, Helvetica, sans-serif;
   --crepe-font-code:

--- a/packages/crepe/src/theme/frame/style.css
+++ b/packages/crepe/src/theme/frame/style.css
@@ -17,6 +17,7 @@
   --crepe-color-selected: #d5d5d5;
   --crepe-color-inline-area: #cacaca;
 
+  --crepe-base-font-size: 16px;
   --crepe-font-title: 'Noto Serif', Cambria, 'Times New Roman', Times, serif;
   --crepe-font-default: 'Noto Sans', Arial, Helvetica, sans-serif;
   --crepe-font-code:

--- a/packages/crepe/src/theme/nord-dark/style.css
+++ b/packages/crepe/src/theme/nord-dark/style.css
@@ -17,6 +17,7 @@
   --crepe-color-selected: #32353a;
   --crepe-color-inline-area: #111418;
 
+  --crepe-base-font-size: 16px;
   --crepe-font-title: Rubik, Cambria, 'Times New Roman', Times, serif;
   --crepe-font-default: Inter, Arial, Helvetica, sans-serif;
   --crepe-font-code:

--- a/packages/crepe/src/theme/nord/style.css
+++ b/packages/crepe/src/theme/nord/style.css
@@ -17,6 +17,7 @@
   --crepe-color-selected: #e1e2e8;
   --crepe-color-inline-area: #d8dae0;
 
+  --crepe-base-font-size: 16px;
   --crepe-font-title: Rubik, Cambria, 'Times New Roman', Times, serif;
   --crepe-font-default: Inter, Arial, Helvetica, sans-serif;
   --crepe-font-code:


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Closes #2315.

Crepe's font sizes were hardcoded in px across the theme (`p` = 16px, `h1`–`h6` = 42/36/32/28/24/18px, plus 11–16px in tables, code blocks, tooltips, menus, etc.). Anyone who wanted a different base size — e.g. 14px to match the rest of their app — had to override every rule by hand.

This adds a single `--crepe-base-font-size` custom property (default `16px`) that scales the whole editor in one line:

```css
.milkdown {
  --crepe-base-font-size: 14px;
}
```

How it works:

- The base is anchored on `.milkdown` (next to the existing `font-family: var(--crepe-font-default)`), and declared in every theme so it's discoverable alongside the other `--crepe-font-*` variables.
- **Main content** (`reset.css` `h1`–`h6`, `p`) uses `em` ratios of the base with unitless line-heights, so leading scales with the font.
- **UI chrome** (tables, code-block chrome, tooltips, slash menu, top bar, image block, AI panel, diff controls) uses `calc(var(--crepe-base-font-size, 16px) * <ratio>)` rather than `em`. `em` would be wrong here because it resolves against local context: the `.ai-instruction` panel sets a font-size its children override (so `em` would compound), and `.milkdown-diff-controls` render inline inside headings of varying size (so `em` would balloon). `calc(base * ratio)` is context-independent and reproduces the current pixels exactly at the 16px default.

Default rendering is unchanged — this is purely additive.

## How did you test this change?

`pnpm --filter=@milkdown/crepe build:theme` (PostCSS) passes.

Ran the `crepe` story (`e2e`) and measured computed `font-size` on injected content + chrome at three base values. At the default the values are byte-identical to `main`; changing the variable scales everything proportionally:

| element | default (16px) | `--crepe-base-font-size: 14px` | `: 20px` |
|---|---|---|---|
| h1 | 42px (unchanged) | 36.75px | 52.5px |
| h2 | 36px (unchanged) | 31.5px | 45px |
| h6 | 18px (unchanged) | 15.75px | 22.5px |
| p  | 16px (unchanged) | 14px | 20px |
| top bar / slash menu / link tooltip | 14px (unchanged) | 12.25px | 17.5px |

No `em` compounding (verified the `.ai-instruction` subtree and inline diff controls resolve directly from the base).
