### PR TITLE
fix(docs): pin builddocs to 1.x to fix api docs build

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,12 @@
       "groupName": "prosemirror"
     },
     {
+      "matchDepNames": ["builddocs"],
+      "description": "builddocs 2.x is an incompatible rewrite (HTML output, no markdown/templates); stay on 1.x",
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Build API docs
+        run: pnpm --filter=@milkdown/docs run build
+
       - name: Publish snapshot
         if: ${{ github.event_name == 'pull_request' }}
         run: >

--- a/docs/api/preset-commonmark.md
+++ b/docs/api/preset-commonmark.md
@@ -166,6 +166,7 @@ Editor.make()
 @linkSchema
 @toggleLinkCommand
 @updateLinkCommand
+@sanitizeLinkHref
 
 ---
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
-    "builddocs": "^2.0.0",
+    "builddocs": "^1.0.9",
     "fs-extra": "^11.3.0"
   }
 }

--- a/docs/src/index.ts
+++ b/docs/src/index.ts
@@ -32,7 +32,7 @@ const logError = (error: unknown) => {
 const write = readdirSync(apiDir)
   .filter((dir) => dir !== '.DS_Store')
   .map((pathname) => parse(pathname).name)
-  .map(async (name) => {
+  .map(async (name): Promise<boolean> => {
     const main = resolve(apiDir, `${name}.md`)
     const out = resolve(apiOutDir, `${name}.md`)
 
@@ -51,9 +51,11 @@ const write = readdirSync(apiDir)
         })
         await writeFile(out, markdown)
         logger.info(`Build module: @milkdown/${name} finished.`)
+        return true
       } catch (error) {
         logger.error(`Build module: @milkdown/${name} failed.`)
         logError(error)
+        return false
       }
     } catch {
       // copy the main file to out
@@ -61,17 +63,26 @@ const write = readdirSync(apiDir)
       try {
         await copyFile(main, out)
         logger.info(`Copy module: @milkdown/${name} finished.`)
+        return true
       } catch (error) {
         logger.error(`Copy module: @milkdown/${name} failed.`)
         logError(error)
+        return false
       }
     }
   })
 
 Promise.all(write)
