### PR TITLE
fix(preset-commonmark): make the inline code mark not inclusive

### DIFF
--- a/packages/crepe/src/feature/cursor/index.ts
+++ b/packages/crepe/src/feature/cursor/index.ts
@@ -33,6 +33,10 @@ export const cursor: DefineFeature<CursorFeatureConfig> = (editor, config) => {
     return
   }
 
-  const virtualCursor = createVirtualCursor()
+  // `inlineCode` is deliberately not inclusive, so that typing at the end of a
+  // code span leaves it. The virtual cursor handles that boundary rather than
+  // being broken by it: it renders which side the caret is on, and the arrow
+  // keys move between the two. So its warning about the mark does not apply.
+  const virtualCursor = createVirtualCursor({ skipWarning: ['inlineCode'] })
   editor.use($prose(() => virtualCursor))
 }

--- a/packages/plugins/preset-commonmark/src/__test__/inline-code-boundary.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/inline-code-boundary.spec.ts
@@ -1,0 +1,81 @@
+import '@testing-library/jest-dom/vitest'
+import { Editor, editorViewCtx } from '@milkdown/core'
+import { TextSelection } from '@milkdown/prose/state'
+import { getMarkdown } from '@milkdown/utils'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { commonmark } from '..'
+
+async function createEditor() {
+  const editor = Editor.make()
+  editor.use(commonmark)
+  await editor.create()
+  return editor
+}
+
+// The input rule leaves the stored marks it found before it ran, which hides an
+// inherited code mark until the next selection change resets them to `null`.
+function moveCaret(editor: Editor, pos?: number) {
+  const view = editor.ctx.get(editorViewCtx)
+  const { state } = view
+  view.dispatch(
+    state.tr.setSelection(
+      TextSelection.create(state.doc, pos ?? state.selection.from)
+    )
+  )
+}
+
+function textWithMark(editor: Editor, markName: string) {
+  const result: string[] = []
+  editor.ctx.get(editorViewCtx).state.doc.descendants((node) => {
+    if (node.marks.some((mark) => mark.type.name === markName))
+      result.push(node.text ?? '')
+  })
+  return result
+}
+
+// https://github.com/Milkdown/milkdown/issues/2447
+// A code span is a closed run of literal text, so typing at its end has to
+// leave it, whether or not the caret moved in between.
+describe('inline code boundary (#2447)', () => {
+  it('types plain text after a code span', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, '`code`')
+    await user.type(view.dom, 'tail')
+
+    expect(textWithMark(editor, 'inlineCode')).toEqual(['code'])
+    expect(editor.action(getMarkdown())).toBe('`code`tail\n')
+  })
+
+  it('types plain text after a code span when the caret moved', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, '`code`')
+    moveCaret(editor)
+    await user.type(view.dom, 'tail')
+
+    expect(textWithMark(editor, 'inlineCode')).toEqual(['code'])
+    expect(editor.action(getMarkdown())).toBe('`code`tail\n')
+  })
+
+  it('still extends the span when typing inside it', async () => {
+    const user = userEvent.setup()
+    const editor = await createEditor()
+    const view = editor.ctx.get(editorViewCtx)
+
+    await user.type(view.dom, '`code`')
+    view.focus()
+    // put the caret between `cod` and `e`, inside the code span
+    moveCaret(editor, 4)
+    await user.keyboard('x')
+
+    expect(textWithMark(editor, 'inlineCode')).toEqual(['codxe'])
+    expect(editor.action(getMarkdown())).toBe('`codxe`\n')
+  })
+})

--- a/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/inline-code-input-rule.spec.ts
@@ -85,9 +85,14 @@ describe('mark input rules around inline code', () => {
     expect(editor.action(getMarkdown())).toBe(`${markdown}\n`)
   })
 
