### PR TITLE
feat(crepe): derive toolbar shortcuts from keymaps

### DIFF
--- a/docs/api/crepe.md
+++ b/docs/api/crepe.md
@@ -444,8 +444,8 @@ builder.addGroup('custom', 'Custom').addItem('bold', {
   icon: boldIcon,
   label: 'Bold',
   keymap: keymapRef(strongKeymap.key, 'ToggleBold'),
-  active: (ctx) => …,
-  onRun: (ctx) => …,
+  active: (ctx) => isBoldActive(ctx),
+  onRun: (ctx) => toggleBold(ctx),
 })
 ```
 
@@ -459,8 +459,8 @@ builder.addGroup('custom', 'Custom').addItem('highlight', {
   label: 'Highlight',
   shortcut: isMac ? '⌘⇧H' : 'Ctrl+Shift+H', // shown to the user
   ariaKeyshortcuts: isMac ? 'Meta+Shift+H' : 'Control+Shift+H', // for AT
-  active: (ctx) => …,
-  onRun: (ctx) => …,
+  active: (ctx) => isHighlightActive(ctx),
+  onRun: (ctx) => toggleHighlight(ctx),
 })
 ```
 

--- a/docs/api/crepe.md
+++ b/docs/api/crepe.md
@@ -413,6 +413,7 @@ type ToolbarItem = {
   active: (ctx: Ctx) => boolean
   icon: string
   label?: string // title + aria-label
+  keymap?: KeymapRef // where the shortcut is bound; both fields below derive from it
   shortcut?: string // display only, appended to the title
   ariaKeyshortcuts?: string // aria-keyshortcuts, in ARIA grammar
 }
