### PR TITLE
fix: keep the dragged node on view.dragging when using the block handle

### DIFF
--- a/e2e/tests/crepe/block-handle.spec.ts
+++ b/e2e/tests/crepe/block-handle.spec.ts
@@ -1,0 +1,56 @@
+import type { Locator } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+
+import { focusEditor, setMarkdown, waitNextFrame } from '../misc'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/crepe/')
+})
+
+async function centerOf(locator: Locator) {
+  const box = await locator.boundingBox()
+  if (!box) throw new Error('cannot measure element')
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2, box }
+}
+
+test('should be able to drag and drop a list item', async ({ page }) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await setMarkdown(page, '- item 1\n- item 2\n- item 3\n- item 4\n')
+  await waitNextFrame(page)
+
+  const items = editor.locator('ul li')
+  await expect(items).toHaveCount(4)
+
+  await items.nth(1).hover()
+  const blockHandle = page.locator('.milkdown-block-handle')
+  await expect(blockHandle).toBeVisible()
+
+  // The first operation item is the add button, the second one is the drag
+  // handle.
+  const { x: originX, y: originY } = await centerOf(
+    blockHandle.locator('.operation-item').nth(1)
+  )
+  const { x: targetX, box: targetBox } = await centerOf(items.nth(3))
+
+  await page.mouse.move(originX, originY)
+  await page.mouse.down()
+  // Two moves: the first one starts the native drag, the second one lands on
+  // the bottom half of the last item so the drop point is after it.
+  await page.mouse.move(targetX, targetBox.y, { steps: 10 })
+  await waitNextFrame(page)
+  await page.mouse.move(targetX, targetBox.y + targetBox.height - 2, {
+    steps: 5,
+  })
+  await waitNextFrame(page)
+  await page.mouse.up()
+  await waitNextFrame(page)
+
+  // The moved item should not leave an empty item behind.
+  await expect(items).toHaveCount(4)
+  await expect(items.nth(0)).toContainText('item 1')
+  await expect(items.nth(1)).toContainText('item 3')
+  await expect(items.nth(2)).toContainText('item 4')
+  await expect(items.nth(3)).toContainText('item 2')
+})

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -45,7 +45,15 @@ export const listItemBlockView = $view(
         }
       })
       let raf = 0
