### PR TITLE
fix(prism): re-highlight non-first code blocks on language change

### DIFF
--- a/packages/plugins/plugin-prism/src/__test__/prism.spec.ts
+++ b/packages/plugins/plugin-prism/src/__test__/prism.spec.ts
@@ -203,6 +203,45 @@ it('should re-highlight when a code block language changes', async () => {
   expect(decorations(view(editor))).not.toEqual(before)
 })
 
+it('should re-highlight a non-first code block when its language changes via setNodeAttribute', async () => {
+  // `updateCodeBlockLanguageCommand` and the code-block node view both change the
+  // language with `setNodeAttribute`, whose `AttrStep` carries no `from`/`to`, so
+  // the step scan can't see it and the block-language comparison must cover every
+  // block, not just the first.
+  const editor = await createEditor(DOC)
+  const before = decorations(view(editor))
+  const secondPos = posOfCodeBlock(view(editor), 1)
+
+  // Caret in the prose above, outside every code block — the missed case.
+  view(editor).dispatch(
+    view(editor).state.tr.setSelection(
+      TextSelection.create(view(editor).state.doc, 1)
+    )
+  )
+  view(editor).dispatch(
+    view(editor).state.tr.setNodeAttribute(secondPos, 'language', 'js')
+  )
+
+  const after = decorations(view(editor))
+  const fresh = await createEditor(DOC.replace('```css', '```js'))
+
+  // The stale css highlighting is gone, and the block matches a from-scratch run.
+  expect(after).not.toEqual(before)
+  expect(after).toEqual(decorations(view(fresh)))
+})
+
+it('should re-highlight the first code block when its language changes via setNodeAttribute', async () => {
+  const editor = await createEditor(DOC)
+  const before = decorations(view(editor))
+  const firstPos = posOfCodeBlock(view(editor))
+
+  view(editor).dispatch(
+    view(editor).state.tr.setNodeAttribute(firstPos, 'language', 'css')
+  )
+
+  expect(decorations(view(editor))).not.toEqual(before)
+})
+
 it('should re-highlight when a code block is removed', async () => {
   const editor = await createEditor(DOC)
   const pos = posOfCodeBlock(view(editor))

--- a/packages/plugins/plugin-prism/src/index.ts
+++ b/packages/plugins/plugin-prism/src/index.ts
@@ -97,8 +97,15 @@ export const prismPlugin = $prose((ctx) => {
             )
             return (
               oldNode.length !== newNode.length ||
-              oldNode[0]?.node.attrs.language !==
-                newNode[0]?.node.attrs.language ||
+              // A language change goes through `setNodeAttribute`, whose
+              // `AttrStep` carries no `from`/`to` and maps to an empty step map,
+              // so the step scan below misses it. Compare every block by index
+              // rather than only the first, or a change to any but the first
+              // block leaves its highlighting stale.
+              oldNode.some(
+                (entry, i) =>
+                  entry.node.attrs.language !== newNode[i]?.node.attrs.language
+              ) ||
               transaction.steps.some((step) => {
                 const s = step as unknown as { from: number; to: number }
                 return (


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Changing a code block's language only re-highlights it when it is the **first** code block in the document. Any later block keeps its old highlighting.

The language is changed with `state.tr.setNodeAttribute(pos, 'language', …)` — that is what both `updateCodeBlockLanguageCommand` (`preset-commonmark`) and the code-block node view (`@milkdown/components`) dispatch. The resulting `AttrStep` carries no `from`/`to` and maps to an empty step map, so the plugin's change detection can't spot it two ways:

- `transaction.steps.some(...)` short-circuits on `s.from !== undefined`, so the step scan never matches an `AttrStep`;
- the fallback only compared `oldNode[0]` vs `newNode[0]`, i.e. the first block's language.

Together these mean a language change on the first block happens to be caught (by the `[0]` comparison), but a change on any other block slips through — `codeBlockChanged` stays `false` and the decoration set is just mapped forward, leaving stale tokens (e.g. a block flipped from `js` to `css` still shows JS keyword highlighting).

The fix compares **every** block's language by index instead of only the first, so the recompute fires for the block that actually changed. Language changes are rare (a dropdown click), so a full recompute here is fine and matches how a first-block change already behaves.

> Note: this bug predates #2436 — the fallback logic is unchanged by that PR — but the change-detection code it touches is the natural place to fix it.

## How did you test this change?

Added two tests to `prism.spec.ts`:

- **non-first block, caret in prose** — flips the 2nd block's `language` via `setNodeAttribute` and asserts the result equals a from-scratch highlight (and differs from before). This fails on `main` (stale `js` tokens survive on the now-`css` block) and passes with the fix.
- **first block via `setNodeAttribute`** — locks in that the first-block path keeps working.

```
✓ src/__test__/prism.spec.ts (16 tests) — all passing
oxlint: 0 warnings, 0 errors
tsc -b: exit 0
```

Verified the non-first test fails against `origin/main`'s `index.ts` and passes with the change applied.