### PR TITLE
fix(prose): respect inline code in mark input rules

### DIFF
--- a/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { Editor, editorViewCtx } from '@milkdown/core'
+import { TextSelection } from '@milkdown/prose/state'
 import { getMarkdown } from '@milkdown/utils'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
@@ -11,6 +12,18 @@ async function createEditor() {
   editor.use(commonmark)
   await editor.create()
   return editor
+}
+
+// Moving the caret drops the stored marks, so the input rule can no longer rely
+// on them to tell whether the next character lands inside an inline code span.
+function moveCaret(editor: Editor, pos?: number) {
+  const view = editor.ctx.get(editorViewCtx)
+  const { state } = view
+  view.dispatch(
+    state.tr.setSelection(
+      TextSelection.create(state.doc, pos ?? state.selection.from)
+    )
+  )
 }
 
 function textWithMark(editor: Editor, markName: string) {
@@ -40,6 +53,22 @@ describe('mark input rules around inline code', () => {
     expect(editor.action(getMarkdown())).toBe('`*_mm`and`*_nn`\n')
   })
 
+  it('keeps delimiters typed inside an existing inline code literal', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, '`ab`')
+    // put the caret between `a` and `b`, inside the code span
+    view.focus()
+    moveCaret(editor, 2)
+    await user.keyboard('*x*')
+
+    expect(textWithMark(editor, 'inlineCode')).toEqual(['a*x*b'])
+    expect(textWithMark(editor, 'emphasis')).toEqual([])
+    expect(editor.action(getMarkdown())).toBe('`a*x*b`\n')
+  })
+
   it.each(['*`code`*', '**`code`**', '*a `code` b*'])(
     'still creates an outer mark for %s',
     async (markdown) => {
@@ -49,6 +78,25 @@ describe('mark input rules around inline code', () => {
       await user.type(editor.ctx.get(editorViewCtx).dom, markdown)
 
       expect(editor.action(getMarkdown())).toBe(`${markdown}\n`)
+    }
+  )
+
+  it.each([
+    ['*`code`', '*'],
+    ['**`code`', '**'],
+  ])(
+    'still creates an outer mark for %s%s when the caret moved',
+    async (typed, closingDelimiter) => {
+      const user = userEvent.setup()
+      const editor = await createEditor()
+      const view = editor.ctx.get(editorViewCtx)
+
+      await user.type(view.dom, typed)
+      moveCaret(editor)
+      await user.type(view.dom, closingDelimiter)
+
+      expect(textWithMark(editor, 'inlineCode')).toEqual(['code'])
+      expect(editor.action(getMarkdown())).toBe(`${typed}${closingDelimiter}\n`)
     }
   )
 })