+      let mountedDiv: HTMLElement | null = null
       const onMount = (div: HTMLElement) => {
+        // Vue invokes function refs on every patch, not only on mount.
+        // Re-running this would dispatch a text selection over whatever is
+        // currently selected, clobbering the node selection created by the
+        // block handle.
+        if (div === mountedDiv) return
+        mountedDiv = div
+
         const { anchor, head } = view.state.selection
         div.appendChild(contentDOM)
         // put the cursor to the new created list item

--- a/packages/plugins/plugin-block/src/__test__/block-drag.spec.ts
+++ b/packages/plugins/plugin-block/src/__test__/block-drag.spec.ts
@@ -1,0 +1,197 @@
+import type { Ctx } from '@milkdown/ctx'
+import type { Node } from '@milkdown/prose/model'
+
+import { editorViewCtx } from '@milkdown/core'
+import { Schema } from '@milkdown/prose/model'
+import {
+  EditorState,
+  NodeSelection,
+  TextSelection,
+} from '@milkdown/prose/state'
+import { EditorView } from '@milkdown/prose/view'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { blockConfig, defaultNodeFilter } from '../block-config'
+import { BlockService } from '../block-service'
+
+// Mirrors the commonmark preset closely enough for the drag math: `list_item`
+// is in its own group (not `block`), so a list item can only be dropped as a
+// sibling inside a list.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*', toDOM: () => ['p', 0] },
+    text: { group: 'inline' },
+    bullet_list: {
+      group: 'block',
+      content: 'listItem+',
+      toDOM: () => ['ul', 0],
+    },
+    list_item: {
+      group: 'listItem',
+      content: 'paragraph block*',
+      defining: true,
+      toDOM: () => ['li', 0],
+    },
+  },
+})
+
+function listItem(text: string) {
+  return schema.nodes.list_item!.create(
+    null,
+    schema.nodes.paragraph!.create(null, schema.text(text))
+  )
+}
+
+// doc(bullet_list(li"item 1", li"item 2", li"item 3", li"item 4"))
+// Every item is 10 wide, so the items start at 1, 11, 21 and 31.
+function createDoc() {
+  return schema.nodes.doc!.create(null, [
+    schema.nodes.bullet_list!.create(null, [
+      listItem('item 1'),
+      listItem('item 2'),
+      listItem('item 3'),
+      listItem('item 4'),
+    ]),
+  ])
+}
+
+const SECOND_ITEM = 11
+// The paragraph inside the second item, which is what `posAtCoords` resolves
+// to when hovering over that item.
+const SECOND_ITEM_PARAGRAPH = 12
+// The end of the text in the fourth item.
+const FOURTH_ITEM_TEXT_END = 39
+
+function itemTexts(view: EditorView) {
+  const list = view.state.doc.firstChild as Node
+  return Array.from(
+    { length: list.childCount },
+    (_, i) => list.child(i).textContent
+  )
+}
+
+function createDataTransfer() {
+  return {
+    effectAllowed: '',
+    clearData: () => {},
+    setData: () => {},
+    getData: () => '',
+    setDragImage: () => {},
+  }
+}
+
+// JSDOM implements neither `DragEvent` nor `DataTransfer`, but prosemirror
+// registers its listeners by event type, so a plain event carrying the bits
+// the handlers read is enough.
+function dispatchDragEvent(
+  el: Element,
+  type: string,
+  extra: Record<string, unknown> = {}
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, { dataTransfer: createDataTransfer() }, extra)
+  el.dispatchEvent(event)
+}
+
+describe('block drag', () => {
+  let view: EditorView
+  let service: BlockService
+  let handle: HTMLElement
+  let place: HTMLElement
+
+  beforeEach(() => {
+    place = document.createElement('div')
+    document.body.appendChild(place)
+    view = new EditorView(place, {
+      state: EditorState.create({ doc: createDoc() }),
+    })
+
+    service = new BlockService()
+    service.bind(
+      {
+        get: (slice: unknown) => {
+          if (slice === editorViewCtx) return view
+          if (slice === blockConfig.key)
+            return { filterNodes: defaultNodeFilter }
+          throw new Error('unexpected slice')
+        },
+      } as unknown as Ctx,
+      () => {}
+    )
+
+    handle = document.createElement('div')
+    document.body.appendChild(handle)
+    service.addEvent(handle)
+
+    // JSDOM cannot hit-test, so pretend the pointer is over the second item.
+    document.elementFromPoint = () => view.dom
+    view.posAtCoords = () => ({
+      pos: SECOND_ITEM_PARAGRAPH + 1,
+      inside: SECOND_ITEM_PARAGRAPH,
+    })
+
+    service.mousemoveCallback(view, { clientY: 0 } as MouseEvent)
+    handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+  })
+
+  afterEach(() => {
+    service.removeEvent(handle)
+    view.destroy()
+    handle.remove()
+    place.remove()
+  })
+
+  it('selects the whole list item on mousedown', () => {
+    const { selection } = view.state
+    expect(selection).toBeInstanceOf(NodeSelection)
+    expect(selection.from).toBe(SECOND_ITEM)
+    expect(selection.to).toBe(SECOND_ITEM + 10)
+  })
+
+  it('records the dragged node on view.dragging', () => {
+    dispatchDragEvent(handle, 'dragstart')
+
+    const { node } = (view.dragging ?? {}) as { node?: NodeSelection }
+    expect(node).toBeInstanceOf(NodeSelection)
+    expect(node?.node.type.name).toBe('list_item')
+    expect(node?.from).toBe(SECOND_ITEM)
+  })
+
+  it('moves the item even when the selection changes mid-drag', () => {
+    dispatchDragEvent(handle, 'dragstart')
+
+    // The list item node view re-dispatches a text selection over the node
+    // selection on the next frame, which used to make the drop delete only the
+    // item's text and leave an empty item behind.
+    const { doc } = view.state
+    view.dispatch(
+      view.state.tr.setSelection(
+        TextSelection.between(
+          doc.resolve(SECOND_ITEM),
+          doc.resolve(SECOND_ITEM + 10)
+        )
+      )
+    )
+    expect(view.state.selection).toBeInstanceOf(TextSelection)
+
+    // Drop at the end of the fourth item.
+    view.posAtCoords = () => ({
+      pos: FOURTH_ITEM_TEXT_END,
+      inside: FOURTH_ITEM_TEXT_END - 7,
+    })
+    dispatchDragEvent(view.dom, 'drop', { clientX: 0, clientY: 0 })
+
+    expect(itemTexts(view)).toEqual(['item 1', 'item 3', 'item 4', 'item 2'])
+  })
+
+  it('clears view.dragging when the drag is cancelled', async () => {
+    dispatchDragEvent(handle, 'dragstart')
+    expect(view.dragging).not.toBeNull()
+
+    dispatchDragEvent(handle, 'dragend')
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    expect(view.dragging).toBeNull()
+  })
+})