-  .then(() => {
+  .then((results) => {
+    const failed = results.filter((ok) => !ok).length
+    if (failed > 0) {
+      logger.error(`Build api failed: ${failed} module(s) could not be built.`)
+      process.exitCode = 1
+      return
+    }
     logger.info('Build api done.')
   })
   .catch((error) => {
-    throw error
+    logError(error)
+    process.exitCode = 1
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^11.0.4
         version: 11.0.4
       builddocs:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^1.0.9
+        version: 1.0.9
       fs-extra:
         specifier: ^11.3.0
         version: 11.4.0
@@ -3435,8 +3435,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  builddocs@2.0.1:
-    resolution: {integrity: sha512-wyhStIWjt7PUGMhYeve+64TxdMNFXwSfr0KT+FQLgsdWyevVELrPuhEFrO0rNBhTZHKtmlEWk5mVGOgFsyGdKQ==}
+  builddocs@1.0.9:
+    resolution: {integrity: sha512-qSHzWHVuw+9ftvGdEYNHeFcCddKT2xwmp8qq73CNm0mn2/ZC97vNge6/7J4zygdP/HGJ28DA6biP0VoeJ5VYyA==}
+    hasBin: true
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -3755,6 +3756,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
@@ -3909,6 +3914,10 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  getdocs-ts@1.0.1:
+    resolution: {integrity: sha512-gF/QEDE9H/sNANIJr1l1cpX0Atxfv293xsb3/H7MvSN9jTDbBGBKhy5Sz10NgcrZLaWa8QzjHIitbwDx0lbQVQ==}
+    hasBin: true
 
   git-cz@4.9.0:
     resolution: {integrity: sha512-cSRL8IIOXU7UFLdbziCYqg8f8InwLwqHezkiRHNSph7oZqGv0togId1kMTfKil6gzK0VaSXeVBb4oDl0fQCHiw==}
@@ -4349,6 +4358,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   lint-staged@17.3.0:
     resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
@@ -4386,6 +4398,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-it-deflist@3.0.1:
+    resolution: {integrity: sha512-pPtXxihDMi9jrwLLQ+Jra/FM20F/FFJWiVjXf0Js6Lwp7LFj+MuK6cUJNMVTRL+n9d/JqF4MEqYZwSMgVodK5g==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4434,6 +4453,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4570,6 +4592,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mold-template@2.0.2:
+    resolution: {integrity: sha512-8VqPPC8l3MtB5rrkekA/CKINh+X18KumW2lCr2xId8cP6bxONUOEhQW+cYM8gfsuS1A8bYo1w122/vyFsuWYaQ==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -4964,6 +4989,10 @@ packages:
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -5386,8 +5415,8 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5395,6 +5424,9 @@ packages:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   unbash@4.0.4:
     resolution: {integrity: sha512-60m9IVGbavD6jholbxt0jVBXZkEB/HsMZq7Tyaghseve2/Sf0zQRAIfWsD34sde+DKP2tBxJS2wP88ZM0D1FhA==}
@@ -7996,9 +8028,12 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  builddocs@2.0.1:
+  builddocs@1.0.9:
     dependencies:
-      typescript: 6.0.3
+      getdocs-ts: 1.0.1
+      markdown-it: 14.3.0
+      markdown-it-deflist: 3.0.1
+      mold-template: 2.0.2
 
   bundle-name@4.1.0:
     dependencies:
@@ -8285,6 +8320,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@4.5.0: {}
+
   entities@7.0.1: {}
 
   entities@8.0.0: {}
@@ -8443,6 +8480,10 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  getdocs-ts@1.0.1:
+    dependencies:
+      typescript: 5.9.3
 
   git-cz@4.9.0: {}
 
@@ -8852,6 +8893,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   lint-staged@17.3.0:
     dependencies:
       picomatch: 4.0.5
@@ -8885,6 +8930,17 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it-deflist@3.0.1: {}
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -9021,6 +9077,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.1.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -9259,6 +9317,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  mold-template@2.0.2: {}
 
   mri@1.2.0: {}
 
@@ -9714,6 +9774,8 @@ snapshots:
       prosemirror-view: 1.42.2
 
   proto-list@1.2.4: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -10212,7 +10274,7 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  typescript@6.0.3: {}
+  typescript@5.9.3: {}
 
   typescript@7.0.2:
     optionalDependencies:
@@ -10236,6 +10298,8 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
+
+  uc.micro@2.1.0: {}
 
   unbash@4.0.4: {}
 


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

`pnpm -F @milkdown/docs run build` currently fails for every module with:

```
TypeError: (0 , import_builddocs.build) is not a function
    at docs/src/index.ts:45:26
```

Root cause: #2404 ("bump up all dependencies") upgraded `builddocs` from `^1.0.8` to `^2.0.0`. builddocs 2.x is an **incompatible rewrite** — the `build({ name, filename, main, format, templates })` function was replaced by `buildDocs({ modules, renderMarkdown, ... })`, which emits **HTML** (`ModuleDocs[].text = builder.html`) and drops both the markdown output (`format: 'markdown'`) and the `templates` mechanism the docs script relies on to generate `docs/lib/*.md`. Migrating to 2.x would change the generated output from markdown to HTML and require rewriting the consumers — out of scope for a build fix.

This PR also fixes **why CI never caught the break**: the docs build already runs in the `build` job (via `pnpm -r run build`), but `docs/src/index.ts` logged each module failure and then resolved anyway, so the process exited `0` even when all 24 modules failed.

### Changes
- **`docs/package.json`**: pin `builddocs` `^2.0.0` → `^1.0.9` (restores the markdown-producing 1.x API).
- **`.github/renovate.json`**: block `builddocs` **major** upgrades so it isn't auto-bumped back to the incompatible 2.x (patches within 1.x still flow).
- **`docs/src/index.ts`**: exit non-zero when any module fails to build, so a broken build actually fails instead of silently exiting 0.
- **`docs/api/preset-commonmark.md`**: add `@sanitizeLinkHref` to the template — a public export added in #2410 that was missing from the doc template (previously logged `Item sanitizeLinkHref is missing from the doc template`).
- **`.github/workflows/ci.yml`**: run the api docs build as an explicit, named step in the `build` job so regressions are caught going forward.
- `pnpm-lock.yaml`: relock.

## How did you test this change?

Success path — all modules build, exit `0`:

```
$ pnpm -F @milkdown/docs run build
...
[docs] Build module: @milkdown/transformer finished.
[docs] Build api done.
$ echo $?
0
```

No more `sanitizeLinkHref` warning, and it renders in the output:

```
$ grep -n sanitizeLinkHref docs/lib/preset-commonmark.md
393: #### sanitizeLinkHref `(href: unknown) → string`
```

Failure now actually fails (temporarily broke the template dir to force it):

```
[docs] Build api failed: 24 module(s) could not be built.
$ echo $?
1
```

`oxlint` and `tsc -b docs/tsconfig.json` both pass clean.