--- a/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
@@ -87,9 +87,7 @@ describe('mark input rules around inline code', () => {
 
   it.each([
     ['*`code`', '*'],
-    ['**`code`', '**'],
     ['_`code`', '_'],
-    ['__`code`', '__'],
   ])(
     'still creates an outer mark for %s%s when the caret moved',
     async (typed, closingDelimiter) => {
@@ -105,4 +103,54 @@ describe('mark input rules around inline code', () => {
       expect(editor.action(getMarkdown())).toBe(`${typed}${closingDelimiter}\n`)
     }
   )
+
+  // The inline code mark is inclusive, so once the caret has moved, the first
+  // half of a two character delimiter typed at the end of a code span joins that
+  // span. It is then literal code content, and closing the mark would delete it.
+  it.each([
+    ['**`code`', '**'],
+    ['__`code`', '__'],
+  ])(
+    'keeps %s%s literal when the caret moved',
+    async (typed, closingDelimiter) => {
+      const user = userEvent.setup()
+      const editor = await createEditor()
+      const view = editor.ctx.get(editorViewCtx)
+
+      await user.type(view.dom, typed)
+      moveCaret(editor)
+      await user.type(view.dom, closingDelimiter)
+
+      expect(textWithMark(editor, 'inlineCode')).toEqual([
+        `code${closingDelimiter}`,
+      ])
+      expect(textWithMark(editor, 'strong')).toEqual([])
+    }
+  )
+
+  it.each([
+    ['`foo*`bar*', 'foo*'],
+    ['`foo~~`bar~~', 'foo~~'],
+  ])(
+    'keeps the code span intact when its last character is a delimiter (%s)',
+    async (typed, code) => {
+      const user = userEvent.setup()
+      const editor = await createEditor()
+
+      await user.type(editor.ctx.get(editorViewCtx).dom, typed)
+
+      expect(textWithMark(editor, 'inlineCode')).toEqual([code])
+      expect(textWithMark(editor, 'emphasis')).toEqual([])
+    }
+  )
+
+  it('keeps a code span whose last character closes a delimiter pair', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+
+    await user.type(editor.ctx.get(editorViewCtx).dom, '**bar`x*`*')
+
+    expect(textWithMark(editor, 'inlineCode')).toEqual(['x*'])
+    expect(textWithMark(editor, 'strong')).toEqual([])
+  })
 })

--- a/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
@@ -69,21 +69,27 @@ describe('mark input rules around inline code', () => {
     expect(editor.action(getMarkdown())).toBe('`a*x*b`\n')
   })
 
-  it.each(['*`code`*', '**`code`**', '*a `code` b*'])(
-    'still creates an outer mark for %s',
-    async (markdown) => {
-      const user = userEvent.setup()
-      const editor = await createEditor()
+  it.each([
+    '*`code`*',
+    '**`code`**',
+    '*a `code` b*',
+    '_`code`_',
+    '__`code`__',
+    '_a `code` b_',
+  ])('still creates an outer mark for %s', async (markdown) => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
 
-      await user.type(editor.ctx.get(editorViewCtx).dom, markdown)
+    await user.type(editor.ctx.get(editorViewCtx).dom, markdown)
 
-      expect(editor.action(getMarkdown())).toBe(`${markdown}\n`)
-    }
-  )
+    expect(editor.action(getMarkdown())).toBe(`${markdown}\n`)
+  })
 
   it.each([
     ['*`code`', '*'],
     ['**`code`', '**'],
+    ['_`code`', '_'],
+    ['__`code`', '__'],
   ])(
     'still creates an outer mark for %s%s when the caret moved',
     async (typed, closingDelimiter) => {

--- a/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom/vitest'
+import { Editor, editorViewCtx } from '@milkdown/core'
+import { getMarkdown } from '@milkdown/utils'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { commonmark } from '..'
+
+async function createEditor() {
+  const editor = Editor.make()
+  editor.use(commonmark)
+  await editor.create()
+  return editor
+}
+
+function textWithMark(editor: Editor, markName: string) {
+  const result: string[] = []
+  editor.ctx.get(editorViewCtx).state.doc.descendants((node) => {
+    if (node.marks.some((mark) => mark.type.name === markName))
+      result.push(node.text ?? '')
+  })
+  return result
+}
+
+describe('mark input rules around inline code', () => {
+  it('does not use a delimiter from inline code to create emphasis', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, '`*_mm`and`*')
+
+    expect(textWithMark(editor, 'inlineCode')).toEqual(['*_mm'])
+    expect(textWithMark(editor, 'emphasis')).toEqual([])
+
+    await user.type(view.dom, '_nn`')
+
+    expect(textWithMark(editor, 'inlineCode')).toEqual(['*_mm', '*_nn'])
+    expect(textWithMark(editor, 'emphasis')).toEqual([])
+    expect(editor.action(getMarkdown())).toBe('`*_mm`and`*_nn`\n')
+  })
+
+  it.each(['*`code`*', '**`code`**', '*a `code` b*'])(
+    'still creates an outer mark for %s',
+    async (markdown) => {
+      const user = userEvent.setup()
+      const editor = await createEditor()
+
+      await user.type(editor.ctx.get(editorViewCtx).dom, markdown)
+
+      expect(editor.action(getMarkdown())).toBe(`${markdown}\n`)
+    }
+  )
+})

--- a/packages/plugins/preset-gfm/src/__test__/inline-code-input-rule.spec.ts
+++ b/packages/plugins/preset-gfm/src/__test__/inline-code-input-rule.spec.ts
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom/vitest'
+import { Editor, editorViewCtx } from '@milkdown/core'
+import { commonmark } from '@milkdown/preset-commonmark'
+import { TextSelection } from '@milkdown/prose/state'
+import { getMarkdown } from '@milkdown/utils'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { gfm } from '..'
+
+// The strikethrough input rule goes through the same `markRule` helper as the
+// CommonMark marks, so it follows the same inline code boundary policy.
+
+async function createEditor() {
+  const editor = Editor.make()
+  editor.use(commonmark)
+  editor.use(gfm)
+  await editor.create()
+  return editor
+}
+
+// Moving the caret drops the stored marks, so the input rule can no longer rely
+// on them to tell whether the next character lands inside an inline code span.
+function moveCaret(editor: Editor, pos?: number) {
+  const view = editor.ctx.get(editorViewCtx)
+  const { state } = view
+  view.dispatch(
+    state.tr.setSelection(
+      TextSelection.create(state.doc, pos ?? state.selection.from)
+    )
+  )
+}
+
+describe('strikethrough input rule around inline code', () => {
+  it('keeps delimiters typed inside an existing inline code literal', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, '`ab`')
+    // put the caret between `a` and `b`, inside the code span
+    view.focus()
+    moveCaret(editor, 2)
+    await user.keyboard('~~x~~')
+
+    expect(editor.action(getMarkdown())).toBe('`a~~x~~b`\n')
+  })
+
+  it('still creates a strikethrough around inline code', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+
+    await user.type(editor.ctx.get(editorViewCtx).dom, '~~`code`~~')
+
+    expect(editor.action(getMarkdown())).toBe('~~`code`~~\n')
+  })
+
+  it('still creates a strikethrough around inline code when the caret moved', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, '~~`code`')
+    moveCaret(editor)
+    await user.type(view.dom, '~~')
+
+    expect(editor.action(getMarkdown())).toBe('~~`code`~~\n')
+  })
+})