--- a/packages/plugins/plugin-block/src/__test__/vitest.setup.ts
+++ b/packages/plugins/plugin-block/src/__test__/vitest.setup.ts
@@ -1,0 +1,65 @@
+// Mock missing DOM APIs that ProseMirror needs but JSDOM doesn't provide
+
+// Mock elementFromPoint
+if (!document.elementFromPoint) {
+  document.elementFromPoint = () => null
+}
+
+// Mock getClientRects for all elements
+Object.defineProperty(Element.prototype, 'getClientRects', {
+  value: function () {
+    return {
+      length: 0,
+      item: () => null,
+      [Symbol.iterator]: function* () {},
+    }
+  },
+})
+
+Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+  value: function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    }
+  },
+})
+
+// Mock Range methods
+Object.defineProperty(Range.prototype, 'getClientRects', {
+  value: function () {
+    return {
+      length: 0,
+      item: () => null,
+      [Symbol.iterator]: function* () {},
+    }
+  },
+})
+
+Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+  value: function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    }
+  },
+})
+
+// Mock scrollIntoView
+Object.defineProperty(Element.prototype, 'scrollIntoView', {
+  value: function () {},
+})

--- a/packages/plugins/plugin-block/src/block-service.ts
+++ b/packages/plugins/plugin-block/src/block-service.ts
@@ -1,5 +1,4 @@
 import type { Ctx } from '@milkdown/ctx'
-import type { Selection } from '@milkdown/prose/state'
 import type { EditorView } from '@milkdown/prose/view'
 
 import { editorViewCtx } from '@milkdown/core'
@@ -33,6 +32,16 @@ export type BlockServiceMessageType =
 export type BlockServiceMessage = (message: BlockServiceMessageType) => void
 
 /// @internal
