### PR TITLE
fix(preset): anchor mark input rules to the cursor to prevent paste corruption

### DIFF
--- a/packages/plugins/preset-commonmark/src/__test__/paste-special-char.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/paste-special-char.spec.ts
@@ -1,0 +1,126 @@
+import '@testing-library/jest-dom/vitest'
+import { Editor, editorViewCtx } from '@milkdown/core'
+import { getMarkdown } from '@milkdown/utils'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { commonmark } from '..'
+
+// https://github.com/Milkdown/milkdown/issues/2400
+// Pasting text that ends with `_` twice and then pressing Space/Enter used to
+// delete characters: the underscore-emphasis input rule was not anchored to the
+// end of the input (`$`), so its regex matched an `_..._` span *across* the two
+// pastes — a match that did not end at the cursor. prosemirror's input-rule
+// runner assumes the match ends at the cursor when it computes the affected
+// range, so the off-by-one range corrupted the document.
+
+const PASTED = 'This is for qa34%^%^&&&(&(&(&()(*()_'
+
+async function createEditor() {
+  const editor = Editor.make()
+  editor.use(commonmark)
+  await editor.create()
+  return editor
+}
+
+function hasEmphasis(editor: Editor) {
+  const { doc } = editor.ctx.get(editorViewCtx).state
+  let found = false
+  doc.descendants((node) => {
+    if (node.marks.some((mark) => mark.type.name === 'emphasis')) found = true
+  })
+  return found
+}
+
+// Simulate a paste: a single programmatic insertion does not run input rules
+// (those only fire from `handleTextInput` / `handleKeyDown`), exactly like a
+// real clipboard paste.
+function paste(editor: Editor, text: string) {
+  const view = editor.ctx.get(editorViewCtx)
+  view.dispatch(view.state.tr.insertText(text))
+}
+
+describe('pasting special characters (#2400)', () => {
+  it('does not delete characters when pressing Space after two pastes', async () => {
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    paste(editor, PASTED)
+    paste(editor, PASTED)
+
+    const before = view.state.doc.textContent
+    const end = view.state.selection.from
+
+    // This is the exact call prosemirror-view makes when a space is typed.
+    // The trailing `deflt` callback is required by the prop type but unused
+    // by the input-rule plugin.
+    view.someProp('handleTextInput', (f) =>
+      f(view, end, end, ' ', () => view.state.tr)
+    )
+
+    expect(view.state.doc.textContent).toBe(before)
+    expect(hasEmphasis(editor)).toBe(false)
+  })
+
+  it('does not delete characters when pressing Enter after two pastes', async () => {
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    paste(editor, PASTED)
+    paste(editor, PASTED)
+
+    const before = view.state.doc.textContent
+
+    // This is the exact call the custom input-rule plugin makes on Enter.
+    const event = new KeyboardEvent('keydown', { key: 'Enter' })
+    view.someProp('handleKeyDown', (f) => f(view, event))
+
+    expect(view.state.doc.textContent).toBe(before)
+    expect(hasEmphasis(editor)).toBe(false)
+  })
+
+  it('still turns _word_ into emphasis when the closing _ is typed', async () => {
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    paste(editor, '_word')
+
+    const end = view.state.selection.from
+    view.someProp('handleTextInput', (f) =>
+      f(view, end, end, '_', () => view.state.tr)
+    )
+
+    expect(view.state.doc.textContent).toBe('word')
+    expect(hasEmphasis(editor)).toBe(true)
+  })
+})
+
+// The `$` anchor added to the underscore rule must not regress typing the
+// markdown syntax by hand: these mirror the input-rule e2e tests.
+describe('typing underscore emphasis still works', () => {
+  it('creates emphasis when typing _on the grass_', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, 'The lunatic is _on the grass_')
+
+    expect(hasEmphasis(editor)).toBe(true)
+    expect(editor.action(getMarkdown())).toBe('The lunatic is _on the grass_\n')
+  })
+
+  it('does not create emphasis for intra-word underscores', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+
+    await user.type(
+      editor.ctx.get(editorViewCtx).dom,
+      'the_lunatic_is_on_the_grass'
+    )
+
+    expect(hasEmphasis(editor)).toBe(false)
+    expect(editor.action(getMarkdown())).toBe(
+      'the\\_lunatic\\_is\\_on\\_the\\_grass\n'
+    )
+  })
+})