--- a/packages/prose/src/toolkit/input-rules/mark-rule.ts
+++ b/packages/prose/src/toolkit/input-rules/mark-rule.ts
@@ -23,20 +23,16 @@ function rangeHasCodeMark(state: EditorState, from: number, to: number) {
   return found
 }
 
-// A code mark is inclusive, so text typed right after a code span inherits it.
-// Such text only belongs to the code span when the span continues after it.
-function codeSpanContinuesAfter(state: EditorState, pos: number) {
-  const { nodeAfter } = state.doc.resolve(pos)
-  return !!nodeAfter && hasCodeMark(nodeAfter.marks)
-}
-
-function delimiterInCodeSpan(state: EditorState, from: number, to: number) {
-  return rangeHasCodeMark(state, from, to) && codeSpanContinuesAfter(state, to)
-}
-
+// The character being typed carries no marks of its own yet, so they have to be
+// inferred from the insertion point. A code mark is inclusive, which means the
+// position right after a code span still reports one: the character only lands
+// inside the span when the span continues after it.
 function typedCharInCodeSpan(state: EditorState, pos: number) {
   const marks = state.storedMarks ?? state.doc.resolve(pos).marks()
-  return hasCodeMark(marks) && codeSpanContinuesAfter(state, pos)
+  if (!hasCodeMark(marks)) return false
+
+  const { nodeAfter } = state.doc.resolve(pos)
+  return !!nodeAfter && hasCodeMark(nodeAfter.marks)
 }
 
 /// Create an input rule for a mark.