+/// prosemirror-view keeps an optional `node` on `view.dragging`: the
+/// `NodeSelection` of the node being dragged. Both prosemirror-view and
+/// prosemirror-drop-indicator use it in `handleDrop` to remove exactly that
+/// node, and fall back to `tr.deleteSelection()` when it is absent. The field
+/// is missing from the published types, so we widen it here.
+type Dragging = NonNullable<EditorView['dragging']> & {
+  node?: NodeSelection
+}
+
+/// @internal
 /// The block service, provide events and methods for block plugin.
 /// Generally you don't need to use this class directly.
 export class BlockService {
@@ -40,10 +49,12 @@ export class BlockService {
   #ctx?: Ctx
 
   /// @internal
-  #createSelection: () => null | Selection = () => {
+  #createSelection: () => null | NodeSelection = () => {
     if (!this.#active) return null
     const result = this.#active
     const view = this.#view
+
+    this.#activeSelection = null
 
     if (view && NodeSelection.isSelectable(result.node)) {
       const nodeSelection = NodeSelection.create(
@@ -59,7 +70,7 @@ export class BlockService {
   }
 
   /// @internal
-  #activeSelection: null | Selection = null
+  #activeSelection: null | NodeSelection = null
   /// @internal
   #active: null | ActiveNode = null
   /// @internal
@@ -166,18 +177,35 @@ export class BlockService {
       const activeEl = this.#active?.el
       if (activeEl) event.dataTransfer.setDragImage(activeEl, 0, 0)
 
-      view.dragging = {
+      // Hand prosemirror the node selection we captured on mousedown so the
+      // move deletes exactly the node we picked up. Without it prosemirror
+      // falls back to `tr.deleteSelection()` on whatever the live selection is
+      // at drop time, which may only strip the text and leave an empty block.
+      const dragging: Dragging = {
         slice,
         move: true,
+        node: selection,
       }
+      view.dragging = dragging
     }
   }
 
   /// @internal
   #handleDragEnd = () => {
-    if (this.#view) {
-      this.#dragEnd(this.#view)
-    }
+    const view = this.#view
+    if (!view) return
+
+    this.#dragEnd(view)
+
+    // `dragend` fires on the handle, which lives outside `view.dom`, so
+    // prosemirror-view's own dragend cleanup never runs for handle drags and
+    // `view.dragging` would survive a cancelled drag. Clear it the way
+    // prosemirror-view does, guarding against browsers that fire `dragend`
+    // before `drop`.
+    const dragging = view.dragging
+    window.setTimeout(() => {
+      if (view.dragging === dragging) view.dragging = null
+    }, 50)
   }
 
   /// @internal

--- a/packages/plugins/plugin-block/vitest.config.ts
+++ b/packages/plugins/plugin-block/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/__test__/vitest.setup.ts'],
+  },
+})


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2449 — reordering a list item with the block drag handle leaves an empty item behind:

```
- item 1
-            <- leftover
- item 3
- item 4
- item 2
```

Two things combine to cause it.

**1. `plugin-block` never told prosemirror which node was being dragged.**

`BlockService#handleDragStart` set `view.dragging = { slice, move: true }`, leaving out the `node` field. Both `prosemirror-view` and `prosemirror-drop-indicator` (which Crepe uses through `plugin-cursor`) do this on drop:

```js
if (move) {
  const { node } = dragging
  if (node) node.replace(tr)   // remove exactly the dragged node
  else tr.deleteSelection()    // fall back to the live selection
}
```

Without `node` the deletion depends entirely on whatever the selection happens to be at drop time. Prosemirror's own `dragstart` handler sets `node`; ours did not.

**2. The list item node view rewrote that selection mid-drag.**

`onMount` in `list-item-block/view.ts` is passed to Vue as a function ref, and Vue invokes function refs on *every* patch, not only on mount. Since `selected` is part of the render, pressing the handle triggers `selectNode()` → re-render → `onMount` runs again → next frame it dispatches `TextSelection.between($from, $to)` over the node selection the handle had just created.

For a node selection spanning a list item at `11..21`, `TextSelection.between` normalizes inward to `13..19` — the item's text. Deleting that leaves `<li><p></p></li>`, which is the empty bullet in the report.

This is a regression from #2422 (7.22): the previous `new TextSelection(anchorPos, headPos)` produced `11..21`, whose `.replace()` happens to take the same `tr.delete(11, 21)` path as a node selection, so the drag accidentally still worked.

### Changes

- `plugin-block`: put the node selection captured on mousedown on `view.dragging.node`, so the move deletes exactly the node that was picked up regardless of the live selection. Narrow `#activeSelection` to `NodeSelection` and reset it when a new one is created.
- `plugin-block`: clear `view.dragging` on `dragend`. The handle lives outside `view.dom`, so prosemirror's own dragend cleanup never runs for handle drags, and a cancelled drag would leave a stale slice and stale positions behind.
- `components`: make the list item mount hook idempotent. This also restores the `.ProseMirror-selectednode` highlight while dragging and drops a redundant transaction on every re-render.

## How did you test this change?

Both new tests were confirmed to reproduce the bug before confirming the fix.

**Unit** — new vitest project for `plugin-block` (`src/__test__/block-drag.spec.ts`, 4 cases). It drives the real `BlockService` against a raw prosemirror view, simulates the selection being clobbered mid-drag, and asserts the drop result. With `node` removed from `view.dragging` again:

```
AssertionError: expected [ 'item 1', '', 'item 3', …(2) ] to deeply equal [ 'item 1', 'item 3', 'item 4', …(1) ]

  [
    "item 1",
+   "",
    "item 3",
    "item 4",
    "item 2",
  ]
```

which is the issue's output verbatim.

**E2E** — `e2e/tests/crepe/block-handle.spec.ts` drags the second item of a four-item bullet list to the end with `page.mouse`, same approach as the existing table drag tests. With both fixes stashed:

```
Expect "toHaveCount" with timeout 5000ms
  - waiting for locator('.editor').locator('ul li')
    14 × locator resolved to 5 elements
       - unexpected value "5"
```

**Suites**

```
pnpm test:lint                        ✓
pnpm build:tsc                        ✓
pnpm test:unit                        ✓  51 files, 401 tests
pnpm codegen && git diff              ✓  no tsconfig drift
pnpm --filter=@milkdown/e2e test      179 passed, 1 failed
```

The one e2e failure is `crepe/streaming.spec.ts › empty selection with insertAt selection behaves like cursor`. It fails identically on a clean `main` with everything stashed, and passes when its file is run on its own — pre-existing cross-file flake, unrelated to this PR.

**Manual** (`/crepe/`)

- Drag item 2 of `1..4` to the bottom → `1, 3, 4, 2`, no empty bullet
- The dragged item keeps its selected highlight while dragging
- Paragraphs and headings still move correctly
- Alt/Ctrl-drag still copies (`handleDrop` recomputes `move` from the drop event, so neither branch runs)
- Cancel a drag with Esc, then drag text in from another app → nothing is deleted
