### PR TITLE
fix(components): sync readonly code block updates

### DIFF
--- a/e2e/tests/crepe/code.spec.ts
+++ b/e2e/tests/crepe/code.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-import { focusEditor } from '../misc'
+import { focusEditor, setMarkdown } from '../misc'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/crepe/')
@@ -62,6 +62,28 @@ test('should not be able to change language in readonly mode', async ({
 
   await languagePicker.click()
   await expect(languagePickerMenu).toBeVisible()
+})
+
+test('should apply programmatic code block updates in readonly mode', async ({
+  page,
+}) => {
+  const before = "const status = 'before'"
+  const after = "const status = 'after'"
+  await setMarkdown(page, `\`\`\`ts\n${before}\n\`\`\``)
+
+  const codeBlockContentArea = page.locator('.cm-content')
+  await expect(codeBlockContentArea).toHaveText(before)
+
+  await page.evaluate(() => {
+    window.__crepe__.setReadonly(true)
+  })
+  await setMarkdown(page, `\`\`\`ts\n${after}\n\`\`\``)
+
+  await expect(codeBlockContentArea).toHaveText(after)
+
+  await codeBlockContentArea.focus()
+  await page.keyboard.type(' ignored')
+  await expect(codeBlockContentArea).toHaveText(after)
 })
 
 test('should copy code block content', async ({ page, browserName }) => {

--- a/packages/components/src/code-block/view/node-view.ts
+++ b/packages/components/src/code-block/view/node-view.ts
@@ -122,7 +122,9 @@ export class CodeMirrorBlock implements NodeView {
         drawSelection(),
         cmKeymap.of(this.codeMirrorKeymap()),
         this.languageConf.of([]),
-        EditorState.changeFilter.of(() => this.view.editable),
+        // Block user edits when the editor is not editable, but always let
+        // updates we sync from ProseMirror through.
+        EditorState.changeFilter.of(() => this.view.editable || this.updating),
         ...this.config.extensions,
         CodeMirror.updateListener.of(this.forwardUpdate),
       ],
@@ -307,8 +309,11 @@ export class CodeMirrorBlock implements NodeView {
 
     this.cm.focus()
     this.updating = true
-    this.cm.dispatch({ selection: { anchor, head } })
-    this.updating = false
+    try {
+      this.cm.dispatch({ selection: { anchor, head } })
+    } finally {
+      this.updating = false
+    }
   }
 
   update(node: Node) {
@@ -343,12 +348,16 @@ export class CodeMirrorBlock implements NodeView {
     const change = computeChange(this.cm.state.doc.toString(), node.textContent)
     if (change) {
       this.updating = true
-      this.cm.dispatch({
-        changes: { from: change.from, to: change.to, insert: change.text },
-        scrollIntoView: true,
-        filter: false,
-      })
-      this.updating = false
+      try {
+        this.cm.dispatch({
+          changes: { from: change.from, to: change.to, insert: change.text },
+          // Only follow the change when the user can actually be editing here,
+          // so programmatic updates don't scroll a readonly editor around.
+          scrollIntoView: this.view.editable,
+        })
+      } finally {
+        this.updating = false
+      }
     }
     return true
   }

--- a/packages/components/src/code-block/view/node-view.ts
+++ b/packages/components/src/code-block/view/node-view.ts
@@ -346,6 +346,7 @@ export class CodeMirrorBlock implements NodeView {
       this.cm.dispatch({
         changes: { from: change.from, to: change.to, insert: change.text },
         scrollIntoView: true,
+        filter: false,
       })
       this.updating = false
     }


### PR DESCRIPTION
- [x] I read the contributing guide.
- [x] I agree to follow the code of conduct.

## Summary

Fixes #2454.

`CodeMirrorBlock` uses a change filter to prevent document edits while the outer ProseMirror view is read-only. The same filter also rejected the trusted transaction from `CodeMirrorBlock.update(node)`, leaving a mounted CodeMirror view stale after a programmatic parent-document update.

This PR bypasses change filters only for that internal ProseMirror-to-CodeMirror synchronization. Normal user changes still go through the existing read-only filter.

## Changes

- Set `filter: false` on the internal content dispatch in `CodeMirrorBlock.update(node)`.
- Add an E2E regression that updates a mounted code block while Crepe is read-only.
- Verify in the same test that keyboard input remains blocked after the programmatic update.

## Verification

- Regression test without the fix: failed as expected (`after` expected, `before` rendered).
- `pnpm --filter=@milkdown/e2e exec playwright test tests/crepe/code.spec.ts`: 3 passed.
- `pnpm test`: 52 test files and 404 tests passed; lint passed.
- `pnpm build`: passed.
- `pnpm build:tsc`: passed.
- `pnpm codegen`: passed with no generated diff.
- `oxfmt --check` and `git diff --check`: passed.

Rebase merge is preferred. Please delete the feature branch after merge.