+  // The inline code mark is not inclusive, so a delimiter typed at the end of a
+  // code span stays outside it and can still close an outer mark, however many
+  // characters it has.
   it.each([
     ['*`code`', '*'],
     ['_`code`', '_'],
+    ['**`code`', '**'],
+    ['__`code`', '__'],
   ])(
     'still creates an outer mark for %s%s when the caret moved',
     async (typed, closingDelimiter) => {
@@ -101,30 +106,6 @@ describe('mark input rules around inline code', () => {
 
       expect(textWithMark(editor, 'inlineCode')).toEqual(['code'])
       expect(editor.action(getMarkdown())).toBe(`${typed}${closingDelimiter}\n`)
-    }
-  )
-
-  // The inline code mark is inclusive, so once the caret has moved, the first
-  // half of a two character delimiter typed at the end of a code span joins that
-  // span. It is then literal code content, and closing the mark would delete it.
-  it.each([
-    ['**`code`', '**'],
-    ['__`code`', '__'],
-  ])(
-    'keeps %s%s literal when the caret moved',
-    async (typed, closingDelimiter) => {
-      const user = userEvent.setup()
-      const editor = await createEditor()
-      const view = editor.ctx.get(editorViewCtx)
-
-      await user.type(view.dom, typed)
-      moveCaret(editor)
-      await user.type(view.dom, closingDelimiter)
-
-      expect(textWithMark(editor, 'inlineCode')).toEqual([
-        `code${closingDelimiter}`,
-      ])
-      expect(textWithMark(editor, 'strong')).toEqual([])
     }
   )
 

--- a/packages/plugins/preset-commonmark/src/mark/inline-code.ts
+++ b/packages/plugins/preset-commonmark/src/mark/inline-code.ts
@@ -24,6 +24,11 @@ withMeta(inlineCodeAttr, {
 export const inlineCodeSchema = $markSchema('inlineCode', (ctx) => ({
   priority: 100,
   code: true,
+  // A code span has a closed end: text typed after it is not part of it, and
+  // typing is the only way to leave a span that ends a block. It also keeps a
+  // code mark on a delimiter meaningful, since the delimiter is then genuinely
+  // inside the span — the mark input rules key their decisions off that.
+  inclusive: false,
   parseDOM: [{ tag: 'code' }],
   toDOM: (mark) => ['code', ctx.get(inlineCodeAttr.key)(mark)],
   parseMarkdown: {

--- a/packages/prose/src/toolkit/input-rules/mark-rule.ts
+++ b/packages/prose/src/toolkit/input-rules/mark-rule.ts
@@ -24,15 +24,12 @@ function rangeHasCodeMark(state: EditorState, from: number, to: number) {
 }
 
 // The character being typed carries no marks of its own yet, so they have to be
-// inferred from the insertion point. A code mark is inclusive, which means the
-// position right after a code span still reports one: the character only lands
-// inside the span when the span continues after it.
+// inferred from the insertion point, exactly like the editor does when it
+// inserts the text. A non-inclusive code mark is already dropped by `marks()`
+// at the end of a span, so the position only reports one while the caret is
+// inside the span.
 function typedCharInCodeSpan(state: EditorState, pos: number) {
-  const marks = state.storedMarks ?? state.doc.resolve(pos).marks()
-  if (!hasCodeMark(marks)) return false
-
-  const { nodeAfter } = state.doc.resolve(pos)
-  return !!nodeAfter && hasCodeMark(nodeAfter.marks)
+  return hasCodeMark(state.storedMarks ?? state.doc.resolve(pos).marks())
 }
 
 /// Create an input rule for a mark.


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2447.

`inlineCodeSchema` declares `code: true` but left `inclusive` at ProseMirror's default of `true`, so `$pos.marks()` at the end of a code span still reported the code mark and every following keystroke inherited it. The inline code input rule hid this by restoring the stored marks it found (`tr.setStoredMarks(initialStoredMarks)`), but any selection change resets `storedMarks` to `null` and the inherited mark becomes visible: typing `tail` after `` `code` `` produced `` `codetail` ``.

Adding `inclusive: false` also removes an ambiguity from the document model. A delimiter carrying a code mark is now always genuinely inside the span, so:

- `` **`code`** `` and `` __`code`__ `` apply the outer mark again after the caret has moved — the conservative behavior #2445 had to settle for.
- `` `foo*`bar* `` still keeps its literal `*` inside the code span.

The two tests added by #2445 that pinned the old behavior are replaced by those positive assertions.

Two related cleanups:

- `typedCharInCodeSpan` in `mark-rule.ts` no longer compensates for the inclusive mark by inspecting the node after the insertion point. `marks()` already drops a non-inclusive mark at the end of a span, and dropping the check also makes the `storedMarks` path correct — a code mark explicitly stored at a span's end used to be reported as *outside* the span.
- `inclusive: false` was originally removed in #1771 in favor of the virtual cursor. That cursor is only wired up in Crepe (`packages/crepe/src/feature/cursor/index.ts`), so plain `@milkdown/preset-commonmark` users were left with no way out of a code span at all. It also handles a non-inclusive mark rather than being broken by one — it renders which side of the boundary the caret is on and the arrow keys move between the two — so `createVirtualCursor` now gets `skipWarning: ['inlineCode']` instead of logging its warning.

`strikethrough` and the other marks are unchanged: inclusive is the wanted behavior for them, and `inlineCode` is the only `code: true` mark in the repo.

## How did you test this change?

New `packages/plugins/preset-commonmark/src/__test__/inline-code-boundary.spec.ts` covers the issue directly: typing after a code span with and without an intervening selection change, plus typing inside the span to check it still extends.

```
pnpm test:unit          # 51 files / 400 tests passed
pnpm test:lint          # clean
pnpm build:tsc          # clean
pnpm --filter=@milkdown/e2e test   # 179 passed
```

Before the fix, the two obsolete `keeps **`code`** literal when the caret moved` cases fail exactly as #2447 predicted (`['code']` vs `['code**']`) and nothing else in the suite does.

The e2e paths that could plausibly be affected by the mark inheritance change all pass: `plugin/automd.spec.ts` (`inline code with * and _`), `plugin/clipboard.spec.ts` (`paste inline text only html should extend mark`), `crepe/insert-macro.spec.ts` (`should inline macro extend current mark`), `input/code-inline.spec.ts` and `shortcut/code-inline.spec.ts`.