@@ -76,17 +72,19 @@ export function markRule(
       const textEnd = textStart + group.length
 
       // Delimiters inside inline code are literal, but an inline code mark can
-      // still be valid content inside an outer mark such as *`code`*.
-      const openingDelimiterInCodeSpan = delimiterInCodeSpan(
+      // still be valid content inside an outer mark such as *`code`*. Delimiters
+      // already in the document are rejected on their marks alone, wherever they
+      // sit inside the span.
+      const openingDelimiterHasCodeMark = rangeHasCodeMark(
         state,
         start + startSpaces,
         textStart
       )
-      const closingDelimiterInCodeSpan =
-        textEnd < end && delimiterInCodeSpan(state, textEnd, end)
+      const closingDelimiterHasCodeMark =
+        textEnd < end && rangeHasCodeMark(state, textEnd, end)
       if (
-        openingDelimiterInCodeSpan ||
-        closingDelimiterInCodeSpan ||
+        openingDelimiterHasCodeMark ||
+        closingDelimiterHasCodeMark ||
         typedCharInCodeSpan(state, end)
       )
         return null

--- a/packages/prose/src/toolkit/input-rules/mark-rule.ts
+++ b/packages/prose/src/toolkit/input-rules/mark-rule.ts
@@ -4,18 +4,39 @@ import type { Captured, Options } from './common'
 
 import { InputRule } from '../../inputrules'
 
+// `MarkSpec.code` declares that the content of a span is literal.
+// `prosemirror-inputrules` keys its own `inCodeMark` barrier off the same flag.
+function hasCodeMark(marks: readonly Mark[]) {
+  return marks.some((mark) => mark.type.spec.code)
+}
+
 function rangeHasCodeMark(state: EditorState, from: number, to: number) {
+  // `nodesBetween` on an empty range still visits the node containing the
+  // position, which would report a code mark that the range does not cover.
+  if (from >= to) return false
+
   let found = false
   state.doc.nodesBetween(from, to, (node) => {
-    if (node.isInline && node.marks.some((mark) => mark.type.spec.code))
-      found = true
+    if (node.isInline && hasCodeMark(node.marks)) found = true
+    return !found
   })
   return found
 }
 
-function inputHasCodeMark(state: EditorState, pos: number) {
+// A code mark is inclusive, so text typed right after a code span inherits it.
+// Such text only belongs to the code span when the span continues after it.
+function codeSpanContinuesAfter(state: EditorState, pos: number) {
+  const { nodeAfter } = state.doc.resolve(pos)
+  return !!nodeAfter && hasCodeMark(nodeAfter.marks)
+}
+
+function delimiterInCodeSpan(state: EditorState, from: number, to: number) {
+  return rangeHasCodeMark(state, from, to) && codeSpanContinuesAfter(state, to)
+}
+
+function typedCharInCodeSpan(state: EditorState, pos: number) {
   const marks = state.storedMarks ?? state.doc.resolve(pos).marks()
-  return marks.some((mark) => mark.type.spec.code)
+  return hasCodeMark(marks) && codeSpanContinuesAfter(state, pos)
 }
 
 /// Create an input rule for a mark.
@@ -56,17 +77,17 @@ export function markRule(
 
       // Delimiters inside inline code are literal, but an inline code mark can
       // still be valid content inside an outer mark such as *`code`*.
-      const openingDelimiterHasCodeMark = rangeHasCodeMark(
+      const openingDelimiterInCodeSpan = delimiterInCodeSpan(
         state,
         start + startSpaces,
         textStart
       )
-      const closingDelimiterHasCodeMark =
-        textEnd < end && rangeHasCodeMark(state, textEnd, end)
+      const closingDelimiterInCodeSpan =
+        textEnd < end && delimiterInCodeSpan(state, textEnd, end)
       if (
-        openingDelimiterHasCodeMark ||
-        closingDelimiterHasCodeMark ||
-        inputHasCodeMark(state, end)
+        openingDelimiterInCodeSpan ||
+        closingDelimiterInCodeSpan ||
+        typedCharInCodeSpan(state, end)
       )
         return null
 

--- a/packages/prose/src/toolkit/input-rules/mark-rule.ts
+++ b/packages/prose/src/toolkit/input-rules/mark-rule.ts
@@ -1,7 +1,22 @@
 import type { Mark, MarkType } from '../../model'
+import type { EditorState } from '../../state'
 import type { Captured, Options } from './common'
 
 import { InputRule } from '../../inputrules'
+
+function rangeHasCodeMark(state: EditorState, from: number, to: number) {
+  let found = false
+  state.doc.nodesBetween(from, to, (node) => {
+    if (node.isInline && node.marks.some((mark) => mark.type.spec.code))
+      found = true
+  })
+  return found
+}
+
+function inputHasCodeMark(state: EditorState, pos: number) {
+  const marks = state.storedMarks ?? state.doc.resolve(pos).marks()
+  return marks.some((mark) => mark.type.spec.code)
+}
 
 /// Create an input rule for a mark.
 export function markRule(
@@ -38,6 +53,22 @@ export function markRule(
       const startSpaces = fullMatch.search(/\S/)
       const textStart = start + fullMatch.indexOf(group)
       const textEnd = textStart + group.length
+
+      // Delimiters inside inline code are literal, but an inline code mark can
+      // still be valid content inside an outer mark such as *`code`*.
+      const openingDelimiterHasCodeMark = rangeHasCodeMark(
+        state,
+        start + startSpaces,
+        textStart
+      )
+      const closingDelimiterHasCodeMark =
+        textEnd < end && rangeHasCodeMark(state, textEnd, end)
+      if (
+        openingDelimiterHasCodeMark ||
+        closingDelimiterHasCodeMark ||
+        inputHasCodeMark(state, end)
+      )
+        return null
 
       initialStoredMarks = tr.storedMarks ?? []
 


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2446.

Mark input rules flatten the text before the cursor before matching Markdown delimiters. As a result, a delimiter already contained in an `inlineCode` mark could be reused as an emphasis delimiter outside that code span. The transformation then removed the literal code character and applied an overlapping mark.

This change rejects a mark input rule when its opening or closing delimiter belongs to a code mark. It checks only the delimiter positions, so valid outer marks that contain inline code, such as ``*`code`*`` and ``**`code`**``, continue to work.

The regression test reproduces the sequential input `` `*_mm`and`*_nn` ``, verifies that both inline-code values remain intact, and covers valid outer emphasis and strong marks.

## How did you test this change?

- `pnpm test` — 49 test files and 383 tests passed
- `pnpm build` — all packages and Storybook built successfully
- `pnpm exec vitest run packages/plugins/preset-gfm/src` — 4 test files and 20 tests passed

Rebase merge is preferred. Please delete the feature branch after merge.

Co-Authored-By: Zero <zero@vm0.ai>