--- a/packages/plugins/preset-commonmark/src/mark/emphasis.ts
+++ b/packages/plugins/preset-commonmark/src/mark/emphasis.ts
@@ -91,7 +91,7 @@ withMeta(emphasisStarInputRule, {
 
 /// Input rule for use `_` to create emphasis mark.
 export const emphasisUnderscoreInputRule = $inputRule((ctx) => {
-  return markRule(/\b_(?![_\s])(.*?[^_\s])_\b/, emphasisSchema.type(ctx), {
+  return markRule(/\b_(?![_\s])(.*?[^_\s])_$/, emphasisSchema.type(ctx), {
     getAttr: () => ({
       marker: '_',
     }),

--- a/packages/plugins/preset-gfm/src/__test__/paste-special-char.spec.ts
+++ b/packages/plugins/preset-gfm/src/__test__/paste-special-char.spec.ts
@@ -1,0 +1,121 @@
+import '@testing-library/jest-dom/vitest'
+import { Editor, editorViewCtx } from '@milkdown/core'
+import { commonmark } from '@milkdown/preset-commonmark'
+import { getMarkdown } from '@milkdown/utils'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { gfm } from '..'
+
+// https://github.com/Milkdown/milkdown/issues/2400
+// The strikethrough input rule shares the same flaw as the underscore-emphasis
+// rule: its regex was not anchored to the end of the input (`$`), so pasting
+// text that ends with `~` twice and then pressing Space/Enter matched a `~...~`
+// span across the two pastes and corrupted the document.
+
+const PASTED = 'qa34 %~'
+
+async function createEditor() {
+  const editor = Editor.make()
+  editor.use(commonmark)
+  editor.use(gfm)
+  await editor.create()
+  return editor
+}
+
+function hasStrikethrough(editor: Editor) {
+  const { doc } = editor.ctx.get(editorViewCtx).state
+  let found = false
+  doc.descendants((node) => {
+    if (node.marks.some((mark) => mark.type.name === 'strike_through'))
+      found = true
+  })
+  return found
+}
+
+function paste(editor: Editor, text: string) {
+  const view = editor.ctx.get(editorViewCtx)
+  view.dispatch(view.state.tr.insertText(text))
+}
+
+describe('pasting special characters — strikethrough (#2400)', () => {
+  it('does not delete characters when pressing Space after two pastes', async () => {
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    paste(editor, PASTED)
+    paste(editor, PASTED)
+
+    const before = view.state.doc.textContent
+    const end = view.state.selection.from
+
+    // The trailing `deflt` callback is required by the prop type but unused
+    // by the input-rule plugin.
+    view.someProp('handleTextInput', (f) =>
+      f(view, end, end, ' ', () => view.state.tr)
+    )
+
+    expect(view.state.doc.textContent).toBe(before)
+    expect(hasStrikethrough(editor)).toBe(false)
+  })
+
+  it('does not delete characters when pressing Enter after two pastes', async () => {
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    paste(editor, PASTED)
+    paste(editor, PASTED)
+
+    const before = view.state.doc.textContent
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter' })
+    view.someProp('handleKeyDown', (f) => f(view, event))
+
+    expect(view.state.doc.textContent).toBe(before)
+    expect(hasStrikethrough(editor)).toBe(false)
+  })
+
+  it('still turns ~~word~~ into strikethrough when the closing ~ is typed', async () => {
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    paste(editor, '~~word~')
+
+    const end = view.state.selection.from
+    view.someProp('handleTextInput', (f) =>
+      f(view, end, end, '~', () => view.state.tr)
+    )
+
+    expect(view.state.doc.textContent).toBe('word')
+    expect(hasStrikethrough(editor)).toBe(true)
+  })
+})
+
+// The `$` anchor added to the strikethrough rule must not regress typing the
+// markdown syntax by hand: these mirror the input-rule e2e tests.
+describe('typing strikethrough still works', () => {
+  it('creates strikethrough when typing ~~on the grass~~', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, 'The lunatic is ~~on the grass~~')
+
+    expect(hasStrikethrough(editor)).toBe(true)
+  })
+
+  it('does not create strikethrough for intra-word tildes', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+
+    await user.type(
+      editor.ctx.get(editorViewCtx).dom,
+      'C:/the/~lunatic~/is/on/the/grass'
+    )
+
+    expect(hasStrikethrough(editor)).toBe(false)
+    expect(editor.action(getMarkdown())).toBe(
+      'C:/the/\\~lunatic\\~/is/on/the/grass\n'
+    )
+  })
+})

--- a/packages/plugins/preset-gfm/src/mark/strike-through.ts
+++ b/packages/plugins/preset-gfm/src/mark/strike-through.ts
@@ -71,7 +71,7 @@ withMeta(toggleStrikethroughCommand, {
 /// Input rule to create the strikethrough mark.
 export const strikethroughInputRule = $inputRule((ctx) => {
   return markRule(
-    /(?<![\w:/])(~{1,2})(.+?)\1(?!\w|\/)/,
+    /(?<![\w:/])(~{1,2})(.+?)\1(?!\w|\/)$/,
     strikethroughSchema.type(ctx)
   )
 })


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2400.

Pasting text that ends with `_` (e.g. `This is for qa34%^%^&&&(&(&(&()(*()_`) **twice** and then pressing **Space** or **Enter** deletes characters after the first paste.

### Root cause

The underscore-emphasis and strikethrough input-rule regexes are not anchored to the end of the input (`$`), unlike the star-emphasis, strong and inline-code rules:

- `emphasisUnderscoreInputRule`: `/\b_(?![_\s])(.*?[^_\s])_\b/`
- `strikethroughInputRule`: `/(?<![\w:/])(~{1,2})(.+?)\1(?!\w|\/)/`

After two pastes the document contains `..._..._`. When Space/Enter runs the input rules, `regexp.exec(textBefore)` matches an `_..._` (or `~...~`) span **across the two pastes** — a match that does **not** end at the cursor. ProseMirror's input-rule runner computes the affected range with `start = from - (match[0].length - text.length)`, assuming the match ends at the cursor. Because it doesn't, the range is off by one and characters are deleted.

Enter triggers this too because Milkdown's `customInputRules` runs the rules from `handleKeyDown` with `text = '\n'`.

### Fix

Anchor both rules to the cursor with `$`. The rules now fire only when the closing marker is typed at the cursor — the intended behavior, and consistent with the other mark rules. `$` (without the `m` flag) does not match before a trailing `\n`, so the Enter case is fixed as well. Typing `_emphasis_` / `~~strike~~` by hand is unchanged (the closing marker is at the cursor, so `$` matches).

## How did you test this change?

Added regression tests in `preset-commonmark` and `preset-gfm` (`__test__/paste-special-char.spec.ts`) that:

- reproduce the bug: two pastes ending in `_` / `~`, then Space and then Enter — asserting the document text is preserved and no `emphasis` / `strike_through` mark leaks in. These **fail on `main`** (a character after the first paste is dropped, e.g. `...()_This...` → `...()_his...`) and **pass with this change**.
- guard the happy path: typing `_on the grass_` / `~~on the grass~~` still creates the mark, and intra-word `the_lunatic_is` / `C:/the/~lunatic~` still do not (mirrors the existing input-rule e2e tests).

```
Test Files  10 passed (10)
     Tests  64 passed (64)
```

`oxlint` and `oxfmt` are clean.