@@ -420,13 +421,37 @@ type ToolbarItem = {
 
 `label` is what gives the button a name — its only other content is an SVG.
 
-The two shortcut fields are separate because they have different readers.
-`shortcut` is what a human reads in the tooltip, so it can be `⌘B` or `Ctrl+B`.
-`ariaKeyshortcuts` goes straight into the `aria-keyshortcuts` attribute, which
-has a defined grammar: `+`-joined modifiers drawn from `Alt`, `Control`,
-`Shift`, `Meta` and `AltGraph`, plus a `KeyboardEvent.key` value. Display glyphs
-and the abbreviation `Ctrl` are both invalid there, so one field cannot serve
-both:
+A shortcut has two readers. `shortcut` is what a human reads in the tooltip, so
+it is `⌘B` or `Ctrl+B`. `ariaKeyshortcuts` goes into the `aria-keyshortcuts`
+attribute, which has a defined grammar: `+`-joined modifiers from `Alt`,
+`Control`, `Shift`, `Meta` and `AltGraph`, plus a `KeyboardEvent.key` value.
+Display glyphs and the abbreviation `Ctrl` are both invalid there, so one field
+cannot serve both.
+
+You should not spell either by hand. A shortcut is bound in exactly one place —
+its keymap — so point the item at that keymap with `keymap` and both strings are
+derived for you, per platform, and stay correct when the host rebinds the key.
+The built-in formatting buttons already do this, and a custom button for a
+command that has a keymap does the same:
+
+```typescript
+import { keymapRef } from '@milkdown/crepe/feature/toolbar'
+import { strongKeymap } from '@milkdown/kit/preset/commonmark'
+
+// A second entry for an existing command reuses the one binding — no need to
+// re-spell ⌘B here or anywhere else it appears.
+builder.addGroup('custom', 'Custom').addItem('bold', {
+  icon: boldIcon,
+  label: 'Bold',
+  keymap: keymapRef(strongKeymap.key, 'ToggleBold'),
+  active: (ctx) => …,
+  onRun: (ctx) => …,
+})
+```
+
+`shortcut` / `ariaKeyshortcuts`, when set explicitly, win over the derived
+values — the escape hatch for a shortcut that is not backed by a milkdown
+keymap:
 
 ```typescript
 builder.addGroup('custom', 'Custom').addItem('highlight', {
@@ -439,9 +464,8 @@ builder.addGroup('custom', 'Custom').addItem('highlight', {
 })
 ```
 
-Neither has a default: which combo is bound, and how it is spelled per platform,
-is the host's business. Buttons also carry `data-toolbar-item="<key>"`, so
-consumers can target a specific one without relying on its position.
+Buttons also carry `data-toolbar-item="<key>"`, so consumers can target a
+specific one without relying on its position.
 
 #### TopBar Feature
 

--- a/packages/crepe/src/feature/toolbar/config.ts
+++ b/packages/crepe/src/feature/toolbar/config.ts
@@ -3,22 +3,27 @@ import type { Ctx } from '@milkdown/kit/ctx'
 import { toggleLinkCommand } from '@milkdown/kit/component/link-tooltip'
 import { commandsCtx, editorViewCtx, schemaCtx } from '@milkdown/kit/core'
 import {
+  emphasisKeymap,
   emphasisSchema,
+  inlineCodeKeymap,
   inlineCodeSchema,
   isMarkSelectedCommand,
   isNodeSelectedCommand,
   linkSchema,
+  strongKeymap,
   strongSchema,
   toggleEmphasisCommand,
   toggleInlineCodeCommand,
   toggleStrongCommand,
 } from '@milkdown/kit/preset/commonmark'
 import {
+  strikethroughKeymap,
   strikethroughSchema,
   toggleStrikethroughCommand,
 } from '@milkdown/kit/preset/gfm'
 
 import type { ToolbarFeatureConfig } from '.'
+import type { KeymapRef } from '../../utils/keyboard-shortcut'
 
 import { CrepeFeature } from '..'
 import { useCrepeFeatures } from '../../core/slice'
@@ -32,6 +37,7 @@ import {
   strikethroughIcon,
 } from '../../icons'
 import { GroupBuilder } from '../../utils/group-builder'
+import { keymapRef, resolveKeymapShortcut } from '../../utils/keyboard-shortcut'
 import { aiProviderConfig } from '../ai/commands'
 import { aiInstructionTooltipAPI } from '../ai/instruction-tooltip'
 import { mathInlineId, toggleLatexCommandName } from '../latex/constants'
@@ -55,6 +61,13 @@ export type ToolbarItem = {
   /// Crepe defaults neither: which combo is bound, and how it is spelled per
   /// platform, is the host's business.
   ariaKeyshortcuts?: string
+  /// A reference to the keymap entry that binds this item's command, e.g.
+  /// `keymapRef(strongKeymap.key, 'ToggleBold')`. When set, `shortcut` and
+  /// `ariaKeyshortcuts` are derived from it — the single source of truth — so
+  /// they follow any host rebinding and never have to be spelled per UI region.
+  /// The two string fields above still win when set explicitly, for shortcuts
+  /// not backed by a milkdown keymap.
+  keymap?: KeymapRef
 }
 
 export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
@@ -65,6 +78,7 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
     .addItem('bold', {
       icon: config?.boldIcon ?? boldIcon,
       label: config?.boldLabel ?? 'Bold',
+      keymap: keymapRef(strongKeymap.key, 'ToggleBold'),
       active: (ctx) => {
         const commands = ctx.get(commandsCtx)
         return commands.call(isMarkSelectedCommand.key, strongSchema.type(ctx))
@@ -77,6 +91,7 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
     .addItem('italic', {
       icon: config?.italicIcon ?? italicIcon,
       label: config?.italicLabel ?? 'Italic',
+      keymap: keymapRef(emphasisKeymap.key, 'ToggleEmphasis'),
       active: (ctx) => {
         const commands = ctx.get(commandsCtx)
         return commands.call(
@@ -92,6 +107,7 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
     .addItem('strikethrough', {
       icon: config?.strikethroughIcon ?? strikethroughIcon,
       label: config?.strikethroughLabel ?? 'Strikethrough',
+      keymap: keymapRef(strikethroughKeymap.key, 'ToggleStrikethrough'),
       active: (ctx) => {
         const commands = ctx.get(commandsCtx)
         return commands.call(
@@ -109,6 +125,7 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
   functionGroup.addItem('code', {
     icon: config?.codeIcon ?? codeIcon,
     label: config?.codeLabel ?? 'Inline code',
+    keymap: keymapRef(inlineCodeKeymap.key, 'ToggleInlineCode'),
     active: (ctx) => {
       const commands = ctx.get(commandsCtx)
       return commands.call(
@@ -178,5 +195,24 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
 
   config?.buildToolbar?.(groupBuilder)
 
-  return groupBuilder.build()
+  const groups = groupBuilder.build()
+
+  // Derive display + `aria-keyshortcuts` from each item's keymap reference —
+  // the one place the shortcut is actually bound — so they follow any host
+  // rebinding. `??=` lets an explicitly configured string win. Runs only with a
+  // ctx (the keymap slices live there); the derived value is read at build time,
+  // so a rebind shows up the next time the toolbar opens, not on an open one.
+  if (ctx) {
+    for (const group of groups) {
+      for (const item of group.items) {
+        if (!item.keymap) continue
+        const resolved = resolveKeymapShortcut(ctx, item.keymap)
+        if (!resolved) continue
+        item.shortcut ??= resolved.display
+        item.ariaKeyshortcuts ??= resolved.aria
+      }
+    }
+  }
+
+  return groups
 }

--- a/packages/crepe/src/feature/toolbar/index.ts
+++ b/packages/crepe/src/feature/toolbar/index.ts
@@ -18,6 +18,10 @@ import { crepeFeatureConfig } from '../../core/slice'
 import { CrepeFeature } from '../../feature'
 import { Toolbar } from './component'
 
+export { keymapRef } from '../../utils/keyboard-shortcut'
+export type { KeymapRef } from '../../utils/keyboard-shortcut'
+export type { ToolbarItem } from './config'
+
 interface ToolbarConfig {
   boldIcon: string
   codeIcon: string

--- a/packages/crepe/src/feature/toolbar/toolbar.spec.ts
+++ b/packages/crepe/src/feature/toolbar/toolbar.spec.ts
@@ -1,10 +1,19 @@
+import { strongKeymap } from '@milkdown/kit/preset/commonmark'
+import { browser } from '@milkdown/kit/prose'
 import { test, expect, describe } from 'vitest'
 
 import type { ToolbarItem } from './config'
 
 import { Crepe } from '../../core'
 import { CrepeFeature } from '../../feature'
+import { formatKeymapShortcut, keymapRef } from '../../utils/keyboard-shortcut'
 import { getGroups } from './config'
+
+/// The shortcut strings a built-in should carry, computed the same way the
+/// resolver does so assertions hold on whatever platform the tests run on.
+function expectedShortcut(raw: string) {
+  return formatKeymapShortcut(raw, browser.mac)
+}
 
 type Config = Parameters<typeof getGroups>[0]
 type Ctx = Parameters<typeof getGroups>[1]
@@ -94,11 +103,90 @@ describe('toolbar item labels', () => {
 })
 
 describe('toolbar item shortcuts', () => {
-  test('neither shortcut field is set by default', () => {
-    // Crepe does not know which combos the host bound, so it advertises none.
+  test('without a ctx there is no binding to read, so none is derived', () => {
+    // The keymap slices live on the editor ctx; getGroups is also called
+    // ctx-less (e.g. to inspect labels), and then it advertises no shortcut.
     for (const item of itemsOf()) {
       expect(item.shortcut).toBeUndefined()
       expect(item.ariaKeyshortcuts).toBeUndefined()
+    }
+  })
+
+  test('built-in items derive their shortcut from the keymap', async () => {
+    const ctx = await ctxWithLatex()
+    const bold = itemByKey('bold', undefined, ctx)
+    expect(bold.shortcut).toBe(expectedShortcut('Mod-b').display)
+    expect(bold.ariaKeyshortcuts).toBe(expectedShortcut('Mod-b').aria)
+    expect(itemByKey('italic', undefined, ctx).ariaKeyshortcuts).toBe(
+      expectedShortcut('Mod-i').aria
+    )
+    expect(itemByKey('code', undefined, ctx).ariaKeyshortcuts).toBe(
+      expectedShortcut('Mod-e').aria
+    )
+    expect(itemByKey('strikethrough', undefined, ctx).ariaKeyshortcuts).toBe(
+      expectedShortcut('Mod-Alt-x').aria
+    )
+  })
+
+  test('a host rebinding flows through — single source of truth', async () => {
+    const ctx = await ctxWithLatex()
+    ctx.set(strongKeymap.key, { ToggleBold: { shortcuts: ['Mod-Alt-b'] } })
+    const bold = itemByKey('bold', undefined, ctx)
+    expect(bold.shortcut).toBe(expectedShortcut('Mod-Alt-b').display)
+    expect(bold.ariaKeyshortcuts).toBe(expectedShortcut('Mod-Alt-b').aria)
+  })
+
+  test('an explicit string overrides the derived one', async () => {
+    const ctx = await ctxWithLatex()
+    const items = itemsOf(
+      {
+        buildToolbar: (builder) => {
+          builder.addGroup('custom', 'Custom').addItem('override', {
+            icon: '<svg />',
+            label: 'Override',
+            keymap: keymapRef(strongKeymap.key, 'ToggleBold'),
+            shortcut: '⌘B',
+            ariaKeyshortcuts: 'Meta+B',
+            active: () => false,
+            onRun: () => {},
+          })
+        },
+      },
+      ctx
+    )
+    const override = items.find((item) => item.key === 'override')
+    expect(override?.shortcut).toBe('⌘B')
+    expect(override?.ariaKeyshortcuts).toBe('Meta+B')
+  })
+
+  test('a custom item can point at a keymap instead of re-spelling it', async () => {
+    // The whole reason keymap refs exist: a second UI entry for the same
+    // command reuses the one binding rather than hand-writing the string again.
+    const ctx = await ctxWithLatex()
+    const items = itemsOf(
+      {
+        buildToolbar: (builder) => {
+          builder.addGroup('custom', 'Custom').addItem('bold-again', {
+            icon: '<svg />',
+            label: 'Bold again',
+            keymap: keymapRef(strongKeymap.key, 'ToggleBold'),
+            active: () => false,
+            onRun: () => {},
+          })
+        },
+      },
+      ctx
+    )
+    const item = items.find((candidate) => candidate.key === 'bold-again')
+    expect(item?.ariaKeyshortcuts).toBe(expectedShortcut('Mod-b').aria)
+  })
+
+  test('items with no keymap advertise no shortcut', async () => {
+    const ctx = await ctxWithAI()
+    for (const key of ['link', 'latex', 'ai']) {
+      const item = itemByKey(key, undefined, ctx)
+      expect(item.shortcut, `${key} shortcut`).toBeUndefined()
+      expect(item.ariaKeyshortcuts, `${key} ariaKeyshortcuts`).toBeUndefined()
     }
   })
 

--- a/packages/crepe/src/feature/toolbar/toolbar.spec.ts
+++ b/packages/crepe/src/feature/toolbar/toolbar.spec.ts
@@ -1,5 +1,6 @@
 import { strongKeymap } from '@milkdown/kit/preset/commonmark'
 import { browser } from '@milkdown/kit/prose'
+import { $useKeymap } from '@milkdown/kit/utils'
 import { test, expect, describe } from 'vitest'
 
 import type { ToolbarItem } from './config'
@@ -179,6 +180,32 @@ describe('toolbar item shortcuts', () => {
     )
     const item = items.find((candidate) => candidate.key === 'bold-again')
     expect(item?.ariaKeyshortcuts).toBe(expectedShortcut('Mod-b').aria)
+  })
+
+  test('a keymap ref to an uninjected slice is ignored, not thrown', async () => {
+    // A custom item may reference a keymap whose plugin this editor never
+    // loaded; reading the missing slice must not crash toolbar construction.
+    const orphanKeymap = $useKeymap('orphanKeymap', {
+      Foo: { shortcuts: 'Mod-j', command: () => () => false },
+    })
+    const ctx = await ctxWithLatex()
+    const items = itemsOf(
+      {
+        buildToolbar: (builder) => {
+          builder.addGroup('custom', 'Custom').addItem('orphan', {
+            icon: '<svg />',
+            label: 'Orphan',
+            keymap: keymapRef(orphanKeymap.key, 'Foo'),
+            active: () => false,
+            onRun: () => {},
+          })
+        },
+      },
+      ctx
+    )
+    const orphan = items.find((item) => item.key === 'orphan')
+    expect(orphan?.shortcut).toBeUndefined()
+    expect(orphan?.ariaKeyshortcuts).toBeUndefined()
   })
 
   test('items with no keymap advertise no shortcut', async () => {

--- a/packages/crepe/src/utils/keyboard-shortcut.spec.ts
+++ b/packages/crepe/src/utils/keyboard-shortcut.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+
+import { formatKeymapShortcut } from './keyboard-shortcut'
+
+describe('formatKeymapShortcut', () => {
+  describe('on macOS', () => {
+    test.each([
+      ['Mod-b', '⌘B', 'Meta+B'],
+      ['Mod-i', '⌘I', 'Meta+I'],
+      ['Mod-e', '⌘E', 'Meta+E'],
+      ['Mod-Alt-x', '⌥⌘X', 'Meta+Alt+X'],
+      ['Mod-Shift-h', '⇧⌘H', 'Meta+Shift+H'],
+    ])('%s → %s / %s', (shortcut, display, aria) => {
+      expect(formatKeymapShortcut(shortcut, true)).toEqual({ display, aria })
+    })
+  })
+
+  describe('elsewhere', () => {
+    test.each([
+      ['Mod-b', 'Ctrl+B', 'Control+B'],
+      ['Mod-Alt-x', 'Ctrl+Alt+X', 'Control+Alt+X'],
+      ['Mod-Shift-h', 'Ctrl+Shift+H', 'Control+Shift+H'],
+    ])('%s → %s / %s', (shortcut, display, aria) => {
+      expect(formatKeymapShortcut(shortcut, false)).toEqual({ display, aria })
+    })
+  })
+
+  test('modifier order in the input does not matter', () => {
+    expect(formatKeymapShortcut('Alt-Mod-x', true)).toEqual(
+      formatKeymapShortcut('Mod-Alt-x', true)
+    )
+  })
+
+  test('the `-` key survives the split', () => {
+    // `/-(?!$)/` must not split the trailing hyphen.
+    expect(formatKeymapShortcut('Mod--', true)).toEqual({
+      display: '⌘-',
+      aria: 'Meta+-',
+    })
+    expect(formatKeymapShortcut('Mod--', false)).toEqual({
+      display: 'Ctrl+-',
+      aria: 'Control+-',
+    })
+  })
+
+  describe('non-letter keys', () => {
+    test('Space becomes the literal space the ARIA grammar wants', () => {
+      expect(formatKeymapShortcut('Mod-Space', true)).toEqual({
+        display: '⌘Space',
+        aria: 'Meta+ ',
+      })
+    })
+
+    test('named keys pass through unchanged', () => {
+      expect(formatKeymapShortcut('Mod-ArrowUp', false)).toEqual({
+        display: 'Ctrl+ArrowUp',
+        aria: 'Control+ArrowUp',
+      })
+    })
+  })
+
+  test('a bare key with no modifier is just the key', () => {
+    expect(formatKeymapShortcut('b', true)).toEqual({ display: 'B', aria: 'B' })
+  })
+})

--- a/packages/crepe/src/utils/keyboard-shortcut.ts
+++ b/packages/crepe/src/utils/keyboard-shortcut.ts
@@ -143,6 +143,10 @@ export function resolveKeymapShortcut(
   ctx: Ctx,
   ref: KeymapRef
 ): ResolvedShortcut | undefined {
+  // A custom item may point at a keymap whose plugin isn't loaded in this
+  // editor; reading a missing slice throws, which would break toolbar
+  // construction, so treat it as "no shortcut" instead.
+  if (!ctx.isInjected(ref.slice)) return undefined
   const entry = ctx.get(ref.slice)[ref.entry]
   const shortcut = entry ? [entry.shortcuts].flat()[0] : undefined
   if (!shortcut) return undefined

--- a/packages/crepe/src/utils/keyboard-shortcut.ts
+++ b/packages/crepe/src/utils/keyboard-shortcut.ts
@@ -1,0 +1,150 @@
+import type { Ctx, SliceType } from '@milkdown/kit/ctx'
+import type { KeymapConfig } from '@milkdown/kit/utils'
+
+import { browser } from '@milkdown/kit/prose'
+
+/// A reference to a single entry of a milkdown keymap slice — the one place a
+/// shortcut is actually bound. UI items point at this instead of re-spelling the
+/// shortcut, so display and `aria-keyshortcuts` are derived from the source of
+/// truth and stay correct when the host rebinds the key.
+export interface KeymapRef {
+  slice: SliceType<KeymapConfig<string>>
+  entry: string
+}
+
+/// Build a `KeymapRef`. The generic keeps `entry` checked against the slice's
+/// real entry names (`keymapRef(strongKeymap.key, 'ToggleBold')` — a typo is a
+/// compile error) while the single unavoidable cast to the erased storage type
+/// is localized here, so `ToolbarItem` never has to be generic.
+export function keymapRef<K extends string>(
+  slice: SliceType<KeymapConfig<K>>,
+  entry: K
+): KeymapRef {
+  return { slice: slice as SliceType<KeymapConfig<string>>, entry }
+}
+
+/// A shortcut rendered for both of its readers: `display` for a human (tooltip),
+/// `aria` for the `aria-keyshortcuts` attribute.
+export interface ResolvedShortcut {
+  display: string
+  aria: string
+}
+
+interface NormalizedKey {
+  display: string
+  aria: string
+}
+
+/// A `KeyboardEvent.key` value for the ARIA attribute, plus a display form.
+/// Single characters are upper-cased (`b` → `B`, `-` stays `-`); named keys
+/// (`Enter`, `ArrowUp`, …) pass through; `Space` maps to the literal space the
+/// ARIA grammar expects for that key.
+function normalizeKey(key: string): NormalizedKey {
+  if (key === ' ' || key.toLowerCase() === 'space')
+    return { display: 'Space', aria: ' ' }
+  if (key.length === 1) {
+    const upper = key.toUpperCase()
+    return { display: upper, aria: upper }
+  }
+  return { display: key, aria: key }
+}
+
+/// Format a prosemirror keymap shortcut (`Mod-b`, `Mod-Alt-x`) into a display
+/// string and an `aria-keyshortcuts` value. `mac` is injected so the pure output
+/// is testable on both platforms without stubbing `navigator`; callers pass
+/// `browser.mac`.
+///
+/// - `Mod` resolves to `Meta` on macOS and `Control` elsewhere, matching what
+///   prosemirror-keymap actually binds.
+/// - Display follows each platform's convention: macOS glyphs `⌃⌥⇧⌘` with the
+///   Command key next to the key and no separators (`⌥⌘X`); elsewhere `+`-joined
+///   names with the primary modifier first (`Ctrl+Alt+X`).
+/// - The ARIA value uses the attribute's grammar: `+`-joined modifiers from
+///   `Meta`/`Control`/`Alt`/`Shift` followed by a `KeyboardEvent.key` value
+///   (`Meta+Shift+H`, `Control+B`).
+export function formatKeymapShortcut(
+  shortcut: string,
+  mac: boolean
+): ResolvedShortcut {
+  // Split on `-` but not a trailing one, so the `-` key survives (`Mod--`).
+  const parts = shortcut.split(/-(?!$)/)
+  const rawKey = parts[parts.length - 1] ?? ''
+  const modifiers = parts.slice(0, -1)
+
+  let meta = false
+  let control = false
+  let alt = false
+  let shift = false
+  for (const modifier of modifiers) {
+    switch (modifier.toLowerCase()) {
+      case 'mod':
+        if (mac) meta = true
+        else control = true
+        break
+      case 'meta':
+      case 'cmd':
+      case 'm':
+        meta = true
+        break
+      case 'ctrl':
+      case 'control':
+      case 'c':
+        control = true
+        break
+      case 'alt':
+      case 'option':
+      case 'a':
+        alt = true
+        break
+      case 'shift':
+      case 's':
+        shift = true
+        break
+      default:
+        // Ignore unknown modifiers rather than emit a broken shortcut.
+        break
+    }
+  }
+
+  const key = normalizeKey(rawKey)
+
+  const display = mac
+    ? [control && '⌃', alt && '⌥', shift && '⇧', meta && '⌘', key.display]
+        .filter(Boolean)
+        .join('')
+    : [
+        control && 'Ctrl',
+        alt && 'Alt',
+        shift && 'Shift',
+        meta && 'Meta',
+        key.display,
+      ]
+        .filter(Boolean)
+        .join('+')
+
+  const aria = [
+    meta && 'Meta',
+    control && 'Control',
+    alt && 'Alt',
+    shift && 'Shift',
+    key.aria,
+  ]
+    .filter(Boolean)
+    .join('+')
+
+  return { display, aria }
+}
+
+/// Resolve a `KeymapRef` against the live editor context. Reads the (possibly
+/// rebound) shortcut from the slice and formats it for the current platform.
+/// Returns `undefined` when the entry carries no shortcut. Only the first
+/// binding is used when an entry lists several.
+export function resolveKeymapShortcut(
+  ctx: Ctx,
+  ref: KeymapRef
+): ResolvedShortcut | undefined {
+  const entry = ctx.get(ref.slice)[ref.entry]
+  const shortcut = entry ? [entry.shortcuts].flat()[0] : undefined
+  if (!shortcut) return undefined
+  return formatKeymapShortcut(shortcut, browser.mac)
+}


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Follow-up to #2435 (toolbar accessible names). That PR gave `ToolbarItem` the `shortcut` / `ariaKeyshortcuts` fields but left the built-in items advertising nothing, because a shortcut is bound in the preset keymaps and spelling it again per UI region is duplicative and drifts from the real binding.

This makes the **keymap the single source of truth**. A `ToolbarItem` can now carry a `keymap` reference to the entry that binds its command; the tooltip `shortcut` and `aria-keyshortcuts` are derived from it — per platform, and rebind-aware, since the keymap slice is user-customizable. The four built-in formatting buttons ship these references:

| item | keymap | shortcut |
|---|---|---|
| bold | `strongKeymap` / `ToggleBold` | `Mod-b` |
| italic | `emphasisKeymap` / `ToggleEmphasis` | `Mod-i` |
| code | `inlineCodeKeymap` / `ToggleInlineCode` | `Mod-e` |
| strikethrough | `strikethroughKeymap` / `ToggleStrikethrough` | `Mod-Alt-x` |

Design notes:

- New `packages/crepe/src/utils/keyboard-shortcut.ts`: `keymapRef()` (a generic factory that keeps the entry name compile-checked and localizes the one cast), a pure `formatKeymapShortcut(shortcut, mac)` that mirrors prosemirror-keymap's `normalizeKeyName` (`Mod` → `Meta` on macOS / `Control` elsewhere), and `resolveKeymapShortcut()`.
- Platform detection reuses prosemirror's `browser.mac` (`@milkdown/kit/prose`) — no hand-rolled `navigator` check, and the AI feature's `detectModSymbol` is intentionally left alone (different semantics / SSR default).
- Resolution happens in `getGroups` as a `ctx`-guarded pass that fills the fields with `??=`, so an explicitly configured string still wins — the escape hatch for shortcuts with no milkdown keymap. `component.tsx` is unchanged.
- `keymapRef` / `KeymapRef` / `ToolbarItem` are exported from `@milkdown/crepe/feature/toolbar` so a custom item can point at a keymap instead of re-spelling the shortcut.
- Scope is the floating Toolbar. The util is region-agnostic; the TopBar can adopt it once it gains accessible names (separate change).

## How did you test this change?

- New `keyboard-shortcut.spec.ts`: table tests for both platforms, input-order normalization, the `-` / `Space` / `ArrowUp` edge cases.
- Extended `toolbar.spec.ts` against a real `Crepe` editor ctx: built-ins derive from the keymap; a `ctx.set(strongKeymap.key, …)` rebind flows through; an explicit string overrides the derived value; a custom item reuses a keymap ref; items with no keymap advertise nothing.
- `tsc --noEmit` clean, `oxlint --deny-warnings` clean, full crepe suite green (80 tests).