### PR TITLE
docs: apply a comment writing standard across the repo

### DIFF
--- a/.claude/skills/review-code-style/SKILL.md
+++ b/.claude/skills/review-code-style/SKILL.md
@@ -9,21 +9,43 @@ Review all changed or newly added code in this repository for code style and qua
 
 ### Naming & Structure
 
-- **Meaningful, consistent names** — same concept = same name throughout. Variable names should be pronounceable and searchable.
-- **Single Responsibility** — each module/function has one reason to change.
-- **Depend on abstractions** — use DI tags and interfaces, not concrete implementations directly.
+- **Meaningful, consistent names**. Use the same name for the same concept everywhere. Make a variable name pronounceable and searchable.
+- **Single Responsibility**. Give each module and function one reason to change.
+- **Depend on abstractions**. Use DI tags and interfaces, not concrete implementations.
 
 ### Code Quality
 
-- **No duplicated code** — similar code in multiple locations with the same calling context should be extracted.
-- **Avoid deep nesting** — max 3 levels of conditional nesting. Refactor with early returns or extraction.
-- **Short parameter lists** — more than 3-4 parameters suggests the need for an options object or restructuring.
-- **Self-documenting code** — comment only what the code cannot express through naming and structure. Remove comments that repeat what the code already says.
+- **No duplicated code**. Extract similar code that runs in the same calling context.
+- **Avoid deep nesting**. Keep conditional nesting to three levels. Refactor with an early return or an extraction.
+- **Short parameter lists**. More than three or four parameters asks for an options object.
+- **Self-documenting code**. Express intent through a name or a structure before you write a comment.
+
+### Comments
+
+When a comment may exist:
+
+- Write a comment only for what the code cannot show: a constraint, an invariant, a reason, an upstream or browser bug, a non-obvious order of operations.
+- Do not narrate the next line. Do not restate a name that the code already carries.
+- Do not record process history, for example "previously" or "per review feedback". Git history owns that. A regression test may state the bug it pins, in one sentence.
+- Write one concrete action in a `TODO`. Add the issue number when one exists: `TODO(#2463)`.
+- `///` is the public API reference. `builddocs` publishes it into `docs/api`. Keep every fact in it accurate.
+
+How a comment reads (adapted from ASD-STE100, Simplified Technical English):
+
+- Give one idea to one sentence. Keep a sentence to 25 words or fewer.
+- Use the active voice and the present tense. Use the imperative for an instruction.
+- Do not use an em dash. Use a period, a colon, or a comma.
+- Do not use the first person: "we", "our", "let's".
+- Use parentheses only for a reference or an example. Move a condition into its own sentence.
+- Use a list when a sentence carries more than three items.
+- Use one word for one meaning. Do not switch synonyms for the same concept.
+- Wrap at 80 columns, to match `printWidth` in `.oxfmtrc.json`.
+- Write in English only.
 
 ### Cleanup
 
-- **No dead code** — remove unused variables, functions, imports, and commented-out code blocks.
-- **Fix typos** — in variable names, comments, and strings.
+- **No dead code**. Remove an unused variable, function, or import. Remove a commented-out code block.
+- **Fix typos** in a name, a comment, and a string.
 
 ### SOLID Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,25 @@ You can run several commands:
 - `pnpm build` runs build for all packages.
 - `pnpm commit` runs commit with git hooks.
 
+# Comments
+
+A comment must earn its place. Follow these rules:
+
+- Write a comment only for what the code cannot show: a constraint, an invariant, a reason, an upstream or browser bug, a non-obvious order of operations.
+- Do not narrate the next line. Do not restate a name that the code already carries.
+- Do not record process history, for example "previously" or "per review feedback". Git history owns that. A regression test may state the bug it pins, in one sentence.
+- Write one concrete action in a `TODO`. Add the issue number when one exists: `TODO(#2463)`.
+- `///` is the public API reference. `builddocs` publishes it into `docs/api`. Keep every fact in it accurate.
+
+Write every comment in plain English, in the style of [ASD-STE100](https://www.asd-ste100.org/):
+
+- Give one idea to one sentence. Keep a sentence to 25 words or fewer.
+- Use the active voice and the present tense. Use the imperative for an instruction.
+- Do not use an em dash. Use a period, a colon, or a comma.
+- Do not use the first person: "we", "our", "let's".
+- Use a list when a sentence carries more than three items.
+- Wrap at 80 columns, to match `printWidth` in `.oxfmtrc.json`.
+
 # Pre Check
 
 Before you create a pull request, please check the following todo:

--- a/e2e/src/crepe-streaming/main.ts
+++ b/e2e/src/crepe-streaming/main.ts
@@ -5,8 +5,9 @@ import { callCommand } from '@milkdown/utils'
 
 import { setup } from '../utils'
 
-// Command names match the string IDs registered by $command() in plugin-streaming.
-// Using strings here because @milkdown/kit is not a direct dependency of e2e.
+// The command names match the string ids that `$command()` registers in
+// plugin-streaming. A string works here because @milkdown/kit is no
+// direct dependency of e2e.
 setup(async () => {
   const crepe = new Crepe({
     root: '#app',

--- a/e2e/tests/crepe/diff.spec.ts
+++ b/e2e/tests/crepe/diff.spec.ts
@@ -218,9 +218,9 @@ test.describe('block diff', () => {
   })
 
   test('within-block edit in list item renders as inline', async ({ page }) => {
-    // Text edit inside a list item paragraph — the old-doc slice contains
-    // sub-block nodes (list_item) but the edit itself is inline.
-    // Should render with inline decorations, not block-level widgets.
+    // A text edit inside a list item paragraph. The old-doc slice holds
+    // a sub-block node, the list_item, while the edit itself is inline.
+    // It renders with an inline decoration, not a block-level widget.
     await applyDiff(page, '- Item one\n- Item two', '- Item ONE\n- Item two')
 
     const editor = page.locator('.editor')
@@ -356,7 +356,7 @@ test.describe('regression: sequential operations', () => {
         .count()
     }
 
-    // Editor should be unlocked — typing should work
+    // The editor is unlocked, so typing works.
     await editor.click()
     await page.keyboard.type('UNLOCKED')
     await waitNextFrame(page)
@@ -408,7 +408,7 @@ test.describe('regression: sequential operations', () => {
       .count()
     expect(initialControls).toBeGreaterThan(0)
 
-    // Reject all one by one — each should succeed
+    // Reject the changes one by one. Each rejection succeeds.
     for (let i = 0; i < initialControls; i++) {
       const before = await editor
         .locator('.milkdown-diff-controls, .milkdown-diff-controls-block')

--- a/e2e/tests/crepe/image-block.spec.ts
+++ b/e2e/tests/crepe/image-block.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
-// A 1000x800 red PNG generated as a data URL is impractical,
-// so we intercept the image request and return a generated PNG.
+// A 1000x800 red PNG is impractical as a data URL, so the route
+// intercepts the image request and returns a generated PNG.
 async function routeMockImage(
   page: Page,
   url: string,
@@ -80,7 +80,8 @@ test.describe('image block maxWidth and maxHeight combined', () => {
       window.__imageBlockMaxHeight__ = 200
     })
 
-    // 1000x800 image: scaled to 400px width -> height would be 320px, then clamped to 200px
+    // A 1000x800 image scaled to a 400px width gives a 320px height,
+    // which the clamp then cuts to 200px.
     await routeMockImage(page, MOCK_IMAGE_URL, 1000, 800)
     await page.goto('/image-block/')
 

--- a/e2e/tests/crepe/list.spec.ts
+++ b/e2e/tests/crepe/list.spec.ts
@@ -49,7 +49,6 @@ test('should focus on the editor after clicking on the list item', async ({
   // Click on the list item
   await li.locator('.label-wrapper').click()
   await waitNextFrame(page)
-  // Check if the editor is focused
   const isFocused = await editor.evaluate(() => window.__view__.hasFocus())
   expect(isFocused).toBe(true)
 

--- a/e2e/tests/crepe/streaming.spec.ts
+++ b/e2e/tests/crepe/streaming.spec.ts
@@ -211,7 +211,8 @@ test.describe('insert-at-cursor', () => {
   test('insert at cursor replaces empty paragraph with blocks', async ({
     page,
   }) => {
-    // Empty editor has a single empty paragraph — streaming should replace it
+    // An empty editor holds one empty paragraph, which streaming
+    // replaces.
     const editor = page.locator('.editor')
     await editor.locator('p').first().click()
     await waitNextFrame(page)
@@ -583,10 +584,10 @@ test.describe('replace-selection', () => {
     await setMarkdown(page, 'Start.\n\nMiddle paragraph.\n\nEnd.')
     await waitNextFrame(page)
 
-    // Select entire "Middle paragraph." text. Using Shift+ArrowRight by
-    // character count rather than Shift+End — the latter extends to
-    // end-of-document on macOS browsers (vs end-of-line on Linux/Windows),
-    // making the test platform-dependent.
+    // Select the whole "Middle paragraph." text with Shift+ArrowRight,
+    // once per character. Shift+End would extend to the end of the
+    // document on a macOS browser and to the end of the line on Linux
+    // and Windows, which makes the test platform-dependent.
     const editor = page.locator('.editor')
     await editor.locator('p').nth(1).click()
     await page.keyboard.press('Home')
@@ -665,8 +666,8 @@ test.describe('replace-selection', () => {
   test('collapsed selection in empty document snaps like cursor mode', async ({
     page,
   }) => {
-    // Empty editor has a single empty paragraph — block content should
-    // replace it cleanly, same as insertAt: 'cursor'.
+    // An empty editor holds one empty paragraph, which block content
+    // replaces cleanly, the same as `insertAt: 'cursor'`.
     const editor = page.locator('.editor')
     await editor.locator('p').first().click()
     await waitNextFrame(page)

--- a/e2e/tests/input/bold.spec.ts
+++ b/e2e/tests/input/bold.spec.ts
@@ -40,11 +40,11 @@ test('should not parse when preceded by word and followed by quote', async ({
   await focusEditor(page)
   await page.keyboard.type('a**"foo"**')
 
-  // Expect no <strong> element created.
   await expect(editor.locator('strong')).toHaveCount(0)
 
   const markdown = await getMarkdown(page)
-  // The markdown should remain unchanged (with newline appended by Milkdown serializer).
+  // The markdown stays unchanged. The Milkdown serializer appends the
+  // newline.
   expect(markdown).toBe('a\\*\\*"foo"\\*\\*\n')
 })
 

--- a/e2e/tests/input/email-autolink.spec.ts
+++ b/e2e/tests/input/email-autolink.spec.ts
@@ -44,7 +44,6 @@ test('auto link email backspace', async ({ page }) => {
     await page.keyboard.press('Backspace')
   }
 
-  // Type new email
   const newEmail = 'new@test.com'
   await page.keyboard.type(newEmail)
   await page.waitForTimeout(100)
@@ -65,11 +64,9 @@ test('phantom link check', async ({ page }) => {
   }
   await page.waitForTimeout(50)
 
-  // Type non-email text
   await page.keyboard.type('hello world')
   await page.waitForTimeout(50)
 
-  // Should NOT be a link
   const link = page.locator('a').first()
   await expect(link).not.toBeVisible()
 })
@@ -78,7 +75,6 @@ test('trailing space should not remove link', async ({ page }) => {
   await page.keyboard.type(email, { delay: 10 })
   await page.waitForTimeout(100)
 
-  // Add a space
   await page.keyboard.press('Space')
   await page.waitForTimeout(100)
 
@@ -160,7 +156,6 @@ test('leaking char check', async ({ page }) => {
   // "add spaces"
   await page.keyboard.type('    ')
 
-  // "type again"
   await page.keyboard.type('hello')
   await page.waitForTimeout(100)
 

--- a/e2e/tests/plugin/listener.spec.ts
+++ b/e2e/tests/plugin/listener.spec.ts
@@ -59,8 +59,8 @@ test('markdownUpdated is properly debounced during rapid typing', async ({
   // Wait for debounce to fire (200ms after last keystroke + buffer)
   await page.waitForTimeout(500)
 
-  // With proper debouncing, we expect at most 3 callbacks
-  // (timing variance may cause 2-3 debounce windows, but never 10)
+  // Debouncing caps the run at three callbacks. Timing variance opens
+  // two or three debounce windows, never ten.
   expect(debounceLogs.length).toBeGreaterThanOrEqual(1)
   expect(debounceLogs.length).toBeLessThanOrEqual(3)
 })

--- a/packages/components/src/__internal__/unique-id.ts
+++ b/packages/components/src/__internal__/unique-id.ts
@@ -4,10 +4,10 @@ import { customAlphabet } from 'nanoid'
 // disambiguate internal inputs within a single page.
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 8)
 
-// Create a unique id for an internal input element, so host pages pass
-// Chrome's "A form field element should have an id or name attribute"
-// audit. We use `id` rather than a shared `name` so these inputs do not
-// leak into host `<form>` submissions when the editor is embedded.
+// Create a unique id for an internal input element, so a host page
+// passes Chrome's "A form field element should have an id or name
+// attribute" audit. An `id` keeps the input out of a host `<form>`
+// submission, which a shared `name` would join.
 export function inputId(prefix: string): string {
   return `${prefix}-${nanoid()}`
 }

--- a/packages/components/src/code-block/view/node-view.ts
+++ b/packages/components/src/code-block/view/node-view.ts
@@ -122,8 +122,8 @@ export class CodeMirrorBlock implements NodeView {
         drawSelection(),
         cmKeymap.of(this.codeMirrorKeymap()),
         this.languageConf.of([]),
-        // Block user edits when the editor is not editable, but always let
-        // updates we sync from ProseMirror through.
+        // Block a user edit when the editor is not editable. An update
+        // synced from ProseMirror always passes.
         EditorState.changeFilter.of(() => this.view.editable || this.updating),
         ...this.config.extensions,
         CodeMirror.updateListener.of(this.forwardUpdate),

--- a/packages/components/src/diff/__tests__/diff-utils.spec.ts
+++ b/packages/components/src/diff/__tests__/diff-utils.spec.ts
@@ -71,7 +71,7 @@ describe('hasBlockContent', () => {
         li({ checked: false }, p(t('world')))
       )
     )
-    // Inside "hello" — depth 3 (doc > bullet_list > list_item > paragraph).
+    // Inside "hello", at depth 3: doc > bullet_list > list_item > paragraph.
     // Position 3 is inside the first paragraph.
     expect(hasBlockContent(d, 3, 4)).toBe(false)
   })
@@ -84,9 +84,9 @@ describe('hasBlockContent', () => {
     const d = doc(
       ul(li({ checked: false }, p(t('a'))), li({ checked: false }, p(t('b'))))
     )
-    // Walk the doc to find a position that sits at the bullet_list depth
-    // just before the second list_item — resolve(pos).depth === 1 means we
-    // are at the list_item boundary inside the bullet_list.
+    // Find a position at the bullet_list depth, just before the second
+    // list_item. A resolved depth of 1 marks that boundary inside the
+    // bullet_list.
     let boundaryPos = -1
     for (let i = 1; i < d.content.size; i++) {
       const $p = d.resolve(i)
@@ -162,8 +162,8 @@ describe('mergeBlockChanges — pure inserts/deletes at custom block boundary', 
     // The change should NOT have been promoted to a custom-block merge,
     // because the insertion is merely adjacent to the table, not inside it.
     expect(merged[0]!.isCustomBlock).toBe(false)
-    // And the range must remain the original pure insertion — no expansion
-    // backwards over the table.
+    // The range must stay the original pure insertion. It must not
+    // expand backwards over the table.
     expect(merged[0]!.fromA).toBe(tableEndA)
     expect(merged[0]!.toA).toBe(tableEndA)
     expect(merged[0]!.fromB).toBe(tableEndB)
@@ -254,9 +254,9 @@ describe('mergeBlockChanges — pure inserts/deletes at custom block boundary', 
   })
 
   it('coalesces two changes that expand into the same custom block', () => {
-    // Two separate non-empty changes, each overlapping the table on a
-    // different side, should collapse into a single merged change —
-    // otherwise the decoration plugin renders the new table twice.
+    // Two non-empty changes overlap the table on different sides, and
+    // they must collapse into one merged change. Otherwise the
+    // decoration plugin renders the new table twice.
     const oldD = doc(
       p(t('head')),
       table(row(td(t('a'))), row(td(t('b')))),
@@ -312,9 +312,9 @@ describe('trailingEmptyParagraphStart', () => {
   })
 
   it('stops at the first non-paragraph block walking backwards', () => {
-    // Empty paragraph after a table is still trailing, but an empty
-    // paragraph before a table is not — walking backwards must stop at
-    // the table.
+    // An empty paragraph after a table still counts as trailing. An
+    // empty paragraph before a table does not, so the backward walk
+    // stops at the table.
     const tableNode = table(row(td(t('a'))))
     const d = doc(p(), tableNode, p())
     const lastEmptySize = d.child(2).nodeSize

--- a/packages/components/src/diff/diff-decoration-plugin.ts
+++ b/packages/components/src/diff/diff-decoration-plugin.ts
@@ -51,8 +51,8 @@ export const diffDecorationPlugin = $prose((ctx) => {
         const diffState = diffPluginKey.getState(newState)
         if (!diffState?.active) return DecorationSet.empty
 
-        // Only rebuild when diff state changes (action dispatched or doc changed).
-        // Selection-only changes reuse the mapped decoration set.
+        // A rebuild costs a full diff, so only a dispatched action or a
+        // doc change earns one. A selection change reuses the mapped set.
         if (tr.getMeta(diffPluginKey) || tr.docChanged)
           return buildDecorations(ctx, newState.doc, diffState, config)
 
@@ -88,7 +88,8 @@ interface CrossBoundaryOptions {
   decorations: Decoration[]
 }
 
-/// Render a cross-boundary change as separate inline + block decorations.
+/// Render a cross-boundary change as a separate inline decoration and
+/// block decoration.
 function addCrossBoundaryDecorations({
   doc,
   newDoc,
@@ -133,7 +134,7 @@ function addCrossBoundaryDecorations({
     }
   }
 
-  // One set of controls for the full change, at block boundary
+  // The whole change shares one set of controls, at a block boundary.
   const lastSeg = segments[segments.length - 1]!
   const lastSegEnd = lastSeg.isBlock
     ? lastSeg.fromA < lastSeg.toA
@@ -183,8 +184,8 @@ function buildDecorations(
     const isDeletion = change.fromA < change.toA
     const isInsertion = change.fromB < change.toB
 
-    // Skip deletion-only changes that are just trailing empty paragraphs.
-    // Editors like Crepe always keep an empty paragraph at the end.
+    // An editor such as Crepe always keeps an empty paragraph at the
+    // end, so a deletion that covers only those is not a real change.
     if (
       isDeletion &&
       !isInsertion &&
@@ -199,12 +200,12 @@ function buildDecorations(
     const insertionHasBlocks =
       isInsertion && hasBlockContent(diffState.newDoc, change.fromB, change.toB)
 
-    // Changes entirely within a single top-level block in the old doc
-    // (e.g. list item text edits, blockquote text changes) should render
-    // as inline — the old-doc slice may contain sub-block nodes but the
-    // edit itself is inline-level.
-    // Only apply when neither side contains block content, otherwise
-    // we'd render block nodes inside a <span> (invalid DOM).
+    // A change that stays inside one top-level block of the old doc
+    // renders inline, for example a text edit in a list item or a
+    // blockquote. The old-doc slice can hold sub-block nodes while the
+    // edit itself stays inline-level. This path needs both sides free of
+    // block content, because a block node inside a `<span>` is invalid
+    // DOM.
     const deletionWithinSingleBlock =
       isDeletion &&
       !deletionSpansBlocks &&
@@ -215,8 +216,8 @@ function buildDecorations(
       (deletionSpansBlocks || deletionHasBlocks || insertionHasBlocks) &&
       !deletionWithinSingleBlock
 
-    // Try to split cross-boundary changes into inline + block segments
-    // so both the inline text change and block additions are visible.
+    // A split into an inline segment and a block segment keeps both the
+    // text change and the added blocks visible.
     if (isBlockLevel && !change.isCustomBlock) {
       const segments = splitCrossBoundaryChange(doc, diffState.newDoc, change)
       if (segments) {
@@ -235,7 +236,7 @@ function buildDecorations(
       }
     }
 
-    // Non-split path: render as a single change
+    // Non-split path: render the change as one decoration.
     if (isDeletion) {
       if (change.isCustomBlock || isBlockLevel) {
         addBlockDeletionDecorations(doc, change.fromA, change.toA, decorations)
@@ -298,10 +299,9 @@ function createInsertedWidget(
 
   const serializer = DOMSerializer.fromSchema(newDoc.type.schema)
 
-  // When the range aligns with complete top-level block boundaries,
-  // serialize each node directly. This ensures complex nodes like tables
-  // get their proper HTML structure (<table>/<tbody>/<tr>) instead of
-  // bare cell content from slice serialization.
+  // A range aligned to complete top-level blocks serializes node by
+  // node. This keeps the HTML structure of a complex node such as a
+  // table, which slice serialization reduces to bare cell content.
   if (isBlockLevel) {
     const nodes = collectTopLevelNodes(newDoc, change.fromB, change.toB)
     if (nodes.length > 0) {
@@ -314,13 +314,12 @@ function createInsertedWidget(
     }
   }
 
-  // Fallback: use slice serialization
   const slice = newDoc.slice(change.fromB, change.toB)
   const fragment = serializer.serializeFragment(slice.content)
   dom.appendChild(fragment)
 
-  // If serialization produced no visible content (but not images/media),
-  // fall back to plain text
+  // Serialization can yield no visible content. Plain text is the
+  // fallback, unless the result holds an image or a media element.
   if (
     !dom.textContent?.trim() &&
     !dom.querySelector('img, video, audio, canvas, svg')
@@ -357,8 +356,8 @@ function createControlsWidget({
   const handler = (action: 'accept' | 'reject') => (e: Event) => {
     e.preventDefault()
     e.stopPropagation()
-    // Always use range-based commands — works for both custom blocks
-    // and split cross-boundary changes.
+    // A range-based command covers both a custom block and a split
+    // cross-boundary change.
     const range = {
       fromA: change.fromA,
       toA: change.toA,

--- a/packages/components/src/diff/doc-utils.ts
+++ b/packages/components/src/diff/doc-utils.ts
@@ -11,10 +11,9 @@ export function isBlockSpanning(doc: Node, from: number, to: number): boolean {
   const $from = doc.resolve(from)
   const $to = doc.resolve(to)
 
-  // Determine which top-level child contains each endpoint.
-  // For depth-0 positions (between top-level nodes), index(0) gives the
-  // child that starts at or after the position — for the `to` endpoint
-  // of a half-open range we use the previous child instead.
+  // At depth 0 the position sits between top-level nodes, and index(0)
+  // gives the child that starts at or after it. The `to` endpoint of a
+  // half-open range needs the previous child instead.
   const fromIndex = $from.index(0)
   const toIndex = $to.depth === 0 ? Math.max(0, $to.index(0) - 1) : $to.index(0)
 
@@ -22,22 +21,21 @@ export function isBlockSpanning(doc: Node, from: number, to: number): boolean {
 }
 
 /// Check if a range in a doc contains any fully-enclosed block node.
-/// Returns false for purely-inline ranges and for 1-char attribute-token
-/// edits that only touch a block node's open/close boundary without
-/// enclosing any real block content.
+/// Return false for a purely inline range. Also return false for a
+/// one-character attribute-token edit that only touches a block node's
+/// open or close boundary and encloses no block content.
 export function hasBlockContent(doc: Node, from: number, to: number): boolean {
   if (from >= to) return false
 
-  // Fast path: if both endpoints share the same textblock parent,
-  // the range is purely inline — no block crossings.
+  // Fast path: endpoints that share one textblock parent make the range
+  // purely inline, so it crosses no block.
   const $from = doc.resolve(from)
   const $to = doc.resolve(to)
   if ($from.sameParent($to) && $from.parent.isTextblock) return false
 
-  // Walk all descendants and return true only if we find a block node
-  // fully enclosed by [from, to]. Wrapper nodes that partially overlap
-  // (e.g. a bullet_list that contains the range) do NOT count — those
-  // get picked up by isBlockSpanning for real cross-block edits.
+  // Only a block node fully enclosed by [from, to] counts. A wrapper
+  // that partially overlaps the range, such as a bullet_list around it,
+  // does not count. `isBlockSpanning` catches a real cross-block edit.
   let found = false
   doc.nodesBetween(from, to, (node, pos) => {
     if (found) return false
@@ -47,7 +45,7 @@ export function hasBlockContent(doc: Node, from: number, to: number): boolean {
       found = true
       return false
     }
-    // Node only partially overlaps — descend into its children.
+    // The node only partially overlaps, so descend into its children.
     return true
   })
   return found
@@ -64,7 +62,6 @@ export function coversOnlyTrailingEmptyParagraphs(
   const $from = doc.resolve(from)
   if ($from.depth !== 0) return false
 
-  // Check all nodes from `from` to end are empty paragraphs
   for (let i = $from.index(0); i < doc.childCount; i++) {
     const child = doc.child(i)
     if (child.type.name !== 'paragraph' || child.content.size > 0) return false
@@ -72,11 +69,11 @@ export function coversOnlyTrailingEmptyParagraphs(
   return true
 }
 
-/// Return the top-level position where the doc's run of trailing empty
-/// paragraphs begins. If the doc has no trailing empty paragraph, returns
-/// `doc.content.size`. Crepe-like editors always keep an empty paragraph
-/// at the end — inserts that target the doc end should anchor here so
-/// the empty paragraph stays in its trailing spot.
+/// Return the top-level position where the run of trailing empty
+/// paragraphs begins. Return `doc.content.size` when the doc has no
+/// trailing empty paragraph. A Crepe-like editor always keeps an empty
+/// paragraph at the end. An insert that targets the doc end anchors
+/// here, so the empty paragraph stays last.
 export function trailingEmptyParagraphStart(doc: Node): number {
   let start = doc.content.size
   for (let i = doc.childCount - 1; i >= 0; i--) {
@@ -87,10 +84,10 @@ export function trailingEmptyParagraphStart(doc: Node): number {
   return start
 }
 
-/// For block-level widgets, find a position between blocks rather than
-/// inside an inline-content node (paragraph, heading). Walks up the
-/// tree until it finds a node that can contain block children, then
-/// snaps to the boundary at that depth.
+/// Find a position between blocks for a block-level widget, not a
+/// position inside an inline-content node such as a paragraph or a
+/// heading. Walk up the tree to the first node that takes block
+/// children, then snap to the boundary at that depth.
 export function snapToBlockBoundary(doc: Node, pos: number): number {
   const $pos = doc.resolve(pos)
   for (let d = $pos.depth; d >= 1; d--) {
@@ -121,10 +118,10 @@ export function forEachTopLevelNodeInRange(
   }
 }
 
-/// Add node-level deletion decorations for each top-level block in a range.
-/// Uses Decoration.node so the class is applied to the node's outer DOM wrapper,
-/// which works with custom node views (CodeMirror, image-block, etc.)
-/// where Decoration.inline cannot penetrate.
+/// Add a node-level deletion decoration for each top-level block in a
+/// range. `Decoration.node` puts the class on the node's outer DOM
+/// wrapper. This reaches a custom node view, such as CodeMirror or
+/// image-block, that `Decoration.inline` cannot enter.
 export function addBlockDeletionDecorations(
   doc: Node,
   from: number,
@@ -132,7 +129,7 @@ export function addBlockDeletionDecorations(
   decorations: Decoration[]
 ): void {
   forEachTopLevelNodeInRange(doc, from, to, (node, start, end) => {
-    // Skip trailing empty paragraphs (editor placeholders)
+    // A trailing empty paragraph is an editor placeholder, not content.
     if (
       end === doc.content.size &&
       node.type.name === 'paragraph' &&
@@ -148,13 +145,13 @@ export function addBlockDeletionDecorations(
   })
 }
 
-/// Find the enclosing top-level block node range for a position.
-/// Returns { from, to } covering the entire block at depth 1.
+/// Find the enclosing top-level block range for a position. Return
+/// `{ from, to }` that covers the whole block at depth 1.
 ///
-/// When `endBoundary` is true and the position sits at depth 0 (between
-/// top-level nodes), prefer the node *before* the position. Use this for
-/// exclusive range ends so the returned range covers the block that was
-/// actually touched (not the unrelated next node).
+/// At depth 0 the position sits between top-level nodes. If
+/// `endBoundary` is true, prefer the node before the position. Pass it
+/// for an exclusive range end, so the range covers the block the edit
+/// touches instead of the next node.
 export function getTopLevelBlockRange(
   doc: Node,
   pos: number,
@@ -170,8 +167,8 @@ export function getTopLevelBlockRange(
     }
   }
 
-  // Depth 0: position sits between top-level nodes. Pick the adjacent node —
-  // prefer the one on the side that was actually touched by the range.
+  // Depth 0: the position sits between top-level nodes. Pick the
+  // adjacent node on the side the range touches.
   if (endBoundary) {
     const nodeBefore = $pos.nodeBefore
     if (nodeBefore) {
@@ -194,11 +191,11 @@ export function getTopLevelBlockRange(
   return null
 }
 
-/// Check only the ancestor chain of `pos` for a custom block.
-/// Unlike `getCustomBlockAt`, this does NOT consider nodeBefore/nodeAfter —
-/// it returns null for positions that merely sit at the boundary between
-/// top-level blocks. Use this for empty ranges (pure inserts/deletes) where
-/// a boundary anchor shouldn't be treated as "touching" its neighbours.
+/// Check only the ancestor chain of `pos` for a custom block. Unlike
+/// `getCustomBlockAt`, this function ignores `nodeBefore` and
+/// `nodeAfter`. It returns null for a position that only sits at the
+/// boundary between two top-level blocks. Use it for an empty range,
+/// where a boundary anchor must not count as touching a neighbour.
 export function getCustomBlockAncestor(
   doc: Node,
   pos: number,
@@ -213,13 +210,13 @@ export function getCustomBlockAncestor(
   return null
 }
 
-/// Check if a position falls inside or at a custom block node in the given document.
-/// Returns the node type name if found, or null.
+/// Check if a position falls inside or at a custom block node. Return
+/// the node type name, or null.
 ///
-/// When `endBoundary` is true, a position immediately *after* an atom custom
-/// block is also considered touching it — use this only for exclusive range
-/// end positions. For point positions or range starts, leave it false so that
-/// edits adjacent to a custom block are not misclassified as inside it.
+/// If `endBoundary` is true, a position right after an atom custom
+/// block also counts as touching it. Pass it only for an exclusive
+/// range end. Leave it false for a point position or a range start, so
+/// an edit next to a custom block does not count as inside it.
 export function getCustomBlockAt(
   doc: Node,
   pos: number,
@@ -229,11 +226,11 @@ export function getCustomBlockAt(
   const ancestor = getCustomBlockAncestor(doc, pos, customBlockTypes)
   if (ancestor) return ancestor
 
-  // Not inside a custom block's ancestor chain — check the sibling on the
-  // touched side. For range starts and point positions this is nodeAfter
-  // (atom/leaf nodes like image-block are touched by the start). For
-  // exclusive range ends we look at nodeBefore instead — nodeAfter is past
-  // the range end and not actually touched.
+  // The position sits outside every custom block ancestor, so check the
+  // sibling on the touched side. A range start or a point position
+  // touches `nodeAfter`, which covers an atom node such as image-block.
+  // An exclusive range end touches `nodeBefore`, because `nodeAfter`
+  // lies past the range.
   const $pos = doc.resolve(Math.min(Math.max(pos, 0), doc.content.size))
   const sibling = endBoundary ? $pos.nodeBefore : $pos.nodeAfter
   if (sibling && customBlockTypes.has(sibling.type.name))
@@ -241,8 +238,9 @@ export function getCustomBlockAt(
   return null
 }
 
-/// Collect complete top-level nodes within a position range.
-/// Returns empty array if the range doesn't align with node boundaries.
+/// Collect the complete top-level nodes inside a position range.
+/// Return an empty array when the range does not align with node
+/// boundaries.
 export function collectTopLevelNodes(
   doc: Node,
   from: number,
@@ -257,7 +255,6 @@ export function collectTopLevelNodes(
     lastEnd = end
     nodes.push(node)
   })
-  // Validate the range starts and ends exactly on node boundaries
   if (nodes.length === 0 || firstStart !== from || lastEnd !== to) {
     aligned = false
   }

--- a/packages/components/src/diff/merge-changes.ts
+++ b/packages/components/src/diff/merge-changes.ts
@@ -15,11 +15,11 @@ function overlaps(a1: number, a2: number, b1: number, b2: number): boolean {
 
 /// Does a range [from, to) in `doc` touch a custom block?
 ///
-/// Non-empty ranges use the full boundary check — a position at the edge
-/// of a custom block counts as touching. Empty ranges (from === to) only
-/// count if the anchor is *inside* a custom block's ancestor chain; a
-/// point sitting between two top-level nodes isn't touching either
-/// neighbour and shouldn't trigger custom-block merging.
+/// A non-empty range uses the full boundary check, so a position at the edge of
+/// a custom block counts as touching. An empty range counts only when the
+/// anchor sits inside a custom block ancestor chain. A point between two
+/// top-level nodes touches neither neighbour, so it starts no custom-block
+/// merge.
 function touchesCustomBlockRange(
   doc: Node,
   from: number,
@@ -40,7 +40,8 @@ export interface MergedChange {
   toA: number
   fromB: number
   toB: number
-  /// Whether this change was merged from a custom block node (table, image-block, etc.).
+  /// Whether the merge came from a custom block node, such as a table
+  /// or an image-block.
   isCustomBlock: boolean
 }
 
@@ -52,14 +53,16 @@ export interface ChangeSegment {
   isBlock: boolean
 }
 
-/// Split a cross-boundary change into inline and block visual segments.
-/// When fromA is inside a top-level textblock (e.g. a paragraph or heading
-/// at doc level), produces an inline segment for the text portion and a
-/// block segment for the remaining blocks.
+/// Split a cross-boundary change into an inline segment and a block
+/// segment. The split happens when fromA sits inside a top-level
+/// textblock, for example a paragraph or a heading at doc level. The
+/// inline segment covers the text, and the block segment covers the
+/// remaining blocks.
 ///
-/// Returns null if the change doesn't need splitting (not cross-boundary,
-/// or fromA is not inside a top-level textblock — nested textblocks such
-/// as list item paragraphs are excluded to avoid producing invalid DOM).
+/// Return null when the change needs no split. A change that stays
+/// inside one boundary needs none. A fromA inside a nested textblock,
+/// such as a list item paragraph, also needs none, because splitting it
+/// would produce invalid DOM.
 export function splitCrossBoundaryChange(
   doc: Node,
   newDoc: Node,
@@ -67,21 +70,19 @@ export function splitCrossBoundaryChange(
 ): ChangeSegment[] | null {
   const $fromA = doc.resolve(change.fromA)
 
-  // Only split if fromA is inside a textblock (inline content) AND
-  // its depth-1 ancestor is itself a textblock. Otherwise (e.g. inside
-  // a list item or blockquote), the inline segment would span block
-  // content and produce invalid DOM (block elements inside <span>).
+  // A split needs fromA inside a textblock and a depth-1 ancestor that
+  // is also a textblock. Inside a list item or a blockquote the inline
+  // segment would span block content, which puts a block element inside
+  // a `<span>`.
   if (!$fromA.parent.isTextblock || $fromA.depth < 1) return null
   if (!$fromA.node(1).isTextblock) return null
 
-  // Find the end of the enclosing top-level block in old doc
   const blockEndA = $fromA.after(1)
 
-  // Find the corresponding split point in newDoc: the first top-level
-  // block boundary at or after fromB. Only produce an inline split when
-  // fromB is also inside a top-level textblock — otherwise the inline
-  // segment would contain block DOM (e.g. a list or blockquote) and
-  // serialize to invalid HTML inside a <span>.
+  // The split point in newDoc is the first top-level block boundary at
+  // or after fromB. An inline split needs fromB inside a top-level
+  // textblock too. Otherwise the inline segment would hold block DOM,
+  // such as a list or a blockquote, inside a `<span>`.
   const $fromB = newDoc.resolve(change.fromB)
   let splitB: number
   if ($fromB.depth >= 1 && $fromB.node(1).isTextblock) {
@@ -91,12 +92,11 @@ export function splitCrossBoundaryChange(
     splitB = change.fromB
   }
 
-  // No split needed if the change is entirely within one block on BOTH sides
+  // A change that stays inside one block on both sides needs no split.
   if (blockEndA >= change.toA && splitB >= change.toB) return null
 
   const segments: ChangeSegment[] = []
 
-  // Inline segment: fromA..blockEndA in old doc, fromB..splitB in new doc
   if (blockEndA > change.fromA || splitB > change.fromB) {
     segments.push({
       fromA: change.fromA,
@@ -107,10 +107,9 @@ export function splitCrossBoundaryChange(
     })
   }
 
-  // Block segment: blockEndA..toA in old doc, splitB..toB in new doc.
-  // Normalize so fromA <= toA — when the deletion stays within the current
-  // textblock (change.toA <= blockEndA) but the insertion continues into
-  // following blocks, the old-doc side has no remainder.
+  // `Math.max` keeps fromA <= toA. A deletion that stays inside the
+  // current textblock leaves no remainder on the old-doc side, while the
+  // insertion continues into the following blocks.
   if (change.toA > blockEndA || change.toB > splitB) {
     segments.push({
       fromA: blockEndA,
@@ -137,9 +136,10 @@ function changeTouchesCustomBlock(
   )
 }
 
-/// Merge changes that fall within custom block nodes (tables, image-blocks,
-/// code blocks) into single block-level changes. This ensures proper rendering
-/// for nodes that use custom node views where inline decorations don't work.
+/// Merge the changes that fall inside a custom block node into one
+/// block-level change. A table, an image-block and a code block are
+/// custom blocks. They render through a custom node view, which an
+/// inline decoration cannot reach.
 export function mergeBlockChanges(
   pending: readonly Change[],
   doc: Node,
@@ -165,10 +165,10 @@ export function mergeBlockChanges(
       continue
     }
 
-    // Expand each side to the enclosing top-level block when that side
-    // actually touches a custom block. For pure inserts/deletes, only the
-    // ancestor check counts — a boundary anchor next to a block doesn't
-    // drag the block into the merge.
+    // Expand a side to the enclosing top-level block only when that side
+    // touches a custom block. For a pure insert or delete only the
+    // ancestor check counts, so a boundary anchor next to a block does
+    // not pull the block into the merge.
     const blockRangeA = expandToCustomBlockRange(
       doc,
       change.fromA,
@@ -182,8 +182,8 @@ export function mergeBlockChanges(
       customBlockTypes
     )
 
-    // Union of the block range and the original change range so we don't
-    // truncate changes that extend beyond the block.
+    // The union of the block range and the original change range keeps a
+    // change that reaches past the block.
     const merged: MergedChange = {
       fromA: Math.min(blockRangeA?.from ?? change.fromA, change.fromA),
       toA: Math.max(blockRangeA?.to ?? change.toA, change.toA),
@@ -211,15 +211,12 @@ export function mergeBlockChanges(
       merged.toB = Math.max(merged.toB, other.toB)
     }
 
-    // Coalesce with an already-emitted merged change whose custom-block
-    // range overlaps this one. Two seed changes can independently expand
-    // to cover the same custom block (e.g. a deletion just before a table
-    // and an insertion just after it), which would otherwise render the
-    // same block as a widget twice.
-    // Coalesce with every already-emitted custom-block merged change whose
-    // range overlaps this one, not just the first. A seed could straddle
-    // two previously-emitted custom blocks, and merging into only the first
-    // would leave overlapping duplicates in the result.
+    // Coalesce with every emitted custom-block change that overlaps this
+    // one, not only the first. Two seed changes can expand to the same
+    // custom block, for example a deletion before a table and an
+    // insertion after it, which would render the block twice. One seed
+    // can also straddle two emitted custom blocks, and merging into only
+    // the first would leave overlapping duplicates.
     const absorbedIndexes: number[] = []
     for (let k = 0; k < result.length; k++) {
       const prev = result[k]!
@@ -242,14 +239,14 @@ export function mergeBlockChanges(
   return result
 }
 
-/// Remap pure inserts that sit at or past the doc's run of trailing empty
-/// paragraphs so they anchor *before* the empty paragraph instead of after.
+/// Move a pure insert that sits at or past the run of trailing empty
+/// paragraphs, so it anchors before the empty paragraph.
 ///
-/// Editors like Crepe always keep an empty paragraph at the doc end. A pure
-/// insert produced at `fromA === doc.content.size` would otherwise be spliced
-/// after the trailing empty paragraph, pushing it out of its trailing slot.
-/// The next diff recompute would then see the empty paragraph as middle-of-doc
-/// content that needs to be deleted, flashing an empty-looking removal widget.
+/// An editor such as Crepe always keeps an empty paragraph at the doc
+/// end. An insert at `fromA === doc.content.size` lands after that
+/// paragraph and pushes it out of the trailing slot. The next diff then
+/// reads the empty paragraph as content to delete, and flashes an empty
+/// removal widget.
 export function anchorTrailingInsertsBeforeEmptyParagraph(
   changes: MergedChange[],
   doc: Node
@@ -266,9 +263,9 @@ export function anchorTrailingInsertsBeforeEmptyParagraph(
   }
 }
 
-/// Pick the top-level block range enclosing a custom block touched by
-/// [from, to). Returns null if neither endpoint actually touches a custom
-/// block (see `touchesCustomBlockRange` for the touch rules).
+/// Pick the top-level block range that encloses a custom block touched by
+/// [from, to). Return null when neither endpoint touches a custom block. See
+/// `touchesCustomBlockRange` for the touch rules.
 function expandToCustomBlockRange(
   doc: Node,
   from: number,

--- a/packages/components/src/image-block/view/components/__tests__/image-viewer.onImageLoadError.spec.tsx
+++ b/packages/components/src/image-block/view/components/__tests__/image-viewer.onImageLoadError.spec.tsx
@@ -36,7 +36,6 @@ test('calls onImageLoadError when img fires error', async () => {
   // simulate the image load error
   img!.dispatchEvent(new Event('error'))
 
-  // expect the onImageLoadError function to have been called
   expect(onImageLoadError).toHaveBeenCalledTimes(1)
   expect(onImageLoadError).toHaveBeenCalledWith(expect.any(Event))
 })

--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -65,8 +65,8 @@ export const listItemBlockView = $view(
           if (anchor > docSize || head > docSize) return
           const anchorPos = state.doc.resolve(anchor)
           const headPos = state.doc.resolve(head)
-          // Use `between` so we fall back to the nearest valid selection when
-          // the resolved positions no longer sit inside a textblock.
+          // `between` falls back to the nearest valid selection when the
+          // resolved positions no longer sit inside a textblock.
           const selection = TextSelection.between(anchorPos, headPos)
           view.dispatch(state.tr.setSelection(selection))
         })

--- a/packages/components/src/table-block/dnd/calc-drag-over.ts
+++ b/packages/components/src/table-block/dnd/calc-drag-over.ts
@@ -14,7 +14,6 @@ function findDragOverElement(
 
     // The pointer is within the boundary of the current element.
     if (boundaryStart <= pointer && pointer <= boundaryEnd) return true
-    // The pointer is beyond the last element.
     if (index === lastIndex && pointer > boundaryEnd) return true
     // The pointer is before the first element.
     if (index === 0 && pointer < boundaryStart) return true

--- a/packages/components/src/table-block/view/component.tsx
+++ b/packages/components/src/table-block/view/component.tsx
@@ -106,7 +106,8 @@ export const TableBlock = defineComponent<TableBlockProps>({
 
     onMounted(() => {
       requestAnimationFrame(() => {
-        // This is a wordaround to keep the popover open when click the select col/row button
+        // Workaround: keep the popover open on a click on the select
+        // column or row button.
         if (view.editable) recoveryStateBetweenUpdate(refs, view, node.value)
       })
     })

--- a/packages/components/src/table-block/view/view.ts
+++ b/packages/components/src/table-block/view/view.ts
@@ -85,7 +85,8 @@ export class TableNodeView implements NodeView {
 
     if (!node) return false
 
-    // if the selection is a text selection, and the current node is the same as the node, return false
+    // A click inside the cell that already holds the caret keeps the
+    // text selection instead of replacing it with a node selection.
     if (state.selection instanceof TextSelection) {
       const currentNode = findParent(
         (node) =>

--- a/packages/core/src/__internal__/remark-handlers.ts
+++ b/packages/core/src/__internal__/remark-handlers.ts
@@ -2,15 +2,15 @@ import type { Options } from 'remark-stringify'
 
 export const remarkHandlers: Required<Options>['handlers'] = {
   text: (node, _, state, info) => {
-    // This config is to remove the `&#20;` entity when have trailing spaces
+    // This handler removes the `&#20;` entity from a trailing space.
     const value = node.value
-    // Check if the text contains only trailing spaces that might be encoded
+    // Text that ends with a space and carries no markdown character to
+    // escape returns as it is, which keeps the trailing space.
     if (/^[^*_\\]*\s+$/.test(value)) {
-      // For text that ends with spaces but has no markdown special characters that need escaping,
-      // return the value directly to preserve trailing spaces
       return value
     }
-    // For other text, use safe to handle markdown escaping but prevent space encoding
+    // Other text goes through `safe`, which escapes markdown. The empty
+    // `encode` list stops it from encoding a space.
     return state.safe(value, { ...info, encode: [] })
   },
   strong: (node, _, state, info) => {

--- a/packages/core/src/editor/editor.ts
+++ b/packages/core/src/editor/editor.ts
@@ -284,8 +284,8 @@ export class Editor {
   /// This method should be used after the editor is created.
   readonly action = <T>(action: (ctx: Ctx) => T) => action(this.#ctx)
 
-  /// Get inspections of plugins in editor.
-  /// Make sure you have enabled inspector by `editor.enableInspector()` before calling this method.
+  /// Get inspections of plugins in editor. Make sure you have enabled inspector
+  /// by `editor.enableInspector()` before calling this method.
   readonly inspect = (): Telemetry[] => {
     if (!this.#enableInspector) {
       console.warn(

--- a/packages/core/src/internal-plugin/atoms.ts
+++ b/packages/core/src/internal-plugin/atoms.ts
@@ -24,8 +24,8 @@ export const editorViewCtx = createSlice({} as EditorView, 'editorView')
 /// A slice which contains the editor state.
 export const editorStateCtx = createSlice({} as EditorState, 'editorState')
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[ConfigReady]`.
+/// A slice that holds the timers to wait for before the plugin
+/// runs. It defaults to `[ConfigReady]`.
 export const initTimerCtx = createSlice([] as TimerType[], 'initTimer')
 
 /// A slice which stores the editor instance.

--- a/packages/core/src/internal-plugin/commands.ts
+++ b/packages/core/src/internal-plugin/commands.ts
@@ -34,10 +34,10 @@ export interface CommandChain {
   }
 }
 
-/// The command manager.
-/// This manager will manage all commands in editor.
-/// Generally, you don't need to use this manager directly.
-/// You can use the `$command` and `$commandAsync` in `@milkdown/utils` to create and call a command.
+/// The command manager. This manager will manage all commands in editor.
+/// Generally, you don't need to use this manager directly. You can use the
+/// `$command` and `$commandAsync` in `@milkdown/utils` to create and call a
+/// command.
 export class CommandManager {
   /// @internal
   #container = new Container()
@@ -97,8 +97,8 @@ export class CommandManager {
     return command(view.state, view.dispatch, view)
   }
 
-  /// Create a command chain.
-  /// All commands added by `pipe` will be run in order until one of them returns `true`.
+  /// Create a command chain. All commands added by `pipe` will be run in order
+  /// until one of them returns `true`.
   chain = (): CommandChain => {
     if (this.#ctx == null) throw callCommandBeforeEditorView()
     const ctx = this.#ctx
@@ -142,8 +142,8 @@ export function createCmdKey<T = undefined>(key = 'cmdKey'): CmdKey<T> {
 /// A slice which contains the command manager.
 export const commandsCtx = createSlice(new CommandManager(), 'commands')
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[SchemaReady]`.
+/// A slice that holds the timers to wait for before the plugin
+/// runs. It defaults to `[SchemaReady]`.
 export const commandsTimerCtx = createSlice([SchemaReady], 'commandsTimer')
 
 /// The timer which will be resolved when the commands plugin is ready.
@@ -152,7 +152,7 @@ export const CommandsReady = createTimer('CommandsReady')
 /// The commands plugin.
 /// This plugin will create a command manager.
 ///
-/// This plugin will wait for the schema plugin.
+/// This plugin waits for the schema plugin.
 export const commands: MilkdownPlugin = (ctx) => {
   const cmd = new CommandManager()
   cmd.setCtx(ctx)

--- a/packages/core/src/internal-plugin/editor-state.ts
+++ b/packages/core/src/internal-plugin/editor-state.ts
@@ -35,8 +35,8 @@ export const editorStateOptionsCtx = createSlice<StateOptionsOverride>(
   'stateOptions'
 )
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[ParserReady, SerializerReady, CommandsReady]`.
+/// A slice that holds the timers to wait for before the plugin runs. It
+/// defaults to `[ParserReady, SerializerReady, CommandsReady]`.
 export const editorStateTimerCtx = createSlice(
   [] as TimerType[],
   'editorStateTimer'
@@ -64,10 +64,10 @@ export function getDoc(
 
 const key = new PluginKey('MILKDOWN_STATE_TRACKER')
 
-/// The editor state plugin.
-/// This plugin will create a prosemirror editor state.
+/// The editor state plugin. This plugin will create a prosemirror editor state.
 ///
-/// This plugin will wait for the parser plugin, serializer plugin and commands plugin.
+/// This plugin waits for the parser plugin, serializer plugin and commands
+/// plugin.
 export const editorState: MilkdownPlugin = (ctx) => {
   ctx
     .inject(defaultValueCtx, '')

--- a/packages/core/src/internal-plugin/editor-view.ts
+++ b/packages/core/src/internal-plugin/editor-view.ts
@@ -24,14 +24,15 @@ type RootType = Node | undefined | null | string
 /// The timer which will be resolved when the editor view plugin is ready.
 export const EditorViewReady = createTimer('EditorViewReady')
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[EditorStateReady]`.
+/// A slice that holds the timers to wait for before the plugin
+/// runs. It defaults to `[EditorStateReady]`.
 export const editorViewTimerCtx = createSlice(
   [] as TimerType[],
   'editorViewTimer'
 )
 
-/// A slice which contains the editor view options which will be passed to the editor view.
+/// A slice which contains the editor view options which will be passed to the
+/// editor view.
 export const editorViewOptionsCtx = createSlice(
   {} as Partial<EditorOptions>,
   'editorViewOptions'
@@ -76,7 +77,7 @@ const key = new PluginKey('MILKDOWN_VIEW_CLEAR')
 /// The editor view plugin.
 /// This plugin will create an editor view.
 ///
-/// This plugin will wait for the editor state plugin.
+/// This plugin waits for the editor state plugin.
 export const editorView: MilkdownPlugin = (ctx) => {
   ctx
     .inject(rootCtx, document.body)

--- a/packages/core/src/internal-plugin/init.ts
+++ b/packages/core/src/internal-plugin/init.ts
@@ -24,10 +24,10 @@ import { ConfigReady } from './config'
 /// The timer which will be resolved when the init plugin is ready.
 export const InitReady = createTimer('InitReady')
 
-/// The init plugin.
-/// This plugin prepare slices that needed by other plugins. And create a remark instance.
+/// The init plugin. This plugin prepare slices that needed by other plugins.
+/// And create a remark instance.
 ///
-/// This plugin will wait for the config plugin.
+/// This plugin waits for the config plugin.
 export function init(editor: Editor): MilkdownPlugin {
   const plugin: MilkdownPlugin = (ctx) => {
     ctx

--- a/packages/core/src/internal-plugin/keymap.ts
+++ b/packages/core/src/internal-plugin/keymap.ts
@@ -57,10 +57,10 @@ export class KeymapManager {
     return this.#ctx
   }
 
-  /// Add a keymap item.
-  /// When not passing a priority, the priority will be 50.
+  /// Add a keymap item. When not passing a priority, the priority will be 50.
   /// For the same key, the keymap with higher priority will be executed first.
-  /// If the priority is the same, the keymap will be executed in the order of addition.
+  /// If the priority is the same, the keymap will be executed in the order of
+  /// addition.
   add = (keymap: KeymapItem) => {
     this.#keymap.push(keymap)
 
@@ -136,8 +136,8 @@ export class KeymapManager {
 /// A slice which stores the keymap manager.
 export const keymapCtx = createSlice(new KeymapManager(), 'keymap')
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[SchemaReady]`.
+/// A slice that holds the timers to wait for before the plugin
+/// runs. It defaults to `[SchemaReady]`.
 export const keymapTimerCtx = createSlice([SchemaReady], 'keymapTimer')
 
 /// The timer which will be resolved when the keymap plugin is ready.
@@ -146,7 +146,7 @@ export const KeymapReady = createTimer('KeymapReady')
 /// The keymap plugin.
 /// This plugin will create a keymap manager.
 ///
-/// This plugin will wait for the schema plugin.
+/// This plugin waits for the schema plugin.
 export const keymap: MilkdownPlugin = (ctx) => {
   const km = new KeymapManager()
   km.setCtx(ctx)

--- a/packages/core/src/internal-plugin/parser.ts
+++ b/packages/core/src/internal-plugin/parser.ts
@@ -19,14 +19,14 @@ const outOfScope = (() => {
 /// A slice which contains the parser.
 export const parserCtx = createSlice(outOfScope, 'parser')
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[SchemaReady]`.
+/// A slice that holds the timers to wait for before the plugin
+/// runs. It defaults to `[SchemaReady]`.
 export const parserTimerCtx = createSlice([] as TimerType[], 'parserTimer')
 
 /// The parser plugin.
 /// This plugin will create a parser.
 ///
-/// This plugin will wait for the schema plugin.
+/// This plugin waits for the schema plugin.
 export const parser: MilkdownPlugin = (ctx) => {
   ctx
     .inject(parserCtx, outOfScope)

--- a/packages/core/src/internal-plugin/paste-rule.ts
+++ b/packages/core/src/internal-plugin/paste-rule.ts
@@ -10,15 +10,16 @@ import { SchemaReady } from './schema'
 export type PasteRule = {
   /// The function to run the paste rule.
   run: (slice: Slice, view: EditorView, isPlainText: boolean) => Slice
-  /// The priority of the paste rule. Higher priority rules will be run first. Default is 50.
+  /// The priority of the paste rule. Higher priority rules will be run first.
+  /// Default is 50.
   priority?: number
 }
 
 /// A slice which contains the paste rules.
 export const pasteRulesCtx = createSlice([] as PasteRule[], 'pasteRule')
 
-/// A slice which stores timers that need to be waited for before starting to run the paste rule plugin.
-/// By default, it's `[SchemaReady]`.
+/// A slice that holds the timers to wait for before the paste rule
+/// plugin runs. It defaults to `[SchemaReady]`.
 export const pasteRulesTimerCtx = createSlice([SchemaReady], 'pasteRuleTimer')
 
 /// The timer which will be resolved when the paste rule plugin is ready.
@@ -27,7 +28,7 @@ export const PasteRulesReady = createTimer('PasteRuleReady')
 /// The paste rule plugin.
 /// This plugin will collect the paste rules to the editor view.
 ///
-/// This plugin will wait for the schema plugin.
+/// This plugin waits for the schema plugin.
 export const pasteRule: MilkdownPlugin = (ctx) => {
   ctx
     .inject(pasteRulesCtx, [])

--- a/packages/core/src/internal-plugin/schema.ts
+++ b/packages/core/src/internal-plugin/schema.ts
@@ -15,8 +15,8 @@ import { InitReady } from './init'
 /// The timer which will be resolved when the schema plugin is ready.
 export const SchemaReady = createTimer('SchemaReady')
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[InitReady]`.
+/// A slice that holds the timers to wait for before the plugin
+/// runs. It defaults to `[InitReady]`.
 export const schemaTimerCtx = createSlice([] as TimerType[], 'schemaTimer')
 
 /// A slice which contains the schema.
@@ -38,7 +38,7 @@ function extendPriority<T extends NodeSchema | MarkSchema>(x: T): T {
 /// The schema plugin.
 /// This plugin will load all nodes spec and marks spec and create a schema.
 ///
-/// This plugin will wait for the init plugin.
+/// This plugin waits for the init plugin.
 export const schema: MilkdownPlugin = (ctx) => {
   ctx
     .inject(schemaCtx, {} as Schema)

--- a/packages/core/src/internal-plugin/serializer.ts
+++ b/packages/core/src/internal-plugin/serializer.ts
@@ -12,8 +12,8 @@ import { SchemaReady, schemaCtx } from './schema'
 /// The timer which will be resolved when the serializer plugin is ready.
 export const SerializerReady = createTimer('SerializerReady')
 
-/// A slice which stores timers that need to be waited for before starting to run the plugin.
-/// By default, it's `[SchemaReady]`.
+/// A slice that holds the timers to wait for before the plugin
+/// runs. It defaults to `[SchemaReady]`.
 export const serializerTimerCtx = createSlice(
   [] as TimerType[],
   'serializerTimer'
@@ -32,7 +32,7 @@ export const serializerCtx = createSlice<Serializer, 'serializer'>(
 /// The serializer plugin.
 /// This plugin will create a serializer.
 ///
-/// This plugin will wait for the schema plugin.
+/// This plugin waits for the schema plugin.
 export const serializer: MilkdownPlugin = (ctx) => {
   ctx
     .inject(serializerCtx, outOfScope)

--- a/packages/crepe/src/core/crepe.ts
+++ b/packages/crepe/src/core/crepe.ts
@@ -23,7 +23,8 @@ export class Crepe extends CrepeBuilder {
 
   /// The constructor of the crepe editor.
   /// You can pass configs to the editor to configure the editor.
-  /// Calling the constructor will not create the editor, you need to call `create` to create the editor.
+  /// The constructor does not create the editor. Call `create` to create
+  /// it.
   constructor({
     features = {},
     featureConfigs = {},

--- a/packages/crepe/src/core/slice.ts
+++ b/packages/crepe/src/core/slice.ts
@@ -5,16 +5,17 @@ import type { CrepeBuilder } from './builder'
 
 /// @internal
 /// The feature flags context.
-/// ⚠️ Most of the time, you should use `useCrepeFeatures` to get the features.
+/// ⚠️ In most cases, call `useCrepeFeatures` to get the features.
 export const FeaturesCtx = createSlice([] as CrepeFeature[], 'FeaturesCtx')
 
 /// @internal
 /// The crepe editor context.
-/// ⚠️ Most of the time, you should use `useCrepe` to get the crepe editor instance.
+/// ⚠️ In most cases, call `useCrepe` to get the crepe editor instance.
 export const CrepeCtx = createSlice({} as CrepeBuilder, 'CrepeCtx')
 
 /// The crepe editor context.
-/// You can use this context to access the crepe editor instance within Milkdown plugins.
+/// Use this context to access the crepe editor instance inside a
+/// Milkdown plugin.
 /// ```ts
 /// import { crepeCtx } from '@milkdown/crepe'
 /// const plugin = (ctx: Ctx) => {
@@ -25,7 +26,7 @@ export const CrepeCtx = createSlice({} as CrepeBuilder, 'CrepeCtx')
 /// }
 /// ```
 export function useCrepe(ctx: Ctx) {
-  // We should use string slice here to avoid the slice to be bundled in multiple entries
+  // The string form keeps the slice out of more than one bundle entry.
   return ctx.get<CrepeBuilder, 'CrepeCtx'>('CrepeCtx')
 }
 
@@ -38,8 +39,9 @@ export function useCrepe(ctx: Ctx) {
 ///     // Do something with CodeMirror
 ///   }
 /// }
+/// ```
 export function useCrepeFeatures(ctx: Ctx) {
-  // We should use string slice here to avoid the slice to be bundled in multiple entries
+  // The string form keeps the slice out of more than one bundle entry.
   return ctx.use<CrepeFeature[], 'FeaturesCtx'>('FeaturesCtx')
 }
 

--- a/packages/crepe/src/feature/ai/ai.spec.ts
+++ b/packages/crepe/src/feature/ai/ai.spec.ts
@@ -26,8 +26,8 @@ import { aiProviderConfig, aiSessionCtx, runAICmd } from './commands'
 // helpers a host with its own toolbar gets, so the tests exercise the same
 // path a consumer does rather than the internal modules.
 import { useAIInstructionTooltipAPI, useAIProviderConfig } from './index'
-// The slice objects themselves stay internal — imported here only to assert
-// the name-based helpers land on the very instance the feature registers.
+// The slice objects stay internal. The import here only asserts that the
+// name-based helpers land on the instance the feature registers.
 import { aiInstructionTooltipAPI } from './instruction-tooltip'
 
 function waitForAsync() {
@@ -51,9 +51,9 @@ function dispatchKeyDown(
     cancelable: true,
     ...modifiers,
   })
-  // Iterate every plugin's handleKeyDown until one claims the event.
-  // Returning `undefined` from the visitor keeps `someProp` looking;
-  // returning `true` short-circuits and is what we treat as "handled".
+  // Visit the `handleKeyDown` of every plugin until one claims the
+  // event. An `undefined` return keeps `someProp` looking. A `true`
+  // return short-circuits, which counts as handled.
   return (
     view.someProp('handleKeyDown', (handler) =>
       handler(view, event) ? true : undefined
@@ -198,10 +198,10 @@ describe('AI streaming inline markdown', () => {
   })
 
   test('inline math survives streaming through the real remark pipeline', async () => {
-    // The latex feature (on by default) parses `$...$` via remark-math.
-    // `$` is not an unconditional fast-path token in plugin-streaming —
-    // math detection is gated on the schema having a math node — so this
-    // pins the whole chain end to end.
+    // The latex feature is on by default and parses `$...$` through
+    // remark-math. In plugin-streaming `$` is no unconditional fast-path
+    // token, because math detection needs a math node in the schema.
+    // This test pins the whole chain end to end.
     const crepe = new Crepe({
       defaultValue: 'pre',
       features: { [CrepeFeature.AI]: true },
@@ -494,7 +494,8 @@ describe('AI session retry metadata', () => {
       featureConfigs: {
         [CrepeFeature.AI]: {
           provider: async function* () {
-            // Hang forever — caller should see runAICmd return false.
+            // The provider hangs, so the caller sees `runAICmd` return
+            // false.
             await new Promise(() => {})
             yield ''
           },
@@ -589,8 +590,8 @@ describe('AI keybindings', () => {
     })
     await crepe.create()
     try {
-      // No `diffOwnedByAI` flip — this represents host code calling
-      // `startDiffReviewCmd` directly, independent of the AI feature.
+      // Nothing flips `diffOwnedByAI` here. This stands for host code
+      // that calls `startDiffReviewCmd` without the AI feature.
       crepe.editor.action((ctx) => {
         ctx.get(commandsCtx).call(startDiffReviewCmd.key, 'goodbye')
       })
@@ -725,8 +726,8 @@ describe('AI diff actions panel visibility', () => {
   })
 
   test('Retry button clears the diff review and re-runs the stored prompt', async () => {
-    // Hanging provider so the re-issued AI session stays in streaming
-    // and doesn't transition back into diff review while we assert.
+    // The provider hangs, so the re-issued AI session stays in streaming
+    // and never returns to diff review during the assertions.
     const provider = vi.fn(async function* () {
       await new Promise(() => {})
       yield ''
@@ -738,10 +739,10 @@ describe('AI diff actions panel visibility', () => {
     })
     await crepe.create()
     try {
-      // Stage the editor as if a previous AI run had ended in diff
-      // review: persistent retry metadata + AI ownership flag + active
-      // diff. We bypass `runAICmd` so the assertions don't have to wait
-      // for a full streaming round-trip.
+      // Stage the editor as if a previous AI run ended in diff review.
+      // That state holds the retry metadata, the AI ownership flag and
+      // an active diff. Skipping `runAICmd` keeps the assertions off a
+      // full streaming round trip.
       crepe.editor.action((ctx) => {
         const session = ctx.get(aiSessionCtx.key)
         ctx.set(aiSessionCtx.key, {
@@ -833,8 +834,8 @@ describe('public AI feature surface', () => {
   // and an object lookup would miss the registered one. Resolution is by
   // name in `Container.get`, which is why it survives the duplication.
   // `core/slice.ts` uses the same trick for `useCrepe`.
-  // Never `.use()`d, so never registered — they only need the same slice
-  // *names* as the real ones. Their values are never read.
+  // No `.use()` call registers these slices. They only need the slice
+  // names of the real ones, and nothing reads their values.
   const duplicateProviderConfig = $ctx(
     {} as AIProviderConfigValue,
     'aiProviderConfig'
@@ -875,8 +876,8 @@ describe('public AI feature surface', () => {
     const crepe = await createAICrepe(provider)
     try {
       const { ctx } = crepe.editor
-      // If the slice were renamed, the helpers would resolve to nothing
-      // while the object lookup kept working — this catches that skew.
+      // A renamed slice would leave the helpers resolving to nothing
+      // while the object lookup kept working. This catches that skew.
       expect(useAIProviderConfig(ctx)).toBe(ctx.get(aiProviderConfig.key))
       expect(useAIInstructionTooltipAPI(ctx)).toBe(
         ctx.get(aiInstructionTooltipAPI.key)
@@ -887,12 +888,12 @@ describe('public AI feature surface', () => {
   })
 
   test('the helpers resolve by name, not by slice object identity', async () => {
-    // Reproduces what the published package does to a host: register slices
-    // that carry the real names but are *different objects* — the copies a
-    // separately-bundled entry constructs — and leave the module-internal
-    // objects unregistered. Name lookup still lands; reverting either helper
-    // to `ctx.get(<slice>.key)` makes this test throw, which is the whole
-    // reason the helpers exist.
+    // Reproduce what the published package does to a host. It registers
+    // slices that carry the real names as different objects, the copies
+    // a separately bundled entry constructs, and leaves the
+    // module-internal objects unregistered. The name lookup still lands.
+    // A helper reverted to `ctx.get(<slice>.key)` makes this test throw,
+    // which is the reason the helpers exist.
     const crepe = new Crepe({
       defaultValue: 'hello',
       features: { [CrepeFeature.AI]: false },
@@ -901,8 +902,8 @@ describe('public AI feature surface', () => {
     await crepe.create()
     try {
       const { ctx } = crepe.editor
-      // The objects this module holds are absent from the container — this is
-      // the host's situation, not a contrived one.
+      // The container holds none of the objects this module holds,
+      // which is the real situation of a host.
       expect(() => ctx.get(aiProviderConfig.key)).toThrow(/aiProviderConfig/)
       expect(() => ctx.get(aiInstructionTooltipAPI.key)).toThrow(
         /aiInstructionTooltipAPI/

--- a/packages/crepe/src/feature/ai/commands.ts
+++ b/packages/crepe/src/feature/ai/commands.ts
@@ -51,10 +51,10 @@ export const aiProviderConfig = $ctx<AIProviderConfigValue, 'aiProviderConfig'>(
   'aiProviderConfig'
 )
 
-/// Read the AI configuration — most usefully `provider`, which is `undefined`
-/// until the host configures one. A custom toolbar should hide its AI entry
-/// while it is unset: the palette would open but every action would be
-/// rejected.
+/// Read the AI configuration. The most useful field is `provider`, which
+/// stays `undefined` until the host configures one. A custom toolbar
+/// hides its AI entry while the field is unset, because the palette
+/// would open and every action would be rejected.
 ///
 /// Throws if the AI feature is disabled, so gate the call on
 /// `useCrepeFeatures(ctx).get().includes(CrepeFeature.AI)`.
@@ -79,10 +79,10 @@ export function useAIProviderConfig(ctx: Ctx) {
 /// indicator. `lastInstruction`, `lastLabel`, `lastFrom`, `lastTo` are
 /// kept after the session ends so the diff-actions Retry button can
 /// re-run the same prompt on the same text range. `diffOwnedByAI` is
-/// flipped on right before our `endStreamingCmd` activates diff review
-/// and back off when the diff panel sees the diff close, so a manually
-/// started diff review (via `startDiffReviewCmd`) doesn't inherit the
-/// previous AI session's Retry affordance.
+/// turned on right before `endStreamingCmd` activates diff review, and
+/// turned off when the diff panel sees the diff close. A diff review
+/// that `startDiffReviewCmd` starts by hand then inherits no Retry
+/// affordance from the previous AI session.
 export const aiSessionCtx = $ctx(
   {
     abortController: null as AbortController | null,
@@ -139,15 +139,15 @@ async function runProvider(
       commands.call(pushChunkCmd.key, chunk)
     }
     if (abortController.signal.aborted) return
-    // Streaming complete — hand off to diff review if configured. The
-    // ownership flag is flipped *before* the dispatch so the diff-actions
-    // panel reads `true` during the same transaction's update cycle.
-    // If the dispatch is rejected (e.g. host code already ended the
-    // streaming session), revert the flag so the next manually-started
-    // diff review isn't misclassified as AI-owned — `clearActiveSession`
-    // intentionally preserves `diffOwnedByAI` because the panel is
-    // responsible for clearing it on the diff true→false edge, but no
-    // such edge fires when the dispatch never landed.
+    // Streaming is complete, so hand off to diff review when the config
+    // asks for it. The ownership flag flips before the dispatch, so the
+    // diff-actions panel reads `true` in the update cycle of the same
+    // transaction. A rejected dispatch reverts the flag, for example
+    // when host code already ended the streaming session. Otherwise the
+    // next diff review started by hand would count as AI-owned.
+    // `clearActiveSession` keeps `diffOwnedByAI` on purpose, because the
+    // panel clears it on the true to false edge of the diff, and that
+    // edge never fires when the dispatch never lands.
     const config = ctx.get(aiProviderConfig.key)
     if (config.diffReviewOnEnd) {
       const cur = ctx.get(aiSessionCtx.key)
@@ -167,9 +167,9 @@ async function runProvider(
     const commands = ctx.get(commandsCtx)
     commands.call(abortStreamingCmd.key, { keep: false })
   } finally {
-    // Only clean up if this session is still the active one. If the
-    // user aborted and immediately started a new session, the new
-    // session owns the ctx now and we must not clobber it.
+    // Clean up only while this session stays the active one. After an
+    // abort and an immediate restart, the new session owns the ctx, and
+    // this one must leave it alone.
     const current = ctx.get(aiSessionCtx.key)
     if (current.abortController === abortController) {
       clearActiveSession(ctx)
@@ -203,18 +203,17 @@ export const runAICmd = $command('RunAI', (ctx) => {
     if (streamingPluginKey.getState(state)?.active) return false
     if (diffPluginKey.getState(state)?.active) return false
 
-    // Dry-run: when dispatch is undefined, ProseMirror is probing
-    // whether this command can execute. All precondition checks above
-    // are side-effect-free so we can return true here.
+    // Dry run: an undefined dispatch means ProseMirror probes whether
+    // the command can run. Every precondition check above is free of
+    // side effects, so the probe returns true here.
     if (!dispatch) return true
 
-    // Set the session label before starting the streaming plugin, so
-    // the streaming-indicator widget reads the right label when its
-    // decoration is first built. Empty string means "no caller-supplied
-    // label" — the indicator widget falls through to its configured
-    // `fallbackLabel`. `lastInstruction` / `lastLabel` are also stored
-    // here so the diff-actions Retry button can re-run the same prompt
-    // later.
+    // The session label is set before the streaming plugin starts, so
+    // the streaming-indicator widget reads the right label when it first
+    // builds its decoration. An empty string means the caller supplied
+    // no label, and the widget falls back to its configured
+    // `fallbackLabel`. `lastInstruction` and `lastLabel` are stored here
+    // too, so the diff-actions Retry button can re-run the same prompt.
     const abortController = new AbortController()
     const { from, to } = state.selection
     ctx.set(aiSessionCtx.key, {
@@ -229,7 +228,7 @@ export const runAICmd = $command('RunAI', (ctx) => {
       diffOwnedByAI: false,
     })
 
-    // Start streaming — replaces the selection if non-empty.
+    // Start streaming. A non-empty selection is replaced.
     const commands = ctx.get(commandsCtx)
     const insertAt = state.selection.empty
       ? ('cursor' as const)
@@ -239,9 +238,9 @@ export const runAICmd = $command('RunAI', (ctx) => {
       return false
     }
 
-    // Everything after startStreamingCmd is wrapped in try/catch: if
-    // buildContext or anything else throws, we must abort the streaming
-    // session to avoid leaving the editor locked with no way to recover.
+    // A try/catch guards everything after `startStreamingCmd`. A throw
+    // from `buildContext` or from any other call has to abort the
+    // streaming session, which would otherwise lock the editor.
     let promptContext: AIPromptContext
     try {
       const buildContext = config.buildContext ?? defaultBuildContext
@@ -254,10 +253,10 @@ export const runAICmd = $command('RunAI', (ctx) => {
       return false
     }
 
-    // Fire-and-forget: the provider pushes chunks asynchronously.
-    // startStreamingCmd already dispatched its own transaction — we
-    // must NOT dispatch state.tr here as it would overwrite the
-    // streaming plugin's state with a stale doc.
+    // Fire and forget: the provider pushes chunks asynchronously.
+    // `startStreamingCmd` already dispatched its own transaction, so a
+    // dispatch of `state.tr` here would overwrite the state of the
+    // streaming plugin with a stale doc.
     void runProvider(ctx, config.provider, promptContext, abortController)
 
     return true
@@ -279,9 +278,8 @@ export const abortAICmd = $command('AbortAI', (ctx) => {
     session.abortController.abort()
     clearActiveSession(ctx)
 
-    // Only call abortStreamingCmd if the streaming plugin is still
-    // active — it may have already finished/errored by the time the
-    // user clicks abort.
+    // Call `abortStreamingCmd` only while the streaming plugin stays
+    // active. It can finish or fail before the user clicks abort.
     if (streamingPluginKey.getState(state)?.active) {
       const commands = ctx.get(commandsCtx)
       commands.call(abortStreamingCmd.key, options)

--- a/packages/crepe/src/feature/ai/context.ts
+++ b/packages/crepe/src/feature/ai/context.ts
@@ -15,16 +15,14 @@ export function defaultBuildContext(
   const serializer = ctx.get(serializerCtx)
   const { state } = view
 
-  // Full document as markdown
   const document = serializer(state.doc)
 
-  // Selected text as markdown (empty if selection is collapsed).
-  // For block-level selections (whole paragraphs, list items, etc.)
-  // we wrap the slice content in a doc node and serialize it. For
-  // inline-only selections (text inside a single paragraph),
-  // createAndFill on the doc type returns null because inline content
-  // isn't valid as direct doc children — wrap it in a paragraph first
-  // so marks (bold, italic, links) survive into the markdown output.
+  // A collapsed selection serializes to an empty string. A block-level
+  // selection, such as a whole paragraph or a list item, serializes
+  // through a doc node that wraps the slice content. An inline-only
+  // selection needs a paragraph wrapper first, because `createAndFill`
+  // on the doc type returns null for inline content. The wrapper also
+  // keeps a mark such as bold, italic or a link in the markdown output.
   let selection = ''
   if (!state.selection.empty) {
     const { from, to } = state.selection

--- a/packages/crepe/src/feature/ai/diff-actions/view.ts
+++ b/packages/crepe/src/feature/ai/diff-actions/view.ts
@@ -16,16 +16,15 @@ import { aiSessionCtx, runAICmd } from '../commands'
 
 const PANEL_CLASS = 'milkdown-ai-diff-actions'
 
-/// Icons in `ResolvedDiffActionsConfig` are user-supplied SVG strings,
-/// so route them through DOMPurify before assigning to `innerHTML` —
-/// matches the sanitization the shared `Icon` component already does
-/// for Vue-rendered icons.
+/// An icon in `ResolvedDiffActionsConfig` is a user-supplied SVG string,
+/// so it passes through DOMPurify before it reaches `innerHTML`. The
+/// shared `Icon` component sanitizes a Vue-rendered icon the same way.
 function setSanitizedIcon(host: HTMLElement, svg: string): void {
   host.innerHTML = DOMPurify.sanitize(svg.trim())
 }
 
-/// Fully resolved diff actions config — every field has a value, so the
-/// view doesn't have to know about defaults.
+/// The fully resolved diff actions config. Every field carries a value,
+/// so the view needs no knowledge of the defaults.
 export interface ResolvedDiffActionsConfig {
   retryLabel: string
   rejectAllLabel: string
@@ -54,14 +53,14 @@ export class DiffActionsPanelView implements PluginView {
   /// can detect false→true / true→false edges independently of whether
   /// the panel is actually being shown.
   #diffActive = false
-  /// Doc snapshot at the moment diff review activated. If the live doc
-  /// drifts from this snapshot the user has accepted some per-change
-  /// diffs and the stored `lastFrom`/`lastTo` no longer point at the
-  /// original range — Retry is unsafe at that point.
+  /// The doc snapshot taken when diff review activated. A live doc that
+  /// drifts from the snapshot means the user accepted a per-change diff.
+  /// The stored `lastFrom` and `lastTo` then point past the original
+  /// range, which makes Retry unsafe.
   #diffStartDoc: Node | null = null
-  /// Whether the active diff review came from this AI session's
-  /// streaming hand-off (vs being started manually via
-  /// `startDiffReviewCmd`). Captured at the false→true transition.
+  /// Whether the active diff review came from the streaming hand-off of
+  /// this AI session, and not from a manual `startDiffReviewCmd` call.
+  /// The value is captured at the false to true transition.
   /// The panel only renders when this is true so it doesn't take over
   /// non-AI diff flows that exist independently of the AI feature.
   #ownedByAI = false
@@ -148,10 +147,10 @@ export class DiffActionsPanelView implements PluginView {
   #retry = (): void => {
     const session = this.ctx.get(aiSessionCtx.key)
     if (!session.lastInstruction) return
-    // Refuse to retry when the active diff didn't originate from this
-    // AI session, or once the user has accepted any individual diff —
-    // `clearDiffReviewCmd` only exits diff mode, it doesn't roll back
-    // accepted changes, so the stored range would point at shifted text.
+    // Retry needs a diff that came from this AI session and no accepted
+    // individual diff. `clearDiffReviewCmd` only exits diff mode and
+    // rolls back no accepted change, so the stored range would point at
+    // shifted text.
     if (!this.#ownedByAI || !this.#canRetry()) return
 
     const commands = this.ctx.get(commandsCtx)

--- a/packages/crepe/src/feature/ai/index.ts
+++ b/packages/crepe/src/feature/ai/index.ts
@@ -78,11 +78,11 @@ export const ai: DefineFeature<AIFeatureConfig> = (editor, config) => {
         ...prev,
         ...streamingCfg,
         ignoreAttrs: streamingCfg.ignoreAttrs ?? CREPE_IGNORE_ATTRS,
-        // Wire diffReviewOnEnd into the streaming plugin so manual
-        // endStreamingCmd calls (outside runAICmd) also respect it.
-        // Only override if the user explicitly set it — otherwise
-        // keep the streaming plugin's own default so tests and
-        // manual-streaming use cases aren't surprised.
+        // `diffReviewOnEnd` reaches the streaming plugin, so an
+        // `endStreamingCmd` call outside `runAICmd` respects it too. An
+        // override happens only on an explicit user value. Otherwise the
+        // streaming plugin keeps its own default, which a test and a
+        // manual streaming session both rely on.
         ...(config?.diffReviewOnEnd !== undefined
           ? { diffReviewOnEnd: config.diffReviewOnEnd }
           : {}),
@@ -108,11 +108,9 @@ export const ai: DefineFeature<AIFeatureConfig> = (editor, config) => {
     .use(aiSessionCtx)
     .use(runAICmd)
     .use(abortAICmd)
-    // -- AI instruction tooltip --
     .config(configureAIInstructionTooltip(config))
     .use(aiInstructionTooltipAPI)
     .use(aiInstructionTooltip)
-    // -- Streaming indicator --
     .use(streamingIndicatorPlugin({ config: config?.streamingIndicator }))
     // -- Diff actions panel --
     .use(

--- a/packages/crepe/src/feature/ai/instruction-tooltip/component.tsx
+++ b/packages/crepe/src/feature/ai/instruction-tooltip/component.tsx
@@ -15,8 +15,9 @@ import { keepAlive } from '../../../utils/keep-alive'
 
 keepAlive(h)
 
-/// Resolved chrome (icons + labels) for the tooltip. All fields required —
-/// the view layer fills in defaults before mounting the component.
+/// The resolved icons and labels for the tooltip. Every field is
+/// required, because the view layer fills in the defaults before it
+/// mounts the component.
 export interface AIInstructionTooltipChrome {
   aiIcon: string
   sendIcon: string

--- a/packages/crepe/src/feature/ai/instruction-tooltip/index.ts
+++ b/packages/crepe/src/feature/ai/instruction-tooltip/index.ts
@@ -36,9 +36,9 @@ export const aiInstructionTooltipAPI = $ctx(
   'aiInstructionTooltipAPI'
 )
 
-/// Open the AI instruction palette over a document range — what Crepe's own
-/// toolbar button does on click. Read the range from the current selection at
-/// click time, not when the toolbar is built.
+/// Open the AI instruction palette over a document range, the same as a
+/// click on the Crepe toolbar button. Read the range from the selection
+/// at click time, not at the time the toolbar is built.
 ///
 /// Throws if the AI feature is disabled, so gate the call on
 /// `useCrepeFeatures(ctx).get().includes(CrepeFeature.AI)`.
@@ -51,8 +51,8 @@ export const aiInstructionTooltipAPI = $ctx(
 /// })
 /// ```
 export function useAIInstructionTooltipAPI(ctx: Ctx) {
-  // String slice, not `aiInstructionTooltipAPI.key` — see the note in
-  // `useAIProviderConfig`.
+  // The string form replaces `aiInstructionTooltipAPI.key`. See the note
+  // in `useAIProviderConfig`.
   return ctx.get<AIInstructionTooltipAPI, 'aiInstructionTooltipAPI'>(
     'aiInstructionTooltipAPI'
   )

--- a/packages/crepe/src/feature/ai/instruction-tooltip/view.ts
+++ b/packages/crepe/src/feature/ai/instruction-tooltip/view.ts
@@ -30,11 +30,11 @@ export class AIInstructionTooltipView implements PluginView {
   #resetSignal
   #from = -1
   #to = -1
-  /// Source of truth for "should the palette currently be showing".
-  /// `TooltipProvider.shouldShow` reads this so that forwarding `update()`
-  /// to the provider on every editor transition (needed to keep the
-  /// floating position in sync with layout changes) doesn't dismiss the
-  /// palette behind our back.
+  /// The source of truth for whether the palette shows.
+  /// `TooltipProvider.shouldShow` reads this flag. Every editor
+  /// transition forwards `update()` to the provider, which keeps the
+  /// floating position in sync with a layout change. The flag stops that
+  /// forwarding from dismissing the palette.
   #wantsShow = false
 
   constructor(
@@ -42,13 +42,14 @@ export class AIInstructionTooltipView implements PluginView {
     view: EditorView,
     config: AIInstructionTooltipViewConfig
   ) {
-    // Wrapped in a ref so the Vue component re-renders if it ever
-    // changes; today there's no setter, but keeping it reactive lets a
-    // future API (e.g. context-sensitive placeholders) plug in cleanly.
+    // A ref re-renders the Vue component on a change. No setter exists
+    // today, and the reactive form leaves room for a later API such as a
+    // context-sensitive placeholder.
     this.#placeholder = ref(config.placeholder)
-    // Bumped on each `show()` so the component clears input/submenu/cursor
-    // state — the Vue app stays mounted across hide/show cycles, so its
-    // local state would otherwise persist into the next session.
+    // Each `show()` bumps this signal, which clears the input, the
+    // submenu and the cursor state of the component. The Vue app stays
+    // mounted across a hide and show cycle, so its local state would
+    // otherwise reach the next session.
     this.#resetSignal = ref(0)
 
     const content = document.createElement('div')

--- a/packages/crepe/src/feature/ai/streaming-indicator.ts
+++ b/packages/crepe/src/feature/ai/streaming-indicator.ts
@@ -167,9 +167,9 @@ export function streamingIndicatorPlugin(
             commands.call(abortAICmd.key, { keep: true })
             return true
           }
-          // Manual streaming session (no AI session in flight) — abort
-          // the streaming plugin directly so the "Esc to cancel" hint
-          // shown in the pill isn't misleading.
+          // A manual streaming session runs with no AI session in
+          // flight, so abort the streaming plugin directly. The pill
+          // shows an "Esc to cancel" hint that must stay true.
           if (streamingPluginKey.getState(view.state)?.active) {
             event.preventDefault()
             commands.call(abortStreamingCmd.key, { keep: true })

--- a/packages/crepe/src/feature/ai/types.ts
+++ b/packages/crepe/src/feature/ai/types.ts
@@ -93,10 +93,9 @@ export interface AIFeatureConfig {
   /// Pass-through config for the diff plugin.
   diff?: AIDiffConfig
 
-  /// Pass-through config for the streaming plugin.
-  /// `diffReviewOnEnd` is excluded here because it's controlled by
-  /// `AIFeatureConfig.diffReviewOnEnd` at the AI layer — setting it on
-  /// both would be confusing.
+  /// Pass-through config for the streaming plugin. This type excludes
+  /// `diffReviewOnEnd`, because `AIFeatureConfig.diffReviewOnEnd`
+  /// controls it at the AI layer.
   streaming?: Partial<Omit<StreamingConfig, 'diffReviewOnEnd'>>
 
   /// Called when an error occurs during AI processing.

--- a/packages/crepe/src/feature/index.ts
+++ b/packages/crepe/src/feature/index.ts
@@ -15,22 +15,27 @@ import type { TopBarFeatureConfig } from './top-bar'
 /// Most features are enabled by default; `TopBar` and `AI` are opt-in.
 /// See `defaultFeatures` for the per-flag default.
 export enum CrepeFeature {
-  /// Syntax highlighting and editing for code blocks with language support, theme customization, and preview capabilities.
+  /// Syntax highlighting and editing for a code block, with language
+  /// support, theme customization and preview.
   CodeMirror = 'code-mirror',
 
-  /// Support for bullet lists, ordered lists, and todo lists with customizable icons and formatting.
+  /// Support for a bullet list, an ordered list and a todo list, with
+  /// customizable icons and formatting.
   ListItem = 'list-item',
 
-  /// Enhanced link editing and preview with customizable tooltips, edit/remove actions, and copy functionality.
+  /// Link editing and preview, with a customizable tooltip, edit and
+  /// remove actions, and copy support.
   LinkTooltip = 'link-tooltip',
 
-  /// Enhanced cursor experience with drop cursor and gap cursor for better content placement.
+  /// A drop cursor and a gap cursor for better content placement.
   Cursor = 'cursor',
 
-  /// Image upload and management with resizing, captions, and support for both inline and block images.
+  /// Image upload and management, with resizing, captions and support
+  /// for both an inline image and a block image.
   ImageBlock = 'image-block',
 
-  /// Drag-and-drop block management and slash commands for quick content insertion and organization.
+  /// Drag-and-drop block management and a slash command for quick
+  /// content insertion.
   BlockEdit = 'block-edit',
 
   /// Formatting toolbar for selected text with customizable icons and actions.
@@ -39,16 +44,20 @@ export enum CrepeFeature {
   /// Document or block level placeholders to guide users when content is empty.
   Placeholder = 'placeholder',
 
-  /// Full-featured table editing with row/column management, alignment options, and drag-and-drop functionality.
+  /// Table editing with row and column management, alignment options and
+  /// drag-and-drop support.
   Table = 'table',
 
-  /// Mathematical formula support with both inline and block math rendering using KaTeX.
+  /// Mathematical formula support, with inline and block math rendered
+  /// by KaTeX.
   Latex = 'latex',
 
-  /// Fixed top toolbar with heading selector, formatting buttons, insert actions, and block commands.
+  /// A fixed top toolbar with a heading selector, formatting buttons,
+  /// insert actions and block commands.
   TopBar = 'top-bar',
 
-  /// AI-assisted editing: streaming input, diff review, and provider integration.
+  /// AI-assisted editing: streaming input, diff review and provider
+  /// integration.
   AI = 'ai',
 }
 

--- a/packages/crepe/src/feature/link-tooltip/link-tooltip.spec.ts
+++ b/packages/crepe/src/feature/link-tooltip/link-tooltip.spec.ts
@@ -16,8 +16,8 @@ function getEditTooltip() {
 }
 
 function createCrepe(defaultValue: string) {
-  // Disable Cursor feature: prosemirror-virtual-cursor uses Range.getClientRects
-  // which jsdom does not implement.
+  // The Cursor feature stays off, because prosemirror-virtual-cursor
+  // calls `Range.getClientRects`, which jsdom does not implement.
   return new Crepe({
     defaultValue,
     features: {
@@ -37,7 +37,7 @@ describe('link tooltip edit', () => {
     await crepe.create()
     await waitForAsync()
 
-    // Cursor between "h" and "ello" — empty selection.
+    // The cursor sits between "h" and "ello", so the selection is empty.
     const cursorPos = 2
     crepe.editor.ctx.get(linkTooltipAPI.key).addLink(cursorPos, cursorPos)
     await waitForAsync()

--- a/packages/crepe/src/feature/toolbar/config.ts
+++ b/packages/crepe/src/feature/toolbar/config.ts
@@ -45,28 +45,32 @@ import { mathInlineId, toggleLatexCommandName } from '../latex/constants'
 export type ToolbarItem = {
   active: (ctx: Ctx) => boolean
   icon: string
-  /// Accessible name for the button, rendered as `title` and `aria-label`.
-  /// Without it the button exposes no name at all — its only content is an SVG.
+  /// Accessible name for the button, rendered as `title` and
+  /// `aria-label`. Without it the button exposes no name, because its
+  /// only content is an SVG.
   label?: string
-  /// Human-readable form of the item's keyboard shortcut, e.g. `⌘B` on macOS or
-  /// `Ctrl+B` elsewhere. Appended to the `title` for display only — it is never
-  /// used for `aria-keyshortcuts`, which has its own grammar.
+  /// Human-readable form of the keyboard shortcut, for example `⌘B` on
+  /// macOS or `Ctrl+B` elsewhere. The `title` appends it for display
+  /// only. `aria-keyshortcuts` never reads it, because that attribute
+  /// has its own grammar.
   shortcut?: string
-  /// The same shortcut in `aria-keyshortcuts` grammar: `+`-joined modifiers from
-  /// `Alt` / `Control` / `Shift` / `Meta` / `AltGraph` plus a `KeyboardEvent.key`
-  /// value, e.g. `Meta+B` or `Control+Shift+H`. Kept separate from `shortcut`
-  /// because display glyphs (`⌘B`) and the abbreviation `Ctrl` are both invalid
-  /// here, and a single field cannot satisfy both readers.
+  /// The same shortcut in `aria-keyshortcuts` grammar. It joins the
+  /// modifiers `Alt`, `Control`, `Shift`, `Meta` and `AltGraph` with `+`,
+  /// then adds a `KeyboardEvent.key` value, as in `Meta+B` or
+  /// `Control+Shift+H`. This field stays separate from `shortcut`,
+  /// because a display glyph such as `⌘B` and the abbreviation `Ctrl` are
+  /// both invalid here. One field cannot serve both readers.
   ///
-  /// Crepe defaults neither: which combo is bound, and how it is spelled per
-  /// platform, is the host's business.
+  /// Crepe defaults neither field. The host owns the bound combination
+  /// and its spelling on each platform.
   ariaKeyshortcuts?: string
-  /// A reference to the keymap entry that binds this item's command, e.g.
-  /// `keymapRef(strongKeymap.key, 'ToggleBold')`. When set, `shortcut` and
-  /// `ariaKeyshortcuts` are derived from it — the single source of truth — so
-  /// they follow any host rebinding and never have to be spelled per UI region.
-  /// The two string fields above still win when set explicitly, for shortcuts
-  /// not backed by a milkdown keymap.
+  /// A reference to the keymap entry that binds the command of this
+  /// item, for example `keymapRef(strongKeymap.key, 'ToggleBold')`. A set
+  /// reference derives `shortcut` and `ariaKeyshortcuts` from the single
+  /// place that binds the key, so both follow a host rebinding and need
+  /// no repetition per UI region. An explicit value in the two string
+  /// fields above still wins, for a shortcut that no milkdown keymap
+  /// backs.
   keymap?: KeymapRef
 }
 
@@ -169,13 +173,12 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
     },
   })
 
-  // Skip the AI button entirely when the feature is disabled or when no
-  // provider is configured — without a provider the palette would open
-  // but `runAICmd` would silently reject every action. Toolbar-level
-  // `aiIcon` wins over `AIFeatureConfig.aiIcon` so consumers can override
-  // just the toolbar entry without touching the tooltip prefix.
-  // The aiProviderConfig slice is only injected when the AI feature is
-  // active, so guard the lookup behind the flag check.
+  // The AI button needs both the feature and a provider. Without a
+  // provider the palette opens and `runAICmd` rejects every action in
+  // silence. The toolbar `aiIcon` wins over `AIFeatureConfig.aiIcon`, so
+  // a consumer can override the toolbar entry alone and keep the tooltip
+  // prefix. Only an active AI feature injects the `aiProviderConfig`
+  // slice, so the flag check has to guard the lookup.
   if (ctx && flags?.includes(CrepeFeature.AI)) {
     const aiCfg = ctx.get(aiProviderConfig.key)
     if (aiCfg.provider) {
@@ -197,11 +200,12 @@ export function getGroups(config?: ToolbarFeatureConfig, ctx?: Ctx) {
 
   const groups = groupBuilder.build()
 
-  // Derive display + `aria-keyshortcuts` from each item's keymap reference —
-  // the one place the shortcut is actually bound — so they follow any host
-  // rebinding. `??=` lets an explicitly configured string win. Runs only with a
-  // ctx (the keymap slices live there); the derived value is read at build time,
-  // so a rebind shows up the next time the toolbar opens, not on an open one.
+  // The keymap reference of an item is the single place that binds the
+  // shortcut, so the display form and `aria-keyshortcuts` derive from it
+  // and follow a host rebinding. `??=` lets a configured string win. The
+  // loop needs a ctx, because the keymap slices live there. The derived
+  // value is read at build time, so a rebind reaches the toolbar on its
+  // next open, not on an open one.
   if (ctx) {
     for (const group of groups) {
       for (const item of group.items) {

--- a/packages/crepe/src/feature/toolbar/index.ts
+++ b/packages/crepe/src/feature/toolbar/index.ts
@@ -30,8 +30,8 @@ interface ToolbarConfig {
   strikethroughIcon: string
   latexIcon: string
   aiIcon: string
-  /// Accessible names for the built-in items, for localization. Each defaults to
-  /// its English label.
+  /// Accessible names for the built-in items, for localization. Each
+  /// name defaults to its English label.
   boldLabel: string
   codeLabel: string
   italicLabel: string

--- a/packages/crepe/src/feature/toolbar/toolbar.spec.ts
+++ b/packages/crepe/src/feature/toolbar/toolbar.spec.ts
@@ -54,8 +54,8 @@ async function ctxWithAI() {
 
 describe('toolbar item labels', () => {
   test('every built-in item ships an accessible name', () => {
-    // Without a label the button exposes no name at all — its only child is an
-    // SVG — so a missing one is an accessibility regression, not a nicety.
+    // Without a label the button exposes no name, because its only child
+    // is an SVG. A missing label is an accessibility regression.
     for (const item of itemsOf()) {
       expect(item.label, `item ${item.key} has no label`).toBeTruthy()
     }
@@ -218,8 +218,8 @@ describe('toolbar item shortcuts', () => {
   })
 
   test('display glyphs and the ARIA value are carried separately', () => {
-    // `⌘⇧H` is what a macOS user should read, but it is not valid
-    // `aria-keyshortcuts` — hence the two fields.
+    // A macOS user reads `⌘⇧H`, which is invalid in
+    // `aria-keyshortcuts`. That gap is why the two fields exist.
     const items = itemsOf({
       buildToolbar: (builder) => {
         builder.addGroup('custom', 'Custom').addItem('highlight', {

--- a/packages/crepe/src/feature/top-bar/config.ts
+++ b/packages/crepe/src/feature/top-bar/config.ts
@@ -173,12 +173,10 @@ export function getGroups(config?: TopBarFeatureConfig, ctx?: Ctx) {
 
   const groupBuilder = new GroupBuilder<TopBarItem>()
 
-  // Heading selector group
   groupBuilder.addGroup('heading', 'Heading').addItem('heading-selector', {
     ...buildHeadingSelector(config?.headingOptions, config?.chevronDownIcon),
   })
 
-  // Formatting group
   groupBuilder
     .addGroup('formatting', 'Formatting')
     .addItem('bold', {
@@ -228,7 +226,6 @@ export function getGroups(config?: TopBarFeatureConfig, ctx?: Ctx) {
       },
     })
 
-  // List group
   groupBuilder
     .addGroup('list', 'List')
     .addItem('bullet-list', {
@@ -262,7 +259,6 @@ export function getGroups(config?: TopBarFeatureConfig, ctx?: Ctx) {
       },
     })
 
-  // Insert group
   const insertGroup = groupBuilder.addGroup('insert', 'Insert')
   insertGroup.addItem('link', {
     icon: config?.linkIcon ?? linkIcon,
@@ -312,7 +308,6 @@ export function getGroups(config?: TopBarFeatureConfig, ctx?: Ctx) {
     })
   }
 
-  // Block group
   const blockGroup = groupBuilder.addGroup('block', 'Block')
   blockGroup.addItem('code-block', {
     icon: config?.codeBlockIcon ?? codeBlockIcon,
@@ -339,7 +334,6 @@ export function getGroups(config?: TopBarFeatureConfig, ctx?: Ctx) {
     })
   }
 
-  // More group
   groupBuilder
     .addGroup('more', 'More')
     .addItem('quote', {

--- a/packages/crepe/src/llm-providers/providers.spec.ts
+++ b/packages/crepe/src/llm-providers/providers.spec.ts
@@ -97,10 +97,9 @@ describe('shared helpers', () => {
   })
 
   test('parseSSE preserves significant whitespace in the trailing payload', async () => {
-    // No trailing newline — the buffer reaches the tail flush. The
-    // payload here intentionally contains leading and trailing spaces
-    // (a streamed token boundary the model emitted on purpose); the
-    // tail flush must not strip them.
+    // The payload carries no trailing newline, so the buffer reaches the
+    // tail flush. Its leading and trailing spaces mark a streamed token
+    // boundary, and the tail flush must keep them.
     const response = chunkedSseResponse(['data:  hello world  '])
     const ac = new AbortController()
     const out = await collect(parseSSE(response, ac.signal))

--- a/packages/crepe/src/llm-providers/shared.ts
+++ b/packages/crepe/src/llm-providers/shared.ts
@@ -139,10 +139,10 @@ export async function* parseSSE(
         }
       }
     }
-    // Flush any trailing data line that wasn't newline-terminated.
-    // Only strip a trailing `\r` (handle CRLF without an LF) — never
-    // `trim()` here, since the payload's leading/trailing whitespace
-    // is significant for streamed token content.
+    // Flush a trailing data line that carries no newline. Strip only a
+    // trailing `\r`, which covers a CRLF without its LF. Never call
+    // `trim()` here, because whitespace at either edge of the payload is
+    // significant for streamed token content.
     const tail = buffer.endsWith('\r') ? buffer.slice(0, -1) : buffer
     if (tail.startsWith('data: ')) yield tail.slice(6)
     else if (tail.startsWith('data:')) yield tail.slice(5)
@@ -161,7 +161,8 @@ export async function readErrorBody(
   try {
     body = await response.text()
   } catch {
-    // ignore — we still want to throw a status-only error
+    // A body that fails to read still leaves a status-only error worth
+    // throwing.
   }
   return new Error(
     `[${providerName}] Request failed with status ${response.status}` +

--- a/packages/crepe/src/utils/keyboard-shortcut.ts
+++ b/packages/crepe/src/utils/keyboard-shortcut.ts
@@ -3,19 +3,21 @@ import type { KeymapConfig } from '@milkdown/kit/utils'
 
 import { browser } from '@milkdown/kit/prose'
 
-/// A reference to a single entry of a milkdown keymap slice — the one place a
-/// shortcut is actually bound. UI items point at this instead of re-spelling the
-/// shortcut, so display and `aria-keyshortcuts` are derived from the source of
-/// truth and stay correct when the host rebinds the key.
+/// A reference to one entry of a milkdown keymap slice, the single
+/// place that binds a shortcut. A UI item points at the entry instead of
+/// spelling the shortcut again. The display form and the
+/// `aria-keyshortcuts` value follow the binding, so both stay correct
+/// when the host rebinds the key.
 export interface KeymapRef {
   slice: SliceType<KeymapConfig<string>>
   entry: string
 }
 
-/// Build a `KeymapRef`. The generic keeps `entry` checked against the slice's
-/// real entry names (`keymapRef(strongKeymap.key, 'ToggleBold')` — a typo is a
-/// compile error) while the single unavoidable cast to the erased storage type
-/// is localized here, so `ToolbarItem` never has to be generic.
+/// Build a `KeymapRef`. The generic checks `entry` against the real
+/// entry names of the slice, so a typo in
+/// `keymapRef(strongKeymap.key, 'ToggleBold')` fails to compile. It also
+/// keeps the one cast to the erased storage type here, so `ToolbarItem`
+/// stays non-generic.
 export function keymapRef<K extends string>(
   slice: SliceType<KeymapConfig<K>>,
   entry: K
@@ -23,8 +25,8 @@ export function keymapRef<K extends string>(
   return { slice: slice as SliceType<KeymapConfig<string>>, entry }
 }
 
-/// A shortcut rendered for both of its readers: `display` for a human (tooltip),
-/// `aria` for the `aria-keyshortcuts` attribute.
+/// A shortcut rendered for both of its readers. `display` goes to a
+/// human in a tooltip. `aria` goes to the `aria-keyshortcuts` attribute.
 export interface ResolvedShortcut {
   display: string
   aria: string
@@ -35,10 +37,10 @@ interface NormalizedKey {
   aria: string
 }
 
-/// A `KeyboardEvent.key` value for the ARIA attribute, plus a display form.
-/// Single characters are upper-cased (`b` → `B`, `-` stays `-`); named keys
-/// (`Enter`, `ArrowUp`, …) pass through; `Space` maps to the literal space the
-/// ARIA grammar expects for that key.
+/// A `KeyboardEvent.key` value for the ARIA attribute, plus a display
+/// form. A single character turns upper-case, so `b` becomes `B` and `-`
+/// stays `-`. A named key such as `Enter` or `ArrowUp` passes through.
+/// `Space` maps to the literal space that the ARIA grammar expects.
 function normalizeKey(key: string): NormalizedKey {
   if (key === ' ' || key.toLowerCase() === 'space')
     return { display: 'Space', aria: ' ' }
@@ -49,19 +51,21 @@ function normalizeKey(key: string): NormalizedKey {
   return { display: key, aria: key }
 }
 
-/// Format a prosemirror keymap shortcut (`Mod-b`, `Mod-Alt-x`) into a display
-/// string and an `aria-keyshortcuts` value. `mac` is injected so the pure output
-/// is testable on both platforms without stubbing `navigator`; callers pass
-/// `browser.mac`.
+/// Format a prosemirror keymap shortcut such as `Mod-b` or `Mod-Alt-x`
+/// into a display string and an `aria-keyshortcuts` value. The caller
+/// passes `mac`, normally `browser.mac`. The injected flag keeps the
+/// output pure and testable on both platforms without a `navigator`
+/// stub.
 ///
-/// - `Mod` resolves to `Meta` on macOS and `Control` elsewhere, matching what
-///   prosemirror-keymap actually binds.
-/// - Display follows each platform's convention: macOS glyphs `⌃⌥⇧⌘` with the
-///   Command key next to the key and no separators (`⌥⌘X`); elsewhere `+`-joined
-///   names with the primary modifier first (`Ctrl+Alt+X`).
-/// - The ARIA value uses the attribute's grammar: `+`-joined modifiers from
-///   `Meta`/`Control`/`Alt`/`Shift` followed by a `KeyboardEvent.key` value
-///   (`Meta+Shift+H`, `Control+B`).
+/// - `Mod` resolves to `Meta` on macOS and to `Control` elsewhere, the
+///   same as prosemirror-keymap binds it.
+/// - Display follows the platform convention. macOS uses the glyphs
+///   `⌃⌥⇧⌘`, puts the Command key next to the key and adds no
+///   separator, as in `⌥⌘X`. Every other platform joins names with `+`
+///   and puts the primary modifier first, as in `Ctrl+Alt+X`.
+/// - The ARIA value follows the attribute grammar. It joins the
+///   modifiers `Meta`, `Control`, `Alt` and `Shift` with `+`, then adds a
+///   `KeyboardEvent.key` value, as in `Meta+Shift+H` or `Control+B`.
 export function formatKeymapShortcut(
   shortcut: string,
   mac: boolean

--- a/packages/ctx/src/inspector/inspector.ts
+++ b/packages/ctx/src/inspector/inspector.ts
@@ -10,7 +10,8 @@ export interface Telemetry {
   waitTimers: { name: string; duration: number; status: TimerStatus }[]
 }
 
-/// The inspector object that is used to inspect the runtime environment of a ctx.
+/// The inspector object that is used to inspect the runtime environment of a
+/// ctx.
 export class Inspector {
   /// @internal
   readonly #meta: Meta

--- a/packages/ctx/src/plugin/ctx.ts
+++ b/packages/ctx/src/plugin/ctx.ts
@@ -33,9 +33,9 @@ export class Ctx {
     return this.#inspector
   }
 
-  /// Produce a new ctx with metadata.
-  /// The new ctx will link to the same container and clock with the current ctx.
-  /// If the metadata is empty, it will return the current ctx.
+  /// Produce a new ctx with metadata. The new ctx will link to the same
+  /// container and clock with the current ctx. If the metadata is empty, it
+  /// will return the current ctx.
   readonly produce = (meta?: Meta) => {
     if (meta && Object.keys(meta).length)
       return new Ctx(this.#container, this.#clock, { ...meta })
@@ -124,8 +124,8 @@ export class Ctx {
     return promise
   }
 
-  /// Start a list of timers from the ctx, the list is stored in a slice in the ctx.
-  /// This is equivalent to
+  /// Start a list of timers from the ctx, the list is stored in a slice in the
+  /// ctx. This is equivalent to
   ///
   /// ```typescript
   /// Promise.all(ctx.get(slice).map(x => ctx.wait(x))).

--- a/packages/ctx/src/timer/clock.ts
+++ b/packages/ctx/src/timer/clock.ts
@@ -22,7 +22,7 @@ export class Clock {
     this.store.delete(timer.id)
   }
 
-  // Check if the clock has a timer by timer type.
+  /// Check if the clock has a timer by timer type.
   has = (timer: TimerType) => {
     return this.store.has(timer.id)
   }

--- a/packages/plugins/plugin-automd/src/config.ts
+++ b/packages/plugins/plugin-automd/src/config.ts
@@ -42,9 +42,9 @@ export const defaultConfig: InlineSyncConfig = {
   shouldSyncNode: ({ prevNode, nextNode }) =>
     prevNode.inlineContent &&
     nextNode &&
-    // if node type changes, do not sync
+    // A changed node type does not sync.
     prevNode.type === nextNode.type &&
-    // if two node fully equal, we don't modify them
+    // Two equal nodes need no modification.
     !prevNode.eq(nextNode),
   movePlaceholder: (placeholderToMove: string, text: string) => {
     const symbolsNeedToMove = ['*', '_']
@@ -62,8 +62,8 @@ export const defaultConfig: InlineSyncConfig = {
   },
 }
 
-/// A slice that contains the inline sync config.
-/// You can set value to this slice to change the config.
+/// A slice that contains the inline sync config. You can set value to this
+/// slice to change the config.
 ///
 /// ```typescript
 /// ctx.update(inlineSyncConfigCtx, (prevCfg) => ({
@@ -72,7 +72,8 @@ export const defaultConfig: InlineSyncConfig = {
 /// }));
 /// ```
 ///
-/// You can find the default config [here](https://github.com/Milkdown/milkdown/blob/main/packages/plugin-automd/src/config.ts).
+/// Read the default config
+/// [here](https://github.com/Milkdown/milkdown/blob/main/packages/plugin-automd/src/config.ts).
 export const inlineSyncConfig = $ctx<InlineSyncConfig, 'inlineSyncConfig'>(
   defaultConfig,
   'inlineSyncConfig'

--- a/packages/plugins/plugin-automd/src/context.ts
+++ b/packages/plugins/plugin-automd/src/context.ts
@@ -222,7 +222,8 @@ export function getContextByState(
         }
       }
 
-      // Fallback: If it's a mailto link and looks like an autolink (href contains text),
+      // Fallback: a mailto link whose href contains the text looks like
+      // an autolink.
       const href = linkMark.attrs.href
       if (
         typeof href === 'string' &&

--- a/packages/plugins/plugin-automd/src/inline-sync-plugin.ts
+++ b/packages/plugins/plugin-automd/src/inline-sync-plugin.ts
@@ -9,11 +9,13 @@ import { inlineSyncConfig } from './config'
 import { getContextByState } from './context'
 import { runReplacer } from './replacer'
 
-/// This plugin is used to sync the inline mark.
-/// It will create and remove marks automatically according to the user input.
+/// This plugin syncs the inline mark. It creates and removes a mark from
+/// the user input.
 ///
-/// When users type something, the plugin will transform the line (for better performance) to real markdown AST by serializer
-/// and render the AST to dom by parser, thus the input texts can be displayed correctly.
+/// On each keystroke the serializer transforms the current line into a
+/// markdown AST, which costs less than a full document pass. The parser
+/// then renders that AST to the DOM, so the typed text displays
+/// correctly.
 export const inlineSyncPlugin = $prose((ctx: Ctx) => {
   let requestId: number | null = null
   const inlineSyncPluginKey = new PluginKey('MILKDOWN_INLINE_SYNC')

--- a/packages/plugins/plugin-automd/src/replacer.ts
+++ b/packages/plugins/plugin-automd/src/replacer.ts
@@ -18,7 +18,6 @@ export function runReplacer(
 ) {
   const { placeholderConfig } = ctx.get(inlineSyncConfig.key)
   const holePlaceholder = placeholderConfig.hole
-  // insert a placeholder to restore the selection
   let tr = state.tr
     .setMeta(key, true)
     .insertText(holePlaceholder, state.selection.from)
@@ -42,10 +41,8 @@ export function runReplacer(
   tr = tr
     .replaceWith(from, to, context.nextNode)
     .setNodeMarkup(from, undefined, attrs)
-    // delete the placeholder
     .delete(offset + 1, offset + 2)
 
-  // restore the selection
   tr = tr.setSelection(TextSelection.near(tr.doc.resolve(offset + 1)))
 
   const needsRestoreMark =

--- a/packages/plugins/plugin-automd/src/utils.ts
+++ b/packages/plugins/plugin-automd/src/utils.ts
@@ -52,10 +52,10 @@ export function calculatePlaceholder(placeholder: SyncNodePlaceholder) {
     const right = text.charAt(index + 1)
     const notAWord = /[^\w]|_/
 
-    // cursor on the right
+    // No character to the right: the hole ends the text.
     if (!right) return placeholder.punctuation
 
-    // cursor on the left
+    // No character to the left: the hole starts the text.
     if (!left) return placeholder.char
 
     if (notAWord.test(left) && notAWord.test(right))

--- a/packages/plugins/plugin-block/src/__internal__/select-node-by-dom.ts
+++ b/packages/plugins/plugin-block/src/__internal__/select-node-by-dom.ts
@@ -36,7 +36,8 @@ export function selectRootNodeByDom(
       if (!filterNodes($pos, node!)) filter(true)
     }
 
-    // If filterNodes returns false, we should look up the parent node.
+    // A false result from `filterNodes` moves the lookup to the parent
+    // node.
     const filterResult = filterNodes($pos, node!)
     filter(!filterResult)
 

--- a/packages/plugins/plugin-block/src/__test__/block-drag.spec.ts
+++ b/packages/plugins/plugin-block/src/__test__/block-drag.spec.ts
@@ -60,7 +60,6 @@ const SECOND_ITEM = 11
 // The paragraph inside the second item, which is what `posAtCoords` resolves
 // to when hovering over that item.
 const SECOND_ITEM_PARAGRAPH = 12
-// The end of the text in the fourth item.
 const FOURTH_ITEM_TEXT_END = 39
 
 function itemTexts(view: EditorView) {

--- a/packages/plugins/plugin-block/src/block-provider.ts
+++ b/packages/plugins/plugin-block/src/block-provider.ts
@@ -35,13 +35,16 @@ export interface BlockProviderOptions {
   shouldShow?: (view: EditorView, prevState?: EditorState) => boolean
   /// The offset to get the block. Default is 0.
   getOffset?: (deriveContext: DeriveContext) => OffsetOptions
-  /// The function to get the position of the block. Default is the position of the active node.
+  /// The function that returns the position of the block. It defaults to
+  /// the position of the active node.
   getPosition?: (deriveContext: DeriveContext) => Omit<DOMRect, 'toJSON'>
   /// The function to get the placement of the block. Default is 'left'.
   getPlacement?: (deriveContext: DeriveContext) => Placement
-  /// Other middlewares for floating ui. This will be added after the internal middlewares.
+  /// Other middlewares for floating ui. They run after the internal
+  /// middlewares.
   middleware?: Middleware[]
-  /// Options for floating ui. If you pass `middleware` or `placement`, it will override the internal settings.
+  /// Options for floating ui. A `middleware` or `placement` value here
+  /// overrides the internal setting.
   floatingUIOptions?: Partial<ComputePositionConfig>
   /// The root element that the block will be appended to.
   root?: HTMLElement

--- a/packages/plugins/plugin-block/src/block-service.ts
+++ b/packages/plugins/plugin-block/src/block-service.ts
@@ -36,7 +36,7 @@ export type BlockServiceMessage = (message: BlockServiceMessageType) => void
 /// `NodeSelection` of the node being dragged. Both prosemirror-view and
 /// prosemirror-drop-indicator use it in `handleDrop` to remove exactly that
 /// node, and fall back to `tr.deleteSelection()` when it is absent. The field
-/// is missing from the published types, so we widen it here.
+/// is missing from the published types, so this type widens it.
 type Dragging = NonNullable<EditorView['dragging']> & {
   node?: NodeSelection
 }
@@ -177,10 +177,10 @@ export class BlockService {
       const activeEl = this.#active?.el
       if (activeEl) event.dataTransfer.setDragImage(activeEl, 0, 0)
 
-      // Hand prosemirror the node selection we captured on mousedown so the
-      // move deletes exactly the node we picked up. Without it prosemirror
-      // falls back to `tr.deleteSelection()` on whatever the live selection is
-      // at drop time, which may only strip the text and leave an empty block.
+      // Pass prosemirror the node selection captured on mousedown, so
+      // the move deletes that node. Without it prosemirror falls back to
+      // `tr.deleteSelection()` on the live selection at drop time, which
+      // can strip the text and leave an empty block.
       const dragging: Dragging = {
         slice,
         move: true,

--- a/packages/plugins/plugin-clipboard/src/index.ts
+++ b/packages/plugins/plugin-clipboard/src/index.ts
@@ -46,17 +46,18 @@ export const clipboard = $prose((ctx) => {
       const prevTransform = prev.transformPastedHTML
       if (prevTransform) html = prevTransform(html, view)
 
-      // Google Docs wraps pasted content in <b style="font-weight:normal;" id="docs-internal-guid-...">
-      // This wrapper causes ProseMirror's parser to fail when parsing multiple tables.
-      // Strip it so block content is at the top level.
+      // Google Docs wraps pasted content in a `<b>` element that carries
+      // `font-weight:normal` and a `docs-internal-guid` id. That wrapper
+      // makes the ProseMirror parser fail on several tables. Strip it to
+      // lift the block content to the top level.
       if (html.includes('docs-internal-guid')) {
         html = html.replace(
           /<b[^>]*id="docs-internal-guid[^"]*"[^>]*>([\s\S]*)<\/b>/,
           '$1'
         )
-        // Also unwrap <div> elements that wrap tables.
-        // Google Docs wraps each table in <div dir="ltr" ...><table>...</table></div>
-        // These wrappers interfere with ProseMirror's parseSlice for multiple tables.
+        // Google Docs also wraps each table in a `<div dir="ltr">`, and
+        // that wrapper disturbs `parseSlice` on several tables. Unwrap
+        // it too.
         html = html.replace(/<div[^>]*>(<table[\s\S]*?<\/table>)<\/div>/g, '$1')
       }
       return html
@@ -103,10 +104,11 @@ export const clipboard = $prose((ctx) => {
         const html = clipboardData.getData('text/html')
         if (html.length === 0 && text.length === 0) return false
 
-        // When HTML is present, use the pre-processed Slice from ProseMirror.
-        // ProseMirror's parseFromClipboard already ran transformPastedHTML
-        // (e.g. Google Docs wrapper stripping) and transformPasted (paste rules
-        // like table header fix), producing a better Slice than re-parsing here.
+        // Present HTML brings a pre-processed Slice from ProseMirror.
+        // `parseFromClipboard` already ran `transformPastedHTML`, which
+        // strips the Google Docs wrapper, and `transformPasted`, which
+        // runs a paste rule such as the table header fix. That Slice
+        // beats a fresh parse here.
         if (html.length > 0 && preProcessedSlice) {
           return dispatchPasteSlice(view, preProcessedSlice)
         }

--- a/packages/plugins/plugin-cursor/src/gap-cursor.ts
+++ b/packages/plugins/plugin-cursor/src/gap-cursor.ts
@@ -3,7 +3,8 @@ import { $prose } from '@milkdown/utils'
 
 import { withMeta } from './__internal__/with-meta'
 
-/// This plugin wraps [gap cursor](https://github.com/ProseMirror/prosemirror-gapcursor).
+/// This plugin wraps
+/// [gap cursor](https://github.com/ProseMirror/prosemirror-gapcursor).
 export const gapCursorPlugin = $prose(() => gapCursor())
 
 withMeta(gapCursorPlugin, {

--- a/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
+++ b/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
@@ -405,7 +405,6 @@ describe('computeDocDiff - range-limited', () => {
     // Same-size docs so a full-doc range is unambiguous in both.
     const oldDoc = doc(p(text('first')), p(text('second')), p(text('third')))
     const newDoc = doc(p(text('first')), p(text('SECOND')), p(text('third')))
-    // Full diff should find changes
     const fullChanges = computeDocDiff(oldDoc, newDoc)
     expect(fullChanges.length).toBeGreaterThan(0)
 
@@ -441,8 +440,8 @@ describe('computeDocDiff - range-limited', () => {
     const fullChanges = computeDocDiff(oldDoc, newDoc)
     expect(fullChanges.length).toBeGreaterThanOrEqual(2)
 
-    // Sub-range covering only the second paragraph (unchanged) — no changes
-    // p1 nodeSize=5 (open+AAA+close), so p2 starts at pos 5 and ends at pos 10
+    // A sub-range over the unchanged second paragraph finds no change.
+    // p1 has nodeSize 5, from open, AAA and close, so p2 covers 5 to 10.
     const subChanges = computeDocDiff(oldDoc, newDoc, {
       range: { from: 5, to: 10 },
     })
@@ -454,7 +453,7 @@ describe('computeDocDiff - range-limited', () => {
     const oldDoc = doc(p(text('AAA')), p(text('BBB')), p(text('CCC')))
     const newDoc = doc(p(text('AAA')), p(text('XXX')), p(text('CCC')))
 
-    // Sub-range covering the second paragraph — should find the change
+    // A sub-range over the second paragraph finds the change.
     const changes = computeDocDiff(oldDoc, newDoc, {
       range: { from: 5, to: 10 },
     })
@@ -701,9 +700,9 @@ describe('computeDocDiff - per-block matching', () => {
   })
 
   it('list item text edit recurses into the list', () => {
-    // bullet_list is a single top-level child, but our algorithm recurses
-    // into container nodes. Editing one item's text should produce a small
-    // change inside that item, not a huge one covering the whole list.
+    // bullet_list is a single top-level child, and the algorithm recurses
+    // into a container node. An edit to the text of one item produces a
+    // small change inside that item, not one over the whole list.
     const oldDoc = doc(ul(li(p(text('one'))), li(p(text('two')))))
     const newDoc = doc(ul(li(p(text('ONE'))), li(p(text('two')))))
 
@@ -768,8 +767,8 @@ describe('computeDocDiff - per-block matching', () => {
     const changes = computeDocDiff(oldDoc, newDoc)
     expect(changes.length).toBeGreaterThanOrEqual(2)
 
-    // Middle paragraph 'middle' starts after h1 (nodeSize 7: open + 'Title' + close)
-    // h1 nodeSize = 7, so p starts at 7, p nodeSize = 8, p ends at 15
+    // The middle paragraph starts after h1, whose nodeSize is 7 from
+    // open, 'Title' and close. The paragraph runs from 7 to 15.
     const h1Size = oldDoc.child(0).nodeSize
     const pSize = oldDoc.child(1).nodeSize
     const pStart = h1Size
@@ -890,8 +889,8 @@ describe('computeDocDiff - range option, per-block', () => {
   })
 
   it('sub-range exactly aligned with one unchanged block returns no changes', () => {
-    // Same shape as the legacy `sub-range excludes changes outside the
-    // range` test — must keep working under the per-block path.
+    // The same shape as the `sub-range excludes changes outside the
+    // range` test, which must keep working on the per-block path.
     const oldDoc = doc(p(text('AAA')), p(text('BBB')), p(text('CCC')))
     const newDoc = doc(p(text('XXX')), p(text('BBB')), p(text('ZZZ')))
 
@@ -1001,10 +1000,10 @@ describe('computeDocDiff - range option, per-block', () => {
   })
 })
 
-// Schema with a container node (`blockquote`) carrying attrs, used for
-// the encoder/ignoreAttrs precondition tests below. The main test schema
-// has no container node with attrs, so we need a small bespoke schema
-// to exercise the ancestor-encoder check.
+// A schema whose container node `blockquote` carries attrs, for the
+// encoder and `ignoreAttrs` precondition tests below. The main test
+// schema has no container node with attrs, so the ancestor-encoder check
+// needs this small schema.
 describe('computeDocDiff - range option, ancestor attrs precondition', () => {
   const blockquoteSchema = new Schema({
     nodes: {

--- a/packages/plugins/plugin-diff/src/__test__/diff-plugin.spec.ts
+++ b/packages/plugins/plugin-diff/src/__test__/diff-plugin.spec.ts
@@ -92,7 +92,6 @@ describe('getPendingChanges', () => {
 
     expect(state.changes.length).toBeGreaterThanOrEqual(2)
 
-    // Reject the first change
     const firstChange = state.changes[0]!
     const stateWithRejection: DiffState = {
       ...state,
@@ -101,7 +100,6 @@ describe('getPendingChanges', () => {
 
     const pending = getPendingChanges(stateWithRejection)
     expect(pending.length).toBeLessThan(state.changes.length)
-    // Rejected change should not be in pending
     expect(pending.every((c) => c !== firstChange)).toBe(true)
   })
 
@@ -209,7 +207,6 @@ describe('sequential reject (regression: index drift)', () => {
     const totalChanges = state.changes.length
     expect(totalChanges).toBeGreaterThanOrEqual(3)
 
-    // Reject the first pending change
     const firstPending = getPendingChanges(state)[0]!
     const afterReject: DiffState = {
       ...state,
@@ -219,7 +216,7 @@ describe('sequential reject (regression: index drift)', () => {
     // After one rejection, pending count decreases by 1
     expect(getPendingChanges(afterReject).length).toBe(totalChanges - 1)
 
-    // The remaining pending changes should all be different from the rejected one
+    // Every remaining pending change differs from the rejected one.
     for (const c of getPendingChanges(afterReject)) {
       const overlaps = c.fromB < firstPending.toB && c.toB > firstPending.fromB
       expect(overlaps).toBe(false)

--- a/packages/plugins/plugin-diff/src/diff-commands.ts
+++ b/packages/plugins/plugin-diff/src/diff-commands.ts
@@ -91,9 +91,10 @@ export const acceptDiffChunkCmd = $command('AcceptDiffChunk', () => {
     if (!change) return false
 
     if (dispatch) {
-      // Two-phase: the replace changes the doc, which triggers recompute
-      // in the plugin's apply(). The 'accept' meta is then a no-op —
-      // the accepted change naturally disappears from the recomputed diff.
+      // The replace runs in two phases. It changes the doc, which
+      // triggers a recompute in the `apply()` of the plugin. The
+      // 'accept' meta then does nothing, because the accepted change
+      // leaves the recomputed diff on its own.
       const newContent = diffState.newDoc.slice(change.fromB, change.toB)
       let tr = state.tr.replace(change.fromA, change.toA, newContent)
 
@@ -208,8 +209,9 @@ export const acceptAllDiffsCmd = $command('AcceptAllDiffs', () => {
       const tr =
         diffState.rejectedRanges.length === 0
           ? state.tr.replaceWith(
-              // Fast path: no rejections, replace entire document at once.
-              // This avoids position drift issues from multiple sequential replaces.
+              // Fast path: with no rejection, one replace covers the
+              // whole document. Several sequential replaces would drift
+              // the positions.
               0,
               state.doc.content.size,
               diffState.newDoc.content

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -26,9 +26,9 @@ export interface ComputeDocDiffOptions {
   ignoreAttrs?: DiffIgnoreAttrs
 }
 
-/// Maximum children count per container for which we run LCS matching.
-/// Beyond this threshold we fall back to the legacy single-step path to
-/// avoid O(n*m) cost.
+/// The maximum child count per container that still runs LCS matching.
+/// A larger container falls back to the single-step path, which avoids
+/// the O(n*m) cost.
 const LCS_MAX_CHILDREN = 500
 
 /**
@@ -339,9 +339,8 @@ function diffContainerContent(
 /// Diff two container nodes by matching their children with LCS.
 /// Returns changes with absolute positions (relative to the full doc).
 ///
-/// The large-container guard runs against raw `childCount` so we never
-/// eagerly compute signatures for a subtree that's about to be handled
-/// by the single-step fallback.
+/// The large-container guard reads the raw `childCount`, so no subtree
+/// computes signatures before the single-step fallback takes it.
 function diffChildrenLcs(
   oldNode: Node,
   newNode: Node,
@@ -503,14 +502,13 @@ interface RangeSubtree {
 ///
 /// - the docs disagree on `sharedDepth` for the range
 /// - any ancestor along the shared chain differs in type, attrs (via
-///   `encoder.encodeNodeStart`, so `ignoreAttrs` is honoured), or
-///   absolute starting position
-/// - the shared ancestor is a textblock (per-block can't subdivide
-///   inside a textblock — callers should widen the range to a block
-///   boundary instead)
-/// - either endpoint lands mid-child instead of between siblings of the
-///   shared ancestor — `Fragment.cut` would mutate the boundary child's
-///   `nodeSize` and break absolute-position translation
+///   `encoder.encodeNodeStart`, so `ignoreAttrs` is honoured), or absolute
+///   starting position
+/// - the shared ancestor is a textblock. The per-block path cannot subdivide
+///   inside a textblock, so widen the range to a block boundary instead.
+/// - either endpoint lands inside a child instead of between siblings of the
+///   shared ancestor. `Fragment.cut` would then change the `nodeSize` of the
+///   boundary child and break the absolute-position translation.
 function buildRangeSubtree(
   oldDoc: Node,
   newDoc: Node,
@@ -530,12 +528,12 @@ function buildRangeSubtree(
     )
   }
 
-  // Ancestor chain identity: the encoder's node-start token always
-  // begins with `node.type.name`, so a single equality check rejects
-  // type mismatches AND attr differences (and honours ignoreAttrs).
-  // Also require the same absolute start position at every depth up to
-  // sharedDepth — this guarantees the cut node's first child lines up
-  // at `from` in both docs.
+  // Ancestor chain identity: the node-start token of the encoder starts
+  // with `node.type.name`, so one equality check rejects both a type
+  // mismatch and an attr difference, and it honours `ignoreAttrs`. Every
+  // depth up to `sharedDepth` also needs the same absolute start
+  // position, which lines up the first child of the cut node at `from`
+  // in both docs.
   for (let d = 0; d <= sharedDepth; d++) {
     if (
       encoder.encodeNodeStart($oldFrom.node(d)) !==
@@ -583,9 +581,9 @@ function buildRangeSubtree(
   const oldCut = sharedOld.copy(sharedOld.content.cut(localFrom, localTo))
   const newCut = sharedNew.copy(sharedNew.content.cut(localFrom, localTo))
 
-  // The cut node's first child has offset 0 inside the cut but absolute
-  // position `from` in the original doc, so `from` is the contentStart
-  // we hand back to diffChildrenLcs.
+  // The first child of the cut node has offset 0 inside the cut and
+  // absolute position `from` in the original doc, so `from` is the
+  // contentStart that `diffChildrenLcs` receives.
   return { oldCut, newCut, cutAbsStart: from }
 }
 
@@ -600,8 +598,8 @@ function buildRangeSubtree(
 /// throws `RangeError`:
 ///
 /// - **boundary-aligned**: both endpoints sit between siblings of a
-///   common (non-textblock) container ancestor — i.e. not inside a
-///   textblock and not in the middle of a child node
+///   common container ancestor that is not a textblock. No endpoint sits
+///   inside a textblock or inside a child node.
 /// - **structurally identical path**: the chain of ancestors leading to
 ///   that shared container has the same node types, attrs (modulo
 ///   `ignoreAttrs`), and absolute start positions in both docs
@@ -623,9 +621,9 @@ export function computeDocDiff(
     return diffChildrenLcs(oldDoc, newDoc, 0, 0, env)
   }
 
-  // Clamp the range to a valid window. Out-of-bounds endpoints are
-  // silently clamped against the smaller doc — once clamped, both old
-  // and new agree on the same `[from, to)` slice.
+  // Clamp the range to a valid window. An out-of-bounds endpoint clamps
+  // against the smaller doc, after which the old doc and the new doc
+  // agree on the same `[from, to)` slice.
   const minSize = Math.min(oldSize, newSize)
   const from = Math.max(0, Math.min(range.from ?? 0, minSize))
   const to = Math.max(from, Math.min(range.to ?? minSize, minSize))

--- a/packages/plugins/plugin-emoji/src/__internal__/parse.ts
+++ b/packages/plugins/plugin-emoji/src/__internal__/parse.ts
@@ -3,8 +3,9 @@ import twemoji from 'twemoji'
 const setAttr = (text: string) => ({ title: text })
 
 /// @internal
-/// This is copied from https://github.com/twitter/twemoji/blob/master/index.d.ts#L14
-/// The file is not released for some reason, so I have to copy it here.
+/// A copy of
+/// https://github.com/twitter/twemoji/blob/master/index.d.ts#L14.
+/// Twemoji does not release that file, so this package carries a copy.
 export interface TwemojiOptions {
   /**
    * Default: Cloudflare

--- a/packages/plugins/plugin-emoji/src/index.ts
+++ b/packages/plugins/plugin-emoji/src/index.ts
@@ -83,9 +83,10 @@ export const emojiSchema = $nodeSchema('emoji', (ctx) => ({
   toMarkdown: {
     match: (node) => node.type.name === 'emoji',
     runner: (state, node) => {
-      // Parse via an inert `<template>`: unlike a live `<span>`, its content
-      // fragment never triggers resource loads, so an `<img onerror>` payload
-      // cannot fire during serialization. Sanitize as well for defense in depth.
+      // An inert `<template>` parses the html. Its content fragment
+      // loads no resource, unlike a live `<span>`, so an `<img onerror>`
+      // payload cannot fire during serialization. The sanitize call adds
+      // a second layer of defense.
       const template = document.createElement('template')
       template.innerHTML = DOMPurify.sanitize(node.attrs.html)
       const img = template.content.querySelector('img')

--- a/packages/plugins/plugin-history/src/index.ts
+++ b/packages/plugins/plugin-history/src/index.ts
@@ -22,21 +22,27 @@ function withMeta<T extends MilkdownPlugin>(
   return plugin
 }
 
-/// The milkdown command wrapper of [undo API](https://prosemirror.net/docs/ref/#history.undo) in [prosemirror-history](https://prosemirror.net/docs/ref/#history).
+/// The milkdown command wrapper of the
+/// [undo API](https://prosemirror.net/docs/ref/#history.undo) in
+/// [prosemirror-history](https://prosemirror.net/docs/ref/#history).
 export const undoCommand = $command('Undo', () => () => undo)
 
 withMeta(undoCommand, {
   displayName: 'Command<undo>',
 })
 
-/// The milkdown command wrapper of [redo API](https://prosemirror.net/docs/ref/#history.redo) in [prosemirror-history](https://prosemirror.net/docs/ref/#history).
+/// The milkdown command wrapper of the
+/// [redo API](https://prosemirror.net/docs/ref/#history.redo) in
+/// [prosemirror-history](https://prosemirror.net/docs/ref/#history).
 export const redoCommand = $command('Redo', () => () => redo)
 
 withMeta(redoCommand, {
   displayName: 'Command<redo>',
 })
 
-/// The [config](https://prosemirror.net/docs/ref/#history.history%5Econfig) of prosemirror history plugin.
+/// The
+/// [config](https://prosemirror.net/docs/ref/#history.history%5Econfig)
+/// of the prosemirror history plugin.
 export const historyProviderConfig = $ctx<
   { depth?: number; newGroupDelay?: number },
   'historyProviderConfig'
@@ -46,7 +52,9 @@ withMeta(historyProviderConfig, {
   displayName: 'Ctx<historyProviderConfig>',
 })
 
-/// The milkdown wrapper of [history API](https://prosemirror.net/docs/ref/#history.history) in [prosemirror-history](https://prosemirror.net/docs/ref/#history).
+/// The milkdown wrapper of the
+/// [history API](https://prosemirror.net/docs/ref/#history.history) in
+/// [prosemirror-history](https://prosemirror.net/docs/ref/#history).
 export const historyProviderPlugin = $prose((ctx) =>
   prosemirrorHistory(ctx.get(historyProviderConfig.key))
 )
@@ -55,7 +63,8 @@ withMeta(historyProviderPlugin, {
   displayName: 'Ctx<historyProviderPlugin>',
 })
 
-/// The keymap of history plugin, it's `mod-z` for undo and `mod-y`/`shift-mod-z` for redo.
+/// The keymap of the history plugin. It binds `mod-z` to undo, and
+/// `mod-y` and `shift-mod-z` to redo.
 export const historyKeymap = $useKeymap('historyKeymap', {
   Undo: {
     shortcuts: 'Mod-z',

--- a/packages/plugins/plugin-indent/src/index.ts
+++ b/packages/plugins/plugin-indent/src/index.ts
@@ -33,8 +33,8 @@ function updateIndent(
   return tr.insertText(text, to)
 }
 
-/// A slice contains the indent config.
-/// You can use [IndentConfigOptions](#IndentConfigOptions) to customize the behavior of the plugin.
+/// A slice that holds the indent config. Use
+/// [IndentConfigOptions](#IndentConfigOptions) to customize the plugin.
 ///
 /// ```ts
 /// import { indent, indentConfig } from '@milkdown/plugin-indent'
@@ -58,7 +58,7 @@ indentConfig.meta = {
   displayName: 'Ctx<indentConfig>',
 }
 
-/// Add indent shortcut, when users press `Tab`, the plugin will insert indent text.
+/// Add the indent shortcut. The plugin inserts indent text on `Tab`.
 export const indentPlugin = $shortcut((ctx) => ({
   Tab: (state, dispatch) => {
     const config = ctx.get(indentConfig.key)

--- a/packages/plugins/plugin-listener/src/index.ts
+++ b/packages/plugins/plugin-listener/src/index.ts
@@ -50,7 +50,8 @@ export class ListenerManager {
   private focusListeners: Array<(ctx: Ctx) => void> = []
   private destroyListeners: Array<(ctx: Ctx) => void> = []
 
-  /// A getter to get all [subscribers](#interface-subscribers). You should not use this method directly.
+  /// A getter for all [subscribers](#interface-subscribers). Do not call
+  /// it directly.
   get listeners(): Subscribers {
     return {
       beforeMount: this.beforeMountedListeners,
@@ -78,9 +79,9 @@ export class ListenerManager {
     return this
   }
 
-  /// Subscribe to the updated event.
-  /// This event will be triggered after the editor state is updated and **the document is changed**.
-  /// The second parameter is the current document and the third parameter is the previous document.
+  /// Subscribe to the updated event. The event fires after the editor
+  /// state updates and **the document changes**. The second parameter is
+  /// the current document. The third parameter is the previous document.
   updated = (
     fn: (ctx: Ctx, doc: ProseNode, prevDoc: ProseNode | null) => void
   ) => {
@@ -88,9 +89,10 @@ export class ListenerManager {
     return this
   }
 
-  /// Subscribe to the markdownUpdated event.
-  /// This event will be triggered after the editor state is updated and **the document is changed**.
-  /// The second parameter is the current markdown and the third parameter is the previous markdown.
+  /// Subscribe to the markdownUpdated event. The event fires after the
+  /// editor state updates and **the document changes**. The second
+  /// parameter is the current markdown. The third parameter is the
+  /// previous markdown.
   markdownUpdated(
     fn: (ctx: Ctx, markdown: string, prevMarkdown: string) => void
   ) {
@@ -133,8 +135,8 @@ export class ListenerManager {
   }
 }
 
-/// The ctx key of the listener manager.
-/// You can use `ctx.get(listenerCtx)` to get the [listener manager](#class-listenermanager).
+/// The ctx key of the listener manager. Call `ctx.get(listenerCtx)` to
+/// get the [listener manager](#class-listenermanager).
 export const listenerCtx = createSlice<ListenerManager>(
   new ListenerManager(),
   'listener'

--- a/packages/plugins/plugin-prism/src/__test__/prism.spec.ts
+++ b/packages/plugins/plugin-prism/src/__test__/prism.spec.ts
@@ -204,15 +204,16 @@ it('should re-highlight when a code block language changes', async () => {
 })
 
 it('should re-highlight a non-first code block when its language changes via setNodeAttribute', async () => {
-  // `updateCodeBlockLanguageCommand` and the code-block node view both change the
-  // language with `setNodeAttribute`, whose `AttrStep` carries no `from`/`to`, so
-  // the step scan can't see it and the block-language comparison must cover every
-  // block, not just the first.
+  // `updateCodeBlockLanguageCommand` and the code-block node view both
+  // change the language with `setNodeAttribute`. Its `AttrStep` carries
+  // no `from` or `to`, so the step scan cannot see the change. The
+  // block-language comparison covers every block, not only the first.
   const editor = await createEditor(DOC)
   const before = decorations(view(editor))
   const secondPos = posOfCodeBlock(view(editor), 1)
 
-  // Caret in the prose above, outside every code block — the missed case.
+  // The caret sits in the prose above, outside every code block, which
+  // is the case the step scan missed.
   view(editor).dispatch(
     view(editor).state.tr.setSelection(
       TextSelection.create(view(editor).state.doc, 1)
@@ -225,7 +226,8 @@ it('should re-highlight a non-first code block when its language changes via set
   const after = decorations(view(editor))
   const fresh = await createEditor(DOC.replace('```css', '```js'))
 
-  // The stale css highlighting is gone, and the block matches a from-scratch run.
+  // The stale css highlighting is gone, and the block matches a fresh
+  // run.
   expect(after).not.toEqual(before)
   expect(after).toEqual(decorations(view(fresh)))
 })

--- a/packages/plugins/plugin-prism/src/index.ts
+++ b/packages/plugins/plugin-prism/src/index.ts
@@ -97,11 +97,12 @@ export const prismPlugin = $prose((ctx) => {
             )
             return (
               oldNode.length !== newNode.length ||
-              // A language change goes through `setNodeAttribute`, whose
-              // `AttrStep` carries no `from`/`to` and maps to an empty step map,
-              // so the step scan below misses it. Compare every block by index
-              // rather than only the first, or a change to any but the first
-              // block leaves its highlighting stale.
+              // A language change goes through `setNodeAttribute`. Its
+              // `AttrStep` carries no `from` or `to` and maps to an
+              // empty step map, so the step scan below misses it. This
+              // comparison walks every block by index. Otherwise a
+              // change to any block after the first leaves its
+              // highlighting stale.
               oldNode.some(
                 (entry, i) =>
                   entry.node.attrs.language !== newNode[i]?.node.attrs.language

--- a/packages/plugins/plugin-slash/src/slash-provider.ts
+++ b/packages/plugins/plugin-slash/src/slash-provider.ts
@@ -25,9 +25,11 @@ export interface SlashProviderOptions {
   trigger?: string | string[]
   /// The offset to get the block. Default is 0.
   offset?: OffsetOptions
-  /// Other middlewares for floating ui. This will be added after the internal middlewares.
+  /// Other middlewares for floating ui. They run after the internal
+  /// middlewares.
   middleware?: Middleware[]
-  /// Options for floating ui. If you pass `middleware` or `placement`, it will override the internal settings.
+  /// Options for floating ui. A `middleware` or `placement` value here
+  /// overrides the internal setting.
   floatingUIOptions?: Partial<ComputePositionConfig>
   /// The root element that the slash will be appended to.
   root?: HTMLElement
@@ -148,8 +150,9 @@ export class SlashProvider {
     this.#updater(view, prevState)
   }
 
-  /// Get the content of the current text block.
-  /// Pass the `matchNode` function to determine whether the current node should be matched, by default, it will match the paragraph node.
+  /// Get the content of the current text block. Pass `matchNode` to
+  /// decide whether the current node matches. It matches a paragraph
+  /// node by default.
   getContent = (
     view: EditorView,
     matchNode: (node: Node) => boolean = (node) =>

--- a/packages/plugins/plugin-streaming/src/__test__/inline-math.spec.ts
+++ b/packages/plugins/plugin-streaming/src/__test__/inline-math.spec.ts
@@ -47,20 +47,20 @@ const plainSchema = new Schema({
   },
 })
 
-/// CommonMark strips leading indentation and trailing spaces/tabs when
-/// it wraps a line into a paragraph — but only ASCII space/tab, not
-/// e.g. U+3000. The real parser does this, so the stub must too: the
-/// whitespace-restoration branches in `parseInlineContent` are exactly
-/// the code under test.
+/// CommonMark strips leading indentation and a trailing space or tab
+/// when it wraps a line into a paragraph. It strips only an ASCII space
+/// or tab, not U+3000. The real parser behaves this way, so the stub
+/// does too. The whitespace-restoration branches in `parseInlineContent`
+/// are the code under test.
 function stripParagraphEdges(markdown: string): string {
   return markdown.replace(/^[ \t]+/, '').replace(/[ \t]+$/, '')
 }
 
 /// Stands in for a parser with `remark-math`, an emoji plugin, links and
-/// entity decoding enabled. Like `remark-math` with the default
-/// `singleDollarTextMath`, math pairing is greedy: the first `$` pairs
-/// with the next `$` on the line, even across `$5 and $10` — the fast
-/// path gate is what must keep such prose away from it.
+/// entity decoding enabled. Math pairing is greedy, the same as
+/// `remark-math` with the default `singleDollarTextMath`. The first `$`
+/// pairs with the next `$` on the line, even across `$5 and $10`. The
+/// fast-path gate keeps such prose away from the parser.
 function richParser(markdown: string): Node {
   const source = stripParagraphEdges(markdown).replace(/&amp;/g, '&')
   const content: Node[] = []
@@ -238,9 +238,9 @@ describe('whitespace restoration around parsed inline content', () => {
   })
 
   it('restores the leading space even when the parsed text itself starts with one', () => {
-    // The link keeps its interior leading space; the stripped outer
-    // space must still come back — previously it was skipped because
-    // the parsed text already "looked like" it started with the space.
+    // The link keeps its interior leading space, and the stripped outer
+    // space must come back. The parsed text starts with a space of its
+    // own, which must not hide the missing outer one.
     const { doc } = flush(' [ a](https://x)')
     expect(doc.textContent).toBe('start  a')
   })

--- a/packages/plugins/plugin-streaming/src/__test__/streaming-plugin.spec.ts
+++ b/packages/plugins/plugin-streaming/src/__test__/streaming-plugin.spec.ts
@@ -364,7 +364,8 @@ describe('defaultInsertStrategy', () => {
         ]),
       ]),
     ])
-    // Position inside table_cell text: doc(1) > table(1) > table_row(1) > table_cell(1) > text
+    // A position inside table_cell text:
+    // doc(1) > table(1) > table_row(1) > table_cell(1) > text
     const resolved = docNode.resolve(4)
     expect(resolved.parent.type.name).toBe('table_cell')
     expect(defaultInsertStrategy(resolved)).toEqual({

--- a/packages/plugins/plugin-streaming/src/flush.ts
+++ b/packages/plugins/plugin-streaming/src/flush.ts
@@ -48,10 +48,11 @@ export function flushBuffer(
 /// Default strategy resolver. Determines how streamed content is inserted
 /// based on the cursor position. Can be overridden via `streamingConfig`.
 ///
-/// - Code blocks → plain text, preserving newlines
-/// - Table cells → plain text, collapsing newlines
-/// - Other textblocks (paragraph, heading, list item, blockquote) → split-block
-/// - Between blocks (depth 0) → full block parse
+/// - Code block → plain text, keeping newlines
+/// - Table cell → plain text, collapsing newlines
+/// - Other textblock, such as a paragraph, a heading, a list item or a
+///   blockquote → split-block
+/// - Between blocks, at depth 0 → full block parse
 export function defaultInsertStrategy(resolved: ResolvedPos): InsertStrategy {
   if (resolved.parent.type.spec.code) {
     return { type: 'plain-text', preserveNewlines: true }
@@ -160,29 +161,26 @@ function applyPlainText(
   return { tr, applied: true, insertEndPos: from + textContent.length }
 }
 
-/// Patterns that could trigger inline markdown parsing into marks,
-/// non-text nodes, or text that differs from the raw source:
-/// - `*`, `_`            emphasis / strong
-/// - `~`                 strikethrough (GFM)
-/// - `` ` ``             inline code
-/// - `[`                 links / images (`]` is omitted because any
-///                       valid link/image starts with `[`, so checking
-///                       the opener is enough)
-/// - `\`                 escape
-/// - `<`                 autolinks (`<https://...>`, `<a@b.com>`) and raw HTML
-/// - `https://`, `www.`, `x@x`
-///                       GFM autolink literals (`https://a.com`,
-///                       `www.a.com`, `a@b.com`) have no bracket or angle
-///                       bracket, so they need their own triggers
-/// - `&` + entity start  character references (`&amp;`, `&#35;`)
+/// Patterns that could trigger inline markdown parsing into marks, non-text
+/// nodes, or text that differs from the raw source:
+/// - `*`, `_` emphasis / strong
+/// - `~` strikethrough (GFM)
+/// - `` ` `` inline code
+/// - `[` links / images (`]` is omitted because any valid link/image starts
+///   with `[`, so checking the opener is enough)
+/// - `\` escape
+/// - `<` autolinks (`<https://...>`, `<a@b.com>`) and raw HTML
+/// - `https://`, `www.`, `x@x` GFM autolink literals (`https://a.com`,
+///   `www.a.com`, `a@b.com`) have no bracket or angle bracket, so they need
+///   their own triggers
+/// - `&` + entity start character references (`&amp;`, `&#35;`)
 ///
-/// The set has to cover syntax added by remark plugins too, not just
-/// CommonMark/GFM: a pattern that is missing here makes the fast path
-/// return the raw string, so the construct is silently streamed in as
-/// literal text and never reaches the parser. Plugin syntax whose trigger
-/// characters are too common in plain prose to test unconditionally
-/// (inline math, emoji shortcodes) is only consulted when the schema
-/// actually has the corresponding node — see `hasInlineMarkdownSyntax`.
+/// The set covers the syntax that a remark plugin adds, not only CommonMark and
+/// GFM. A missing pattern makes the fast path return the raw string, so the
+/// construct streams in as literal text and never reaches the parser. Some
+/// plugin syntax carries trigger characters that are too common in prose for an
+/// unconditional test, such as inline math and an emoji shortcode. Those run
+/// only when the schema has the matching node. See `hasInlineMarkdownSyntax`.
 const INLINE_MARKDOWN_TOKENS =
   /[*_~`[\\<]|https?:\/\/|www\.|[\w.+-]@\w|&[a-zA-Z#]/
 
@@ -201,11 +199,10 @@ const INLINE_MATH_SPAN = /\$(?!\s)(?:[^$\n]*[^\s$])?\$(?!\d)/
 /// (`@milkdown/plugin-emoji`).
 const EMOJI_SHORTCODE = /:[\w+-]+:/
 
-/// Fast-path gate: decide whether a line may contain inline markdown
-/// syntax and needs the full parser. Base tokens are always checked;
-/// schema-gated patterns only run when the corresponding node exists in
-/// the schema, so editors without the feature never pay for the parse —
-/// and never have prose reinterpreted by a syntax they don't render.
+/// Decide whether a line can contain inline markdown syntax and needs
+/// the full parser. Base tokens always run. A schema-gated pattern runs
+/// only when the schema has the matching node. An editor without that
+/// node pays no parse cost, and its prose keeps the literal meaning.
 function hasInlineMarkdownSyntax(
   schema: Node['type']['schema'],
   text: string
@@ -236,20 +233,19 @@ function tryParse(
 /// Parse a single markdown line and return its inline content (text
 /// nodes with marks, links, etc.) for merging into a textblock. Falls
 /// back to the original string when:
-/// - the text contains no markdown-relevant syntax (fast path —
-///   insert-mode flushes reparse the current line on every throttled
-///   flush, so plain prose shouldn't pay for a full parse)
+/// - the text contains no markdown-relevant syntax. This is the fast
+///   path. An insert-mode flush reparses the current line on every
+///   throttled flush, so plain prose must not pay for a full parse.
 /// - the line parses as a non-paragraph block: a heading (`# **bold**`),
 ///   code block, etc. is also a textblock but extracting its content
 ///   would silently drop the block marker (`# `, indent, ...) from the
 ///   streamed text
 /// - the parser fails (see `tryParse`)
 ///
-/// When the line does parse as a paragraph, the parsed content is used
-/// as-is — including text-only results, so entity references (`&amp;`)
-/// and escapes (`\*`) render with their final semantics instead of
-/// flipping between raw and decoded depending on what else is on the
-/// line.
+/// A line that parses as a paragraph keeps the parsed content as it is,
+/// including a text-only result. An entity reference such as `&amp;` and
+/// an escape such as `\*` then render with their final meaning, instead
+/// of flipping between raw and decoded with the rest of the line.
 function parseInlineContent(
   ctx: Ctx,
   schema: Node['type']['schema'],
@@ -270,10 +266,11 @@ function parseInlineContent(
   // For mid-paragraph inserts that loss visibly concatenates words
   // (` **bold**` after `foo` renders as `foo**bold**`), so re-attach
   // exactly what CommonMark strips: ASCII spaces and tabs at the edges.
-  // Only those — non-ASCII whitespace (e.g. U+3000) survives the parse
-  // and must not be duplicated. Lines indented far enough to become an
-  // indented code block never reach this point (non-paragraph fallback
-  // above), so the stripped edges are unconditionally safe to restore.
+  // Only those two. Non-ASCII whitespace such as U+3000 survives the
+  // parse and must stay unique. A line indented far enough to become an
+  // indented code block never reaches this point, because the
+  // non-paragraph fallback above catches it. The stripped edges are
+  // therefore always safe to restore.
   let content = firstBlock.content
   const leading = /^[ \t]+/.exec(text)?.[0]
   if (leading) {
@@ -301,7 +298,8 @@ function applySplitBlock({
   const schema = tr.doc.type.schema
   const firstNewline = buffer.indexOf('\n')
 
-  // Single line — parse as inline markdown so marks/links survive.
+  // A single line parses as inline markdown, which keeps a mark and a
+  // link alive.
   if (firstNewline < 0) {
     const inlineContent = parseInlineContent(ctx, schema, buffer)
     tr = tr.replaceWith(from, to, inlineContent)
@@ -311,7 +309,6 @@ function applySplitBlock({
   const inlinePart = buffer.substring(0, firstNewline)
   const blockPart = buffer.substring(firstNewline + 1)
 
-  // Try to parse the block part as markdown
   const parser = ctx.get(parserCtx)
   const parsed = blockPart.trim() ? tryParse(parser, blockPart) : null
   const blockContent = parsed
@@ -396,8 +393,9 @@ export interface FlushResult {
   insertEndPos?: number
 }
 
-/// Perform a flush for both insert and replace modes.
-/// Used by the flush controller (throttled loop) and endStreamingCmd (final flush).
+/// Perform a flush for both insert mode and replace mode. The throttled
+/// loop of the flush controller calls it, and `endStreamingCmd` calls it
+/// for the final flush.
 export function performFlush(
   ctx: Ctx,
   tr: Transaction,

--- a/packages/plugins/plugin-streaming/src/streaming-commands.ts
+++ b/packages/plugins/plugin-streaming/src/streaming-commands.ts
@@ -15,11 +15,11 @@ import { performFlush } from './flush'
 import { streamingConfig } from './streaming-config'
 import { streamingPluginKey } from './streaming-plugin'
 
-/// Start a streaming session. Captures the current doc and locks editing.
-/// Pass `{ insertAt: 'cursor' }` or `{ insertAt: <pos> }` for insert-at-cursor mode.
+/// Start a streaming session. The command captures the current doc and
+/// locks editing. Pass `{ insertAt: 'cursor' }` or `{ insertAt: <pos> }`
+/// for insert-at-cursor mode.
 export const startStreamingCmd = $command('StartStreaming', () => {
   return (options?: StartStreamingOptions) => (state, dispatch) => {
-    // Don't start if already streaming
     const existing = streamingPluginKey.getState(state)
     if (existing?.active) return false
 
@@ -57,12 +57,12 @@ export const startStreamingCmd = $command('StartStreaming', () => {
             Math.min(Math.round(rawPos), state.doc.content.size)
           )
 
-          // If cursor is inside a top-level empty textblock (e.g. the default
-          // empty paragraph in a new editor), snap the range to cover the whole
-          // block so that block-level content replaces it cleanly.
-          // Only depth === 1 — nested empty textblocks (inside list items,
-          // blockquotes, etc.) should not be snapped; the normal strategy
-          // handles them correctly at their original position.
+          // A cursor inside a top-level empty textblock, such as the
+          // default empty paragraph of a new editor, snaps the range to
+          // the whole block, so block-level content replaces it cleanly.
+          // Only depth 1 snaps. A nested empty textblock, inside a list
+          // item or a blockquote, keeps its original position, where the
+          // normal strategy handles it.
           const resolved = state.doc.resolve(insertPos)
           if (
             resolved.parent.isTextblock &&
@@ -132,7 +132,6 @@ export const endStreamingCmd = $command('EndStreaming', (ctx) => {
       const result = performFlush(ctx, state.tr, streamingState)
       let tr = result.tr
 
-      // End streaming
       tr = tr.setMeta(streamingPluginKey, {
         type: 'end',
       } satisfies StreamingAction)

--- a/packages/plugins/plugin-streaming/src/streaming-plugin.ts
+++ b/packages/plugins/plugin-streaming/src/streaming-plugin.ts
@@ -141,7 +141,7 @@ function createFlushController(ctx: Ctx, config: StreamingConfig) {
 
       const state = streamingPluginKey.getState(updatedView.state)
       if (!state?.active) {
-        // Streaming ended or aborted — clean up trailing timer
+        // Streaming ended or aborted, so clear the trailing timer.
         if (trailingTimer != null) {
           clearTimeout(trailingTimer)
           trailingTimer = null

--- a/packages/plugins/plugin-streaming/src/types.ts
+++ b/packages/plugins/plugin-streaming/src/types.ts
@@ -70,7 +70,8 @@ export interface EndStreamingOptions {
 
 /// Options for aborting a streaming session.
 export interface AbortStreamingOptions {
-  /// If true, keep the partial content. If false, restore original doc (default: false).
+  /// If true, keep the partial content. If false, restore the original
+  /// doc. Defaults to false.
   keep?: boolean
 }
 

--- a/packages/plugins/plugin-tooltip/src/tooltip-provider.ts
+++ b/packages/plugins/plugin-tooltip/src/tooltip-provider.ts
@@ -31,9 +31,11 @@ export interface TooltipProviderOptions {
   offset?: OffsetOptions
   /// The amount to shift options the block by.
   shift?: ShiftOptions
-  /// Other middlewares for floating ui. This will be added after the internal middlewares.
+  /// Other middlewares for floating ui. They run after the internal
+  /// middlewares.
   middleware?: Middleware[]
-  /// Options for floating ui. If you pass `middleware` or `placement`, it will override the internal settings.
+  /// Options for floating ui. A `middleware` or `placement` value here
+  /// overrides the internal setting.
   floatingUIOptions?: Partial<ComputePositionConfig>
   /// The root element that the tooltip will be appended to.
   root?: HTMLElement

--- a/packages/plugins/plugin-trailing/src/index.ts
+++ b/packages/plugins/plugin-trailing/src/index.ts
@@ -7,17 +7,18 @@ import { $ctx, $prose } from '@milkdown/utils'
 
 /// Options for trailing config.
 export interface TrailingConfigOptions {
-  /// A function that returns a boolean value.
-  /// If it returns `true`, the plugin will append a node at the end of the document.
-  /// By default, it returns `false` if the last node is a heading or a paragraph.
+  /// A function that returns a boolean value. On `true` the plugin
+  /// appends a node at the end of the document. It returns `false` by
+  /// default when the last node is a heading or a paragraph.
   shouldAppend: (lastNode: Node | null, state: EditorState) => boolean
   /// A function that returns a node.
   /// By default, it returns a paragraph node.
   getNode: (state: EditorState) => Node
 }
 
-/// A slice contains the trailing config.
-/// You can use [TrailingConfigOptions](#TrailingConfigOptions) to customize the behavior of the plugin.
+/// A slice that holds the trailing config. Use
+/// [TrailingConfigOptions](#TrailingConfigOptions) to customize the
+/// plugin.
 export const trailingConfig = $ctx<TrailingConfigOptions, 'trailingConfig'>(
   {
     shouldAppend: (lastNode) => {

--- a/packages/plugins/plugin-upload/src/upload.ts
+++ b/packages/plugins/plugin-upload/src/upload.ts
@@ -19,18 +19,19 @@ interface Spec {
 
 /// The configuration for upload.
 export interface UploadOptions {
-  /// The uploader for upload plugin.
-  /// It takes the files / schema / ctx / insertPos as parameters.
-  /// It should return a `Promise` of Prosemirror `Fragment` or `Node` or `Node[]`.
+  /// The uploader for the upload plugin. It takes the files, the schema,
+  /// the ctx and the insert position. It returns a `Promise` of a
+  /// prosemirror `Fragment`, `Node` or `Node[]`.
   uploader: (
     files: FileList,
     schema: Schema,
     ctx: Ctx,
     insertPos: number
   ) => Promise<Fragment | Node | Node[]>
-  /// Whether to enable the html file uploader.
-  /// When paste files from html (for example copy images by right click context menu),
-  /// this option will make the plugin to upload the image copied instead of using the original link.
+  /// Whether to enable the html file uploader. A paste of files from
+  /// html, for example an image copied through the right-click context
+  /// menu, then uploads the copied image instead of keeping the original
+  /// link.
   enableHtmlFileUploader: boolean
   /// The factory for upload widget.
   /// The widget will be displayed when the file is uploading.

--- a/packages/plugins/preset-commonmark/src/__internal__/clone-node.ts
+++ b/packages/plugins/preset-commonmark/src/__internal__/clone-node.ts
@@ -11,10 +11,11 @@ interface Position {
   end: Point
 }
 
-/// Copy a childless leaf node (e.g. an mdast html node). Shallow on
-/// purpose — it must never throw, whatever a plugin has attached to
-/// `data`. Only `position` is cloned so the copy and the original cannot
-/// alias location data, and a `children` property is never carried over.
+/// Copy a childless leaf node, for example an mdast html node. The copy
+/// stays shallow on purpose, so it never throws over whatever a plugin
+/// attached to `data`. Only `position` is cloned, so the copy and the
+/// original share no location data. A `children` property never carries
+/// over.
 export function cloneLeaf<T extends Node>(node: T): T {
   const copy = { ...node } as T & { position?: Position; children?: unknown }
   if (copy.position) {

--- a/packages/plugins/preset-commonmark/src/__test__/inline-br.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/inline-br.spec.ts
@@ -127,10 +127,10 @@ describe('inline br round-trip (#2428)', () => {
   })
 })
 
-// A trailing lone <br> is byte-identical to the serializer's own
-// empty-line placeholder (documents saved by older versions routinely end
-// with one), so it folds into an empty paragraph like everywhere else —
-// which the trailing trim in `docSchema` then drops from the output.
+// A trailing lone <br> is byte-identical to the empty-line placeholder
+// of the serializer, and a document saved by an older version often ends
+// with one. It folds into an empty paragraph the same as anywhere else,
+// and the trailing trim in `docSchema` then drops it from the output.
 describe('trailing <br> at the end of the document', () => {
   it('folds a trailing lone <br> into an empty paragraph', async () => {
     const output = await roundTrip('foo\n\n<br>\n')
@@ -213,12 +213,12 @@ describe('trailing empty paragraphs', () => {
 // sweeps the typing area in without the user choosing it, and a collapsed
 // range must never conjure content out of the fill paragraph. Known cost,
 // also deliberate: copying a range that stops exactly at a mid-document
-// blank line drops that blank line from the plain-text clipboard —
-// distinguishing it would require threading serialization intent through
-// the serializer API.
+// blank line drops that blank line from the plain-text clipboard. A
+// distinction here would need serialization intent threaded through the
+// serializer API.
 describe('ranged serialization', () => {
   it('trims or keeps a blank line by where the range ends', async () => {
-    // Loads as [p('a') 0..3, p() 3..5, p('b') 5..8, p() 8..10] — the
+    // Loads as [p('a') 0..3, p() 3..5, p('b') 5..8, p() 8..10]. The
     // trailing placeholder folds into a real typing-area paragraph.
     await withEditor('a\n\n<br />\n\nb\n\n<br />\n', (editor) =>
       editor.action((ctx) => {

--- a/packages/plugins/preset-commonmark/src/__test__/list-spread-roundtrip.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/list-spread-roundtrip.spec.ts
@@ -5,10 +5,10 @@ import { describe, expect, it } from 'vitest'
 import { roundTrip, withEditor } from './test-utils'
 
 // https://github.com/Milkdown/milkdown/issues/2419
-// The `spread` attribute is parsed into a stringified boolean ("true"/"false").
-// The bullet_list and list_item toMarkdown runners used to forward that string
-// straight to mdast, where the *string* "false" is truthy — so every tight list
-// was serialized as loose (blank lines between the items).
+// The `spread` attribute parses into a stringified boolean, "true" or
+// "false". The bullet_list and list_item toMarkdown runners forwarded
+// that string to mdast, where the string "false" is truthy. Every tight
+// list then serialized as loose, with a blank line between the items.
 describe('list spread round-trip (#2419)', () => {
   // Exact-string checks for the tight/loose distinction. The serializer
   // normalizes bullet markers to `*`, so the inputs use `*` to keep the

--- a/packages/plugins/preset-commonmark/src/__test__/paste-special-char.spec.ts
+++ b/packages/plugins/preset-commonmark/src/__test__/paste-special-char.spec.ts
@@ -7,12 +7,12 @@ import { describe, expect, it } from 'vitest'
 import { commonmark } from '..'
 
 // https://github.com/Milkdown/milkdown/issues/2400
-// Pasting text that ends with `_` twice and then pressing Space/Enter used to
-// delete characters: the underscore-emphasis input rule was not anchored to the
-// end of the input (`$`), so its regex matched an `_..._` span *across* the two
-// pastes — a match that did not end at the cursor. prosemirror's input-rule
-// runner assumes the match ends at the cursor when it computes the affected
-// range, so the off-by-one range corrupted the document.
+// Two pastes of text that ends with `_`, followed by Space or Enter,
+// deleted characters. The underscore-emphasis input rule carried no `$`
+// anchor, so its regex matched an `_..._` span across the two pastes and
+// ended before the cursor. The prosemirror input-rule runner computes
+// the affected range from a match that ends at the cursor, so the
+// off-by-one range corrupted the document.
 
 const PASTED = 'This is for qa34%^%^&&&(&(&(&()(*()_'
 

--- a/packages/plugins/preset-commonmark/src/mark/inline-code.ts
+++ b/packages/plugins/preset-commonmark/src/mark/inline-code.ts
@@ -24,10 +24,10 @@ withMeta(inlineCodeAttr, {
 export const inlineCodeSchema = $markSchema('inlineCode', (ctx) => ({
   priority: 100,
   code: true,
-  // A code span has a closed end: text typed after it is not part of it, and
-  // typing is the only way to leave a span that ends a block. It also keeps a
-  // code mark on a delimiter meaningful, since the delimiter is then genuinely
-  // inside the span — the mark input rules key their decisions off that.
+  // A code span has a closed end. Text typed after it stays outside it,
+  // and typing is the only way to leave a span that ends a block. A code
+  // mark on a delimiter also stays meaningful, because the delimiter
+  // then sits inside the span. The mark input rules read that state.
   inclusive: false,
   parseDOM: [{ tag: 'code' }],
   toDOM: (mark) => ['code', ctx.get(inlineCodeAttr.key)(mark)],
@@ -77,14 +77,12 @@ export const toggleInlineCodeCommand = $command(
       (x) => x !== inlineCodeSchema.type.name
     )
 
-    // remove other marks
     restMarksName
       .map((name) => state.schema.marks[name] as MarkType)
       .forEach((t) => {
         tr.removeMark(from, to, t)
       })
 
-    // add inlineCode mark
     dispatch?.(tr.addMark(from, to, inlineCodeSchema.type(ctx).create()))
     return true
   }

--- a/packages/plugins/preset-commonmark/src/mark/strong.ts
+++ b/packages/plugins/preset-commonmark/src/mark/strong.ts
@@ -86,9 +86,10 @@ withMeta(toggleStrongCommand, {
 
 /// A input rule that will capture the strong mark.
 export const strongInputRule = $inputRule((ctx) => {
-  // Avoid matching when the opening delimiter is directly adjacent to alphanumeric characters,
-  // colon or slash (to prevent matches inside file paths, URLs, or intra-word like `a**b**c`).
-  // Also ensure the closing delimiter is not followed by such characters (mirrors strike-through rule).
+  // An opening delimiter next to an alphanumeric character, a colon or a
+  // slash must not match. That keeps the rule out of a file path, a URL
+  // and an intra-word case such as `a**b**c`. The closing delimiter
+  // rejects the same characters, the same as the strike-through rule.
   return markRule(
     /(?<![\w:/])(?:\*\*|__)([^*_]+?)(?:\*\*|__)(?![\w/])$/,
     strongSchema.type(ctx),

--- a/packages/plugins/preset-commonmark/src/node/code-block.ts
+++ b/packages/plugins/preset-commonmark/src/node/code-block.ts
@@ -97,8 +97,8 @@ withMeta(codeBlockSchema.ctx, {
   group: 'CodeBlock',
 })
 
-/// A input rule for creating code block.
-/// For example, ` ```javascript ` will create a code block with language javascript.
+/// An input rule that creates a code block. For example,
+/// ` ```javascript ` creates a code block with the javascript language.
 export const createCodeBlockInputRule = $inputRule((ctx) =>
   textblockTypeInputRule(
     /^```(?<language>[a-z]*)?[\s\n]$/,

--- a/packages/plugins/preset-commonmark/src/node/doc.ts
+++ b/packages/plugins/preset-commonmark/src/node/doc.ts
@@ -15,12 +15,12 @@ export const docSchema = $node('doc', () => ({
     match: (node) => node.type.name === 'doc',
     runner: (state, node) => {
       state.openNode('root')
-      // The last empty paragraph is the typing area, not content: skip it
-      // so it does not serialize as an empty-line placeholder (see
-      // `paragraphSchema`). By index, so it applies equally to synthetic
-      // documents (clipboard slices, ranged getMarkdown) — a selection
-      // that ends with a blank line deliberately drops that blank line
-      // from the output.
+      // The last empty paragraph is the typing area, not content. Skip
+      // it, so it does not serialize as an empty-line placeholder. See
+      // `paragraphSchema`. The skip works by index, so it also covers a
+      // synthetic document such as a clipboard slice or a ranged
+      // `getMarkdown`. A selection that ends with a blank line drops
+      // that blank line from the output on purpose.
       const last = node.childCount > 0 ? node.child(node.childCount - 1) : null
       const content =
         last?.type.name === 'paragraph' && last.content.size === 0

--- a/packages/plugins/preset-commonmark/src/node/heading.ts
+++ b/packages/plugins/preset-commonmark/src/node/heading.ts
@@ -155,9 +155,9 @@ withMeta(wrapInHeadingCommand, {
   group: 'Heading',
 })
 
-/// This command can downgrade the selected heading.
-/// For example, if you have a `h2` element, and you call this command, you will get a `h1` element.
-/// If the element is already a `h1` element, it will turn it into a `p` element.
+/// This command downgrades the selected heading. It turns an `h2`
+/// element into an `h1` element. It turns an `h1` element into a `p`
+/// element.
 export const downgradeHeadingCommand = $command(
   'DowngradeHeading',
   (ctx) => () => (state, dispatch, view) => {

--- a/packages/plugins/preset-commonmark/src/node/image.ts
+++ b/packages/plugins/preset-commonmark/src/node/image.ts
@@ -113,8 +113,8 @@ withMeta(insertImageCommand, {
   group: 'Image',
 })
 
-/// This command will update the selected image node.
-/// You can pass a payload to update `src`, `alt` and `title` for the image node.
+/// This command updates the selected image node. Pass a payload to
+/// update the `src`, the `alt` and the `title` of the node.
 export const updateImageCommand = $command(
   'UpdateImage',
   (ctx) =>

--- a/packages/plugins/preset-commonmark/src/node/list-item.ts
+++ b/packages/plugins/preset-commonmark/src/node/list-item.ts
@@ -175,7 +175,6 @@ function liftFirstListItem(ctx: Ctx): Command {
     if (!empty || $from.parentOffset !== 0) return false
 
     const parentItem = $from.node(-1)
-    // selection should be in list item
     if (parentItem.type !== listItemSchema.type(ctx)) return false
 
     return joinBackward(state, dispatch, view)

--- a/packages/plugins/preset-commonmark/src/plugin/block-container-types.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/block-container-types.ts
@@ -4,11 +4,11 @@ import { $ctx } from '@milkdown/utils'
 
 import { withMeta } from '../__internal__'
 
-// `footnoteDefinition` is a GFM type, but it ships in the defaults so
-// cherry-picked footnote compositions keep round-tripping without extra
-// wiring — the same pragmatism as `hardbreakFilterNodes` shipping
-// 'table'. Frozen (and typed readonly) so in-place mutation fails loudly
-// instead of silently polluting every editor sharing the module.
+// `footnoteDefinition` is a GFM type, and it ships in the defaults so a
+// cherry-picked footnote composition round-trips without extra wiring.
+// `hardbreakFilterNodes` ships 'table' for the same reason. The array is
+// frozen and typed readonly, so an in-place mutation fails loudly
+// instead of polluting every editor that shares the module.
 const DEFAULT_BLOCK_CONTAINER_TYPES: readonly string[] = Object.freeze([
   'root',
   'blockquote',
@@ -41,9 +41,9 @@ const KNOWN_PHRASING_TYPES = new Set([
 /// mdast type names with `ctx.update(blockContainerTypes.key, (types) =>
 /// [...types, 'myContainer'])`; otherwise a serialized empty-line
 /// placeholder inside such a container cannot round-trip and the parser
-/// drops the container. Never register a phrasing (inline content)
-/// container — such entries are ignored with a warning, because honoring
-/// them would corrupt documents.
+/// drops the container. Never register a phrasing container, which holds
+/// inline content. Such an entry is ignored with a warning, because
+/// honoring it would corrupt a document.
 ///
 /// Compositions that do not use the preset's composed `plugins` array
 /// must `.use(blockContainerTypes)` before updating the slice; without

--- a/packages/plugins/preset-commonmark/src/plugin/hardbreak-filter-plugin.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/hardbreak-filter-plugin.ts
@@ -3,7 +3,7 @@ import { $ctx, $prose } from '@milkdown/utils'
 
 import { withMeta } from '../__internal__'
 
-/// This slice contains the nodes that within which the hardbreak will be ignored.
+/// This slice holds the nodes that ignore a hardbreak inside them.
 export const hardbreakFilterNodes = $ctx(
   ['table', 'code_block'],
   'hardbreakFilterNodes'
@@ -14,8 +14,8 @@ withMeta(hardbreakFilterNodes, {
   group: 'Prose',
 })
 
-/// This plugin is used to filter the hardbreak node.
-/// If the hardbreak is going to be inserted within a node that is in the `hardbreakFilterNodes`, ignore it.
+/// This plugin filters the hardbreak node. It ignores a hardbreak that
+/// lands inside a node listed in `hardbreakFilterNodes`.
 export const hardbreakFilterPlugin = $prose((ctx) => {
   const notIn = ctx.get(hardbreakFilterNodes.key)
   return new Plugin({

--- a/packages/plugins/preset-commonmark/src/plugin/inline-nodes-cursor-plugin.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/inline-nodes-cursor-plugin.ts
@@ -4,7 +4,8 @@ import { $prose } from '@milkdown/utils'
 
 import { withMeta } from '../__internal__'
 
-/// This plugin is to solve the [chrome 98 bug](https://discuss.prosemirror.net/t/cursor-jumps-at-the-end-of-line-when-it-betweens-two-inline-nodes/4641).
+/// This plugin fixes the
+/// [chrome 98 bug](https://discuss.prosemirror.net/t/cursor-jumps-at-the-end-of-line-when-it-betweens-two-inline-nodes/4641).
 export const inlineNodesCursorPlugin = $prose(() => {
   let lock = false
   const inlineNodesCursorPluginKey = new PluginKey(

--- a/packages/plugins/preset-commonmark/src/plugin/remark-html-transformer.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/remark-html-transformer.ts
@@ -40,7 +40,7 @@ function flatMapWithDepth(
 }
 
 /// @internal
-/// This plugin should be deprecated after we support HTML.
+/// This plugin becomes obsolete once the preset supports HTML.
 export const remarkHtmlTransformer = $remark(
   'remarkHTMLTransformer',
   (ctx) => () => (tree: Node) => {

--- a/packages/plugins/preset-commonmark/src/plugin/remark-inline-link-plugin.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/remark-inline-link-plugin.ts
@@ -3,7 +3,8 @@ import remarkInlineLinks from 'remark-inline-links'
 
 import { withMeta } from '../__internal__'
 
-/// This plugin wraps [remark-inline-links](https://github.com/remarkjs/remark-inline-links).
+/// This plugin wraps
+/// [remark-inline-links](https://github.com/remarkjs/remark-inline-links).
 export const remarkInlineLinkPlugin = $remark(
   'remarkInlineLink',
   () => remarkInlineLinks

--- a/packages/plugins/preset-commonmark/src/plugin/remark-marker-plugin.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/remark-marker-plugin.ts
@@ -5,7 +5,8 @@ import { visit } from 'unist-util-visit'
 
 import { withMeta } from '../__internal__'
 
-/// This plugin is used to keep the marker (`_` and `*`) of emphasis and strong nodes.
+/// This plugin keeps the `_` and `*` marker of an emphasis node and a
+/// strong node.
 export const remarkMarker = $remark(
   'remarkMarker',
   () => () => (tree, file) => {

--- a/packages/plugins/preset-commonmark/src/plugin/remark-preserve-empty-line.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/remark-preserve-empty-line.ts
@@ -8,20 +8,20 @@ import { getBlockContainerTypes } from './block-container-types'
 
 type ParentNode = Node & { children: Node[] }
 
-// The serializer emits its empty-line placeholder in exactly two shapes:
-// a lone <br /> inside a paragraph (or a table cell, where paragraphs are
-// flattened in mdast), and — before `remarkHtmlTransformer` wraps it — a
-// <br /> directly inside a block container. This plugin folds exactly
-// those shapes back into empty paragraphs and keeps every other <br> as
-// user-authored inline HTML.
+// The serializer emits its empty-line placeholder in two shapes. The
+// first is a lone <br /> inside a paragraph, or inside a table cell,
+// where mdast flattens a paragraph. The second is a <br /> directly
+// inside a block container, before `remarkHtmlTransformer` wraps it.
+// This plugin folds those two shapes back into empty paragraphs and
+// keeps every other <br> as user-authored inline HTML.
 //
-// 'tableCell' is a GFM type shipped here for the same compat pragmatism
-// as `blockContainerTypes`' defaults. Unlike flow containers, phrasing
-// containers have no registration point, deliberately: the placeholder
-// shapes are defined by this preset's serializer, and a third-party
-// phrasing container that emits its own placeholders can fold them in
-// its own remark plugin. Do NOT add phrasing types to
-// `blockContainerTypes` (see its doc comment).
+// 'tableCell' is a GFM type, and it ships here for the same
+// compatibility reason as the `blockContainerTypes` defaults. A phrasing
+// container has no registration point, unlike a flow container. That is
+// deliberate: this preset's serializer defines the placeholder shapes,
+// and a third-party phrasing container that emits its own placeholder
+// folds it in its own remark plugin. Never add a phrasing type to
+// `blockContainerTypes`. See its doc comment.
 const PLACEHOLDER_PARENTS = new Set(['paragraph', 'tableCell'])
 
 function visitEmptyLine(ast: Node, blockContainers: ReadonlySet<string>) {
@@ -53,22 +53,22 @@ function visitEmptyLine(ast: Node, blockContainers: ReadonlySet<string>) {
         return SKIP
       }
 
-      // Any other parent (heading, link, emphasis, unknown containers):
-      // the <br> is user content — keep it, exactly like any other inline
-      // html tag.
+      // Under any other parent, such as a heading, a link, an emphasis
+      // or an unknown container, the <br> is user content. Keep it, the
+      // same as any other inline html tag.
       return undefined
     }
   )
 }
 
-/// This plugin makes the serializer's empty-line placeholders round-trip.
-/// The serializer represents a preserved empty paragraph as a lone
-/// `<br />` (see `paragraphSchema`); on load this plugin folds such a
-/// placeholder — a `<br>` that is the sole child of a paragraph or table
-/// cell, or a `<br>` sitting on its own between blocks — back into an
-/// empty paragraph. Any other `<br>` (with siblings, or inside another
-/// parent such as a heading, link, or emphasis) is user-authored HTML and
-/// is kept.
+/// This plugin makes the empty-line placeholder of the serializer
+/// round-trip. The serializer writes a preserved empty paragraph as a
+/// lone `<br />`. See `paragraphSchema`. On load this plugin folds the
+/// placeholder back into an empty paragraph. A placeholder is a `<br>`
+/// that is the only child of a paragraph or a table cell, or a `<br>`
+/// that sits on its own between blocks. Any other `<br>` is
+/// user-authored HTML and stays, for example one with siblings or one
+/// inside a heading, a link or an emphasis.
 ///
 /// In the composed presets `remarkHtmlTransformer` runs first and wraps
 /// block-level HTML into paragraphs; this plugin also folds unwrapped

--- a/packages/plugins/preset-commonmark/src/plugin/sync-list-order-plugin.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/sync-list-order-plugin.ts
@@ -9,7 +9,8 @@ import { bulletListSchema } from '../node'
 import { listItemSchema } from '../node/list-item'
 import { orderedListSchema } from '../node/ordered-list'
 
-/// This plugin is used to keep the label of list item up to date in ordered list.
+/// This plugin keeps the label of a list item current in an ordered
+/// list.
 export const syncListOrderPlugin = $prose((ctx) => {
   const syncOrderLabel = (
     transactions: readonly Transaction[],

--- a/packages/plugins/preset-gfm/src/__test__/inline-br-containers.spec.ts
+++ b/packages/plugins/preset-gfm/src/__test__/inline-br-containers.spec.ts
@@ -64,10 +64,10 @@ describe('inline br in gfm containers', () => {
     expect(output).toBe('| a<br>b | c |\n| ------ | - |\n| x      | y |\n')
   })
 
-  // A trailing hardbreak in a cell (reachable via HTML paste) must be
-  // dropped like the paragraph serializer does, or it renders as a
-  // trailing space that the next parse trims — making consecutive saves
-  // diverge.
+  // An HTML paste can put a trailing hardbreak in a cell. The
+  // serializer drops it, the same as the paragraph serializer does.
+  // Otherwise it renders as a trailing space that the next parse trims,
+  // and two consecutive saves diverge.
   it('drops a trailing hardbreak in a cell so saves stay stable', async () => {
     const output = await withEditor(
       '| a | c |\n| --- | --- |\n| x | y |\n',

--- a/packages/plugins/preset-gfm/src/__test__/table-header-row.spec.ts
+++ b/packages/plugins/preset-gfm/src/__test__/table-header-row.spec.ts
@@ -30,7 +30,7 @@ it('should not crash when serializing a table with empty header row', async () =
   const schema = editor.ctx.get(schemaCtx)
   const serializer = editor.ctx.get(serializerCtx)
 
-  // Create a table with an empty header row (content.size === 0)
+  // An empty header row has a content size of 0.
   const tableHeaderRow = schema.nodes.table_header_row!.create()
   const tableRow = schema.nodes.table_row!.create(null, [
     schema.nodes.table_cell!.create(
@@ -41,7 +41,6 @@ it('should not crash when serializing a table with empty header row', async () =
   const table = schema.nodes.table!.create(null, [tableHeaderRow, tableRow])
   const doc = schema.topNodeType.createAndFill(null, [table])!
 
-  // This should not throw
   expect(() => serializer(doc)).not.toThrow()
 })
 

--- a/packages/plugins/preset-gfm/src/node/footnote/definition.ts
+++ b/packages/plugins/preset-gfm/src/node/footnote/definition.ts
@@ -38,7 +38,8 @@ export const footnoteDefinitionSchema = $nodeSchema(
       return [
         'dl',
         {
-          // TODO: add a prosemirror plugin to sync label on change
+          // TODO: add a prosemirror plugin that syncs the label on a
+          // change.
           'data-label': label,
           'data-type': id,
         },

--- a/packages/plugins/preset-gfm/src/node/footnote/reference.ts
+++ b/packages/plugins/preset-gfm/src/node/footnote/reference.ts
@@ -35,7 +35,8 @@ export const footnoteReferenceSchema = $nodeSchema(
       return [
         'sup',
         {
-          // TODO: add a prosemirror plugin to sync label on change
+          // TODO: add a prosemirror plugin that syncs the label on a
+          // change.
           'data-label': label,
           'data-type': id,
         },

--- a/packages/plugins/preset-gfm/src/node/table/input.ts
+++ b/packages/plugins/preset-gfm/src/node/table/input.ts
@@ -59,10 +59,10 @@ withMeta(insertTableInputRule, {
   group: 'Table',
 })
 
-/// A paste rule for fixing tables without header cells.
-/// This is a workaround for some editors (e.g. Google Docs) which allow creating tables without header cells,
-/// which is not supported by Markdown schema.
-/// This paste rule will promote the first data row to header, or add empty header cells as a fallback.
+/// A paste rule that fixes a table without header cells. An editor such
+/// as Google Docs creates a table without header cells, which the
+/// Markdown schema does not support. This rule promotes the first data
+/// row to a header row, or adds empty header cells as a fallback.
 export const tablePasteRule = $pasteRule((ctx) => ({
   run: (slice, _view, isPlainText) => {
     if (isPlainText) {
@@ -124,9 +124,9 @@ export const tablePasteRule = $pasteRule((ctx) => ({
       return newTable
     }
 
-    // Wrap consecutive orphaned table_row nodes (at the top level of a fragment)
-    // into a proper table. This happens when ProseMirror's parseSlice breaks
-    // a table apart (e.g. when pasting multiple tables from Google Docs).
+    // Wrap the consecutive orphaned table_row nodes at the top level of
+    // a fragment into a table. `parseSlice` breaks a table apart this
+    // way, for example on a paste of several tables from Google Docs.
     function wrapOrphanedRows(fragment: FragmentType): FragmentType {
       const rowType = tableRowSchema.type(ctx)
       const nodes: ProsemirrorNode[] = []
@@ -136,7 +136,8 @@ export const tablePasteRule = $pasteRule((ctx) => ({
       function flushPendingRows() {
         if (pendingRows.length === 0) return
 
-        // Create an empty table_header_row, then fixTable will promote the first data row
+        // An empty table_header_row lets `fixTable` promote the first
+        // data row.
         const emptyHeaderRow = tableHeaderRowSchema.type(ctx).createAndFill()!
         const table = tableSchema
           .type(ctx)

--- a/packages/plugins/preset-gfm/src/node/table/schema.ts
+++ b/packages/plugins/preset-gfm/src/node/table/schema.ts
@@ -6,11 +6,11 @@ import { $nodeSchema } from '@milkdown/utils'
 
 import { withMeta } from '../../__internal__'
 
-/// A cell holds exactly one paragraph (see `cellContent` below), while an
-/// mdast tableCell holds phrasing content directly. Serializing the
-/// paragraph's inline content keeps the paragraph serializer (and its
-/// empty-line placeholder) out of table cells — the mirror of the parse
-/// runners, which wrap the flat cell content in a paragraph.
+/// A cell holds exactly one paragraph. See `cellContent` below. An mdast
+/// tableCell holds phrasing content directly. Serializing the inline
+/// content of the paragraph keeps the paragraph serializer and its
+/// empty-line placeholder out of a table cell. The parse runners mirror
+/// this and wrap the flat cell content in a paragraph.
 ///
 /// Like `serializeText` in the paragraph runner, a trailing hardbreak is
 /// dropped: mdast renders it as a trailing space inside a cell, which
@@ -129,8 +129,8 @@ export const tableHeaderRowSchema = $nodeSchema('table_header_row', () => ({
   toMarkdown: {
     match: (node) => node.type.name === 'table_header_row',
     runner: (state, node) => {
-      // if the row is empty, we don't need to create a table row
-      // prevent remark from crashing
+      // An empty row needs no table row, and skipping it keeps remark
+      // from crashing.
       if (node.content.size === 0) {
         return
       }
@@ -172,8 +172,8 @@ export const tableRowSchema = $nodeSchema('table_row', () => ({
   toMarkdown: {
     match: (node) => node.type.name === 'table_row',
     runner: (state, node) => {
-      // if the row is empty, we don't need to create a table row
-      // prevent remark from crashing
+      // An empty row needs no table row, and skipping it keeps remark
+      // from crashing.
       if (node.content.size === 0) {
         return
       }

--- a/packages/plugins/preset-gfm/src/node/task-list-item.ts
+++ b/packages/plugins/preset-gfm/src/node/task-list-item.ts
@@ -5,7 +5,8 @@ import { $inputRule } from '@milkdown/utils'
 
 import { withMeta } from '../__internal__'
 
-/// This schema extends the [list item](/preset-commonmark#list-item) schema and add task list support for it.
+/// This schema extends the [list item](/preset-commonmark#list-item)
+/// schema and adds task list support to it.
 export const extendListItemSchemaForTask = listItemSchema.extendSchema(
   (prev) => {
     return (ctx) => {
@@ -109,8 +110,8 @@ withMeta(extendListItemSchemaForTask.ctx, {
   group: 'ListItem',
 })
 
-/// Input rule for wrapping a block in task list node.
-/// Users can type `[ ] ` or `[x] ` to wrap the block in task list node with checked status.
+/// An input rule that wraps a block in a task list node. Type `[ ] ` or
+/// `[x] ` to wrap the block and set its checked status.
 export const wrapInTaskListInputRule = $inputRule(() => {
   return new InputRule(
     /^\[(?<checked>\s|x)\]\s$/,

--- a/packages/plugins/preset-gfm/src/plugin/auto-insert-span-plugin.ts
+++ b/packages/plugins/preset-gfm/src/plugin/auto-insert-span-plugin.ts
@@ -3,8 +3,9 @@ import { imeSpan } from 'prosemirror-safari-ime-span'
 
 import { withMeta } from '../__internal__'
 
-/// This plugin is used to fix the bug of IME composing in table in Safari browser.
-/// original discussion in https://discuss.prosemirror.net/t/ime-composing-problems-on-td-or-th-element-in-safari-browser/4501
+/// This plugin fixes an IME composing bug in a table in the Safari browser. See
+/// the
+/// [original discussion](https://discuss.prosemirror.net/t/ime-composing-problems-on-td-or-th-element-in-safari-browser/4501).
 export const autoInsertSpanPlugin = $prose(() => imeSpan)
 
 withMeta(autoInsertSpanPlugin, {

--- a/packages/plugins/preset-gfm/src/plugin/column-resizing-plugin.ts
+++ b/packages/plugins/preset-gfm/src/plugin/column-resizing-plugin.ts
@@ -3,7 +3,8 @@ import { $prose } from '@milkdown/utils'
 
 import { withMeta } from '../__internal__'
 
-/// This plugin is wrapping the `columnResizing` plugin from [prosemirror-tables](https://github.com/ProseMirror/prosemirror-tables).
+/// This plugin wraps the `columnResizing` plugin from
+/// [prosemirror-tables](https://github.com/ProseMirror/prosemirror-tables).
 export const columnResizingPlugin = $prose(() => columnResizing({}))
 
 withMeta(columnResizingPlugin, {

--- a/packages/plugins/preset-gfm/src/plugin/keep-table-align-plugin.ts
+++ b/packages/plugins/preset-gfm/src/plugin/keep-table-align-plugin.ts
@@ -47,7 +47,7 @@ export const keepTableAlignPlugin = $prose(() => {
         const tableRow = $pos.node($pos.depth)
         const table = $pos.node($pos.depth - 1)
         const tableHeaderRow = table.firstChild
-        // TODO: maybe consider add a header row
+        // TODO: add a header row when the table has none.
         if (!tableHeaderRow) return
 
         const index = getChildIndex(node, tableRow)

--- a/packages/plugins/preset-gfm/src/plugin/remark-gfm-plugin.ts
+++ b/packages/plugins/preset-gfm/src/plugin/remark-gfm-plugin.ts
@@ -6,7 +6,8 @@ import remarkGFM from 'remark-gfm'
 
 import { withMeta } from '../__internal__'
 
-/// This plugin is wrapping the [remark-gfm](https://github.com/remarkjs/remark-gfm).
+/// This plugin wraps
+/// [remark-gfm](https://github.com/remarkjs/remark-gfm).
 export const remarkGFMPlugin: $Remark<'remarkGFM', Options | null | undefined> =
   $remark('remarkGFM', () => remarkGFM)
 

--- a/packages/plugins/preset-gfm/src/plugin/table-editing-plugin.ts
+++ b/packages/plugins/preset-gfm/src/plugin/table-editing-plugin.ts
@@ -3,7 +3,8 @@ import { $prose } from '@milkdown/utils'
 
 import { withMeta } from '../__internal__'
 
-/// This plugin is wrapping the `tableEditing` plugin from [prosemirror-tables](https://github.com/ProseMirror/prosemirror-tables).
+/// This plugin wraps the `tableEditing` plugin from
+/// [prosemirror-tables](https://github.com/ProseMirror/prosemirror-tables).
 export const tableEditingPlugin = $prose(() =>
   tableEditing({ allowTableNodeSelection: true })
 )

--- a/packages/prose/src/toolkit/input-rules/custom-input-rules.ts
+++ b/packages/prose/src/toolkit/input-rules/custom-input-rules.ts
@@ -78,14 +78,14 @@ export function customInputRules({ rules }: { rules: InputRule[] }): Plugin {
           return false
         },
         keydown: (view, event) => {
-          // On Chrome Android, prosemirror-view suppresses Enter keydown events
-          // to avoid input corruption during composition. It then relies on DOM
-          // mutation detection to retroactively handle Enter. However, this
-          // fallback fails with custom node views (e.g. list-item-block) whose
-          // wrapper DOM structure prevents the Enter detection heuristics from
-          // recognizing the mutation. We intercept Enter here — before
-          // prosemirror-view's suppression — and manually route it through
-          // handleKeyDown so that keymaps (splitListItem, etc.) work correctly.
+          // On Chrome Android, prosemirror-view suppresses an Enter
+          // keydown event, which avoids input corruption during
+          // composition. It then handles Enter through DOM mutation
+          // detection. That fallback fails with a custom node view such
+          // as list-item-block, whose wrapper DOM hides the mutation
+          // from the detection heuristics. This handler catches Enter
+          // before the suppression and routes it through
+          // `handleKeyDown`, so a keymap such as `splitListItem` runs.
           if (!(android && chrome && (event as KeyboardEvent).key === 'Enter'))
             return false
           if (view.composing) return false

--- a/packages/prose/src/toolkit/input-rules/mark-rule.ts
+++ b/packages/prose/src/toolkit/input-rules/mark-rule.ts
@@ -68,10 +68,10 @@ export function markRule(
       const textStart = start + fullMatch.indexOf(group)
       const textEnd = textStart + group.length
 
-      // Delimiters inside inline code are literal, but an inline code mark can
-      // still be valid content inside an outer mark such as *`code`*. Delimiters
-      // already in the document are rejected on their marks alone, wherever they
-      // sit inside the span.
+      // A delimiter inside inline code is literal. An inline code mark
+      // still counts as valid content inside an outer mark such as
+      // *`code`*. A delimiter already in the document is rejected on its
+      // marks alone, wherever it sits inside the span.
       const openingDelimiterHasCodeMark = rangeHasCodeMark(
         state,
         start + startSpaces,

--- a/packages/prose/src/toolkit/prose/snapshot.ts
+++ b/packages/prose/src/toolkit/prose/snapshot.ts
@@ -123,9 +123,10 @@ export function textOffsetToPos(
   return lastPos
 }
 
-/// Render the document text with the selection drawn in: `┃` for a caret,
-/// `❰…❱` for a range. Blocks are joined with `blockSeparator` and leaf nodes
-/// render as `leafText`. Made for inline snapshot assertions in tests.
+/// Render the document text with the selection drawn in. A caret shows
+/// as `┃`, and a range shows as `❰…❱`. `blockSeparator` joins the
+/// blocks, and a leaf node renders as `leafText`. Use it for an inline
+/// snapshot assertion in a test.
 export function getSelectionSnapshot(
   state: EditorState,
   options?: TextIndexOptions

--- a/packages/transformer/src/parser/state.ts
+++ b/packages/transformer/src/parser/state.ts
@@ -194,14 +194,15 @@ export class ParserState extends Stack<Node, ParserStackElement> {
     return doc
   }
 
-  /// Give the node or node list back to the state and
-  /// the state will find a proper runner (by `match` method in parser spec) to handle it.
+  /// Give the node or node list back to the state and the state will find a
+  /// proper runner (by `match` method in parser spec) to handle it.
   next = (nodes: MarkdownNode | MarkdownNode[] = []) => {
     ;[nodes].flat().forEach((node) => this.#runNode(node))
     return this
   }
 
-  /// Build the current state into a [prosemirror document](https://prosemirror.net/docs/ref/#model.Document_Structure).
+  /// Build the current state into a
+  /// [prosemirror document](https://prosemirror.net/docs/ref/#model.Document_Structure).
   toDoc = () => this.build()
 
   /// Transform a markdown string into prosemirror state.

--- a/packages/transformer/src/parser/types.ts
+++ b/packages/transformer/src/parser/types.ts
@@ -3,7 +3,8 @@ import type { MarkType, Node, NodeType } from '@milkdown/prose/model'
 import type { MarkdownNode } from '../utility/types'
 import type { ParserState } from './state'
 
-/// The parser type which is used to transform markdown text into prosemirror node.
+/// The parser type which is used to transform markdown text into prosemirror
+/// node.
 export type Parser = (text: string) => Node
 
 /// The spec for node parser in schema.

--- a/packages/transformer/src/serializer/state.spec.ts
+++ b/packages/transformer/src/serializer/state.spec.ts
@@ -222,7 +222,8 @@ describe('serializer-state', () => {
 
     state.openNode('doc')
     state.openNode('paragraph')
-    // Open a bold mark, add a text node with surrounding spaces, then close the mark
+    // Open a bold mark, add a text node with surrounding spaces, then
+    // close the mark.
     state.withMark(boldMark, 'bold')
     state.addNode('text', [], ' hello ')
     state.closeMark(boldMark)
@@ -332,7 +333,7 @@ describe('serializer-state', () => {
   it('keeps a mark open across nodes that share it', () => {
     const state = new SerializerState(schema)
 
-    // **a *b* c** — the strong mark spans all three text nodes.
+    // In `**a *b* c**` the strong mark spans all three text nodes.
     state.openNode('doc')
     state.openNode('paragraph')
     state.next(
@@ -372,9 +373,9 @@ describe('serializer-state', () => {
   it('keeps continuing marks outside of newly opened marks', () => {
     const state = new SerializerState(schema)
 
-    // *a **b** c* — the italic mark opens first and must stay the
-    // outer mark when bold opens on the second text node, even if the
-    // mark set of that node lists bold first.
+    // In `*a **b** c*` the italic mark opens first and stays the outer
+    // mark when bold opens on the second text node, even when the mark
+    // set of that node lists bold first.
     state.openNode('doc')
     state.openNode('paragraph')
     state.next(
@@ -414,8 +415,8 @@ describe('serializer-state', () => {
   it('closes value-based marks after the node that carries them', () => {
     const state = new SerializerState(schema)
 
-    // **`code` b** — inlineCode holds its content as a value and must not
-    // stay open, while the bold mark spans both text nodes.
+    // In ``**`code` b**`` inlineCode holds its content as a value and
+    // closes at once, while the bold mark spans both text nodes.
     state.openNode('doc')
     state.openNode('paragraph')
     state.next(
@@ -450,8 +451,8 @@ describe('serializer-state', () => {
   it('does not trim spaces inside a mark spanning multiple nodes', () => {
     const state = new SerializerState(schema)
 
-    // **a *b*** — the space between "a" and the italic node is internal
-    // and must be preserved when the bold mark closes.
+    // In `**a *b***` the space between "a" and the italic node is
+    // internal, and it survives the close of the bold mark.
     state.openNode('doc')
     state.openNode('paragraph')
     state.next(

--- a/packages/transformer/src/serializer/state.ts
+++ b/packages/transformer/src/serializer/state.ts
@@ -343,10 +343,10 @@ export class SerializerState extends Stack<
     return doc
   }
 
-  /// Give the node or node list back to the state and
-  /// the state will find a proper runner (by `match` method in serializer spec) to handle it.
-  /// When a node list is given, marks shared between adjacent nodes are kept
-  /// open across them so that they are serialized as one continuous span.
+  /// Give the node or node list back to the state and the state will find a
+  /// proper runner (by `match` method in serializer spec) to handle it. When a
+  /// node list is given, marks shared between adjacent nodes are kept open
+  /// across them so that they are serialized as one continuous span.
   next = (nodes: Node | Fragment) => {
     if (isFragment(nodes)) {
       nodes.forEach((node, _offset, index) => {

--- a/packages/transformer/src/serializer/types.ts
+++ b/packages/transformer/src/serializer/types.ts
@@ -2,7 +2,8 @@ import type { Mark, Node } from '@milkdown/prose/model'
 
 import type { SerializerState } from './state'
 
-/// The serializer type which is used to transform prosemirror node into markdown text.
+/// The serializer type which is used to transform prosemirror node into
+/// markdown text.
 export type Serializer = (content: Node) => string
 
 /// The spec for node serializer in schema.

--- a/packages/transformer/src/utility/stack.ts
+++ b/packages/transformer/src/utility/stack.ts
@@ -10,11 +10,12 @@ export abstract class StackElement<Node> {
 ///
 /// > Generally, you don't need to use this class directly.
 ///
-/// When using the stack, users can call `stack.open` to push a new element into the stack.
-/// And use `stack.push` to push a node into the top element.
-/// Then use `stack.close` to close the top element and pop it.
+/// When using the stack, users can call `stack.open` to push a new element into
+/// the stack. And use `stack.push` to push a node into the top element. Then
+/// use `stack.close` to close the top element and pop it.
 ///
-/// For example: `stack.open(A).push(B).push(C).close()` will generate a structure like `A(B, C)`.
+/// For example: `stack.open(A).push(B).push(C).close()` will generate a
+/// structure like `A(B, C)`.
 export class Stack<Node, Element extends StackElement<Node>> {
   protected elements: Element[] = []
 

--- a/packages/transformer/src/utility/types.ts
+++ b/packages/transformer/src/utility/types.ts
@@ -29,22 +29,26 @@ export type JSONRecord = Record<string, JSONValue>
 /// @internal
 export type RemarkPluginRaw<T> = Plugin<[T], Root>
 
-/// The universal type of a [remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md).
+/// The universal type of a
+/// [remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md).
 export interface RemarkPlugin<T = Record<string, unknown>> {
   plugin: Plugin<[T], Root>
   options: T
 }
 
-/// The type of [remark instance](https://github.com/remarkjs/remark/tree/main/packages/remark#remark-1).
+/// The type of
+/// [remark instance](https://github.com/remarkjs/remark/tree/main/packages/remark#remark-1).
 export type RemarkParser = ReturnType<typeof remark>
 
-/// The universal type of a node in [mdast](https://github.com/syntax-tree/mdast).
+/// The universal type of a node in
+/// [mdast](https://github.com/syntax-tree/mdast).
 export type MarkdownNode = Node & {
   children?: MarkdownNode[]
   [x: string]: unknown
 }
 
-/// Schema spec for node. It is a super set of [NodeSpec](https://prosemirror.net/docs/ref/#model.NodeSpec).
+/// Schema spec for node. It is a super set of
+/// [NodeSpec](https://prosemirror.net/docs/ref/#model.NodeSpec).
 export interface NodeSchema extends NodeSpec {
   /// To markdown serializer spec.
   readonly toMarkdown: NodeSerializerSpec
@@ -54,7 +58,8 @@ export interface NodeSchema extends NodeSpec {
   readonly priority?: number
 }
 
-/// Schema spec for mark. It is a super set of [MarkSpec](https://prosemirror.net/docs/ref/#model.MarkSpec).
+/// Schema spec for mark. It is a super set of
+/// [MarkSpec](https://prosemirror.net/docs/ref/#model.MarkSpec).
 export interface MarkSchema extends MarkSpec {
   /// To markdown serializer spec.
   readonly toMarkdown: MarkSerializerSpec

--- a/packages/utils/src/composable/$command.ts
+++ b/packages/utils/src/composable/$command.ts
@@ -16,11 +16,12 @@ export type $Command<T> = MilkdownPlugin & {
   key: CmdKey<T>
 }
 
-/// Create a command plugin. The command will be registered in the `commandsCtx` and can be called by other parts of the editor.
-/// It takes a key and a factory function. The factory function will be called when the plugin is created.
-/// The factory should return a function that will be called when the command is executed.
-/// The function should receive at **most one parameter**, which is the payload of the command.
-/// And the payload should always be **optional**.
+/// Create a command plugin. The command will be registered in the `commandsCtx`
+/// and can be called by other parts of the editor. It takes a key and a factory
+/// function. The factory function will be called when the plugin is created.
+/// The factory should return a function that will be called when the command is
+/// executed. The function should receive at **most one parameter**, which is
+/// the payload of the command. And the payload should always be **optional**.
 ///
 /// ```ts
 /// import { setBlockType } from '@milkdown/prose/commands'
@@ -38,7 +39,10 @@ export type $Command<T> = MilkdownPlugin & {
 ///
 /// ```ts
 /// import { callCommand } from '@milkdown/utils';
-/// const editor = Editor.make().use(/* some plugins */).use(commandPlugin).create();
+/// const editor = Editor.make()
+///   .use(/* some plugins */)
+///   .use(commandPlugin)
+///   .create()
 ///
 /// editor.action(callCommand(commandPlugin.key, 3));
 /// ```
@@ -64,7 +68,8 @@ export function $command<T, K extends string>(
   return <$Command<T>>plugin
 }
 
-/// The async version for `$command`. You can use `await` in the factory when creating the command.
+/// The async version for `$command`. You can use `await` in the factory when
+/// creating the command.
 /// ```ts
 /// const commandPlugin = $commandASync('LoadRemoteDoc', (ctx) => {
 ///   return async (url = 'my-remote-api') => {

--- a/packages/utils/src/composable/$ctx.ts
+++ b/packages/utils/src/composable/$ctx.ts
@@ -7,7 +7,8 @@ export type $Ctx<T, N extends string> = MilkdownPlugin & {
   key: SliceType<T, N>
 }
 
-/// Create a slice plugin. The plugin will be registered in the `ctx` and can be accessed by other parts of the editor.
+/// Create a slice plugin. The plugin will be registered in the `ctx` and can be
+/// accessed by other parts of the editor.
 /// ```ts
 /// const counterCtx = $ctx(0, 'counter');
 /// ```

--- a/packages/utils/src/composable/$input-rule.ts
+++ b/packages/utils/src/composable/$input-rule.ts
@@ -10,8 +10,8 @@ export type $InputRule = MilkdownPlugin & {
   inputRule: InputRule
 }
 
-/// Create an input rule plugin.
-/// It takes a factory function which returns a [prosemirror input rule](https://prosemirror.net/docs/ref/#inputrules.InputRule).
+/// Create an input rule plugin. It takes a factory function which returns a
+/// [prosemirror input rule](https://prosemirror.net/docs/ref/#inputrules.InputRule).
 ///
 /// Additional property:
 /// - `inputRule`: The prosemirror input rule created.
@@ -30,7 +30,8 @@ export function $inputRule(inputRule: (ctx: Ctx) => InputRule): $InputRule {
   return <$InputRule>plugin
 }
 
-/// The async version for `$inputRule`. You can use `await` in the factory when creating the input rule.
+/// The async version for `$inputRule`. You can use `await` in the factory when
+/// creating the input rule.
 ///
 /// Additional property:
 /// - `inputRule`: The prosemirror input rule created.

--- a/packages/utils/src/composable/$mark.ts
+++ b/packages/utils/src/composable/$mark.ts
@@ -14,14 +14,15 @@ export type $Mark = MilkdownPlugin & {
   type: (ctx: Ctx) => MarkType
 }
 
-/// Create a mark plugin.
-/// It takes a mark id and a factory function.
-/// The factory should return a function that returns a [mark schema](/transformer#interface-markschema).
+/// Create a mark plugin. It takes a mark id and a factory function. The factory
+/// should return a function that returns a
+/// [mark schema](/transformer#interface-markschema).
 ///
 /// Additional property:
 /// - `id`: The id of the mark.
 /// - `schema`: The mark schema created.
-/// - `type`: A function that will return the [prosemirror mark type](https://prosemirror.net/docs/ref/#model.MarkType).
+/// - `type`: A function that will return the
+///   [prosemirror mark type](https://prosemirror.net/docs/ref/#model.MarkType).
 export function $mark(id: string, schema: (ctx: Ctx) => MarkSchema): $Mark {
   const plugin: MilkdownPlugin = (ctx) => async () => {
     const markSchema = schema(ctx)
@@ -44,12 +45,14 @@ export function $mark(id: string, schema: (ctx: Ctx) => MarkSchema): $Mark {
   return <$Mark>plugin
 }
 
-/// The async version for `$mark`. You can use `await` in the factory when creating the mark schema.
+/// The async version for `$mark`. You can use `await` in the factory when
+/// creating the mark schema.
 ///
 /// Additional property:
 /// - `id`: The id of the mark.
 /// - `schema`: The mark schema created.
-/// - `type`: A function that will return the [prosemirror mark type](https://prosemirror.net/docs/ref/#model.MarkType).
+/// - `type`: A function that will return the
+///   [prosemirror mark type](https://prosemirror.net/docs/ref/#model.MarkType).
 /// - `timer`: The timer which will be resolved when the mark schema is ready.
 export function $markAsync(
   id: string,

--- a/packages/utils/src/composable/$node.ts
+++ b/packages/utils/src/composable/$node.ts
@@ -14,14 +14,15 @@ export type $Node = MilkdownPlugin & {
   type: (ctx: Ctx) => NodeType
 }
 
-/// Create a node plugin.
-/// It takes a node id and a factory function.
-/// The factory should return a function that returns a [node schema](/transformer#interface-nodeschema).
+/// Create a node plugin. It takes a node id and a factory function. The factory
+/// should return a function that returns a
+/// [node schema](/transformer#interface-nodeschema).
 ///
 /// Additional property:
 /// - `id`: The id of the node.
 /// - `schema`: The node schema created.
-/// - `type`: A function that will return the [prosemirror node type](https://prosemirror.net/docs/ref/#model.NodeType).
+/// - `type`: A function that will return the
+///   [prosemirror node type](https://prosemirror.net/docs/ref/#model.NodeType).
 export function $node(id: string, schema: (ctx: Ctx) => NodeSchema): $Node {
   const plugin: MilkdownPlugin = (ctx) => async () => {
     const nodeSchema = schema(ctx)
@@ -46,12 +47,14 @@ export function $node(id: string, schema: (ctx: Ctx) => NodeSchema): $Node {
   return <$Node>plugin
 }
 
-/// The async version for `$node`. You can use `await` in the factory when creating the node schema.
+/// The async version for `$node`. You can use `await` in the factory when
+/// creating the node schema.
 ///
 /// Additional property:
 /// - `id`: The id of the node.
 /// - `schema`: The node schema created.
-/// - `type`: A function that will return the [prosemirror node type](https://prosemirror.net/docs/ref/#model.NodeType).
+/// - `type`: A function that will return the
+///   [prosemirror node type](https://prosemirror.net/docs/ref/#model.NodeType).
 /// - `timer`: The timer which will be resolved when the node schema is ready.
 export function $nodeAsync(
   id: string,

--- a/packages/utils/src/composable/$paste-rule.ts
+++ b/packages/utils/src/composable/$paste-rule.ts
@@ -34,7 +34,8 @@ export function $pasteRule(pasteRule: (ctx: Ctx) => PasteRule): $PasteRule {
   return <$PasteRule>plugin
 }
 
-/// The async version for `$pasteRule`. You can use `await` in the factory when creating the paste rule.
+/// The async version for `$pasteRule`. You can use `await` in the factory when
+/// creating the paste rule.
 ///
 /// Additional property:
 /// - `pasteRule`: The paste rule created.

--- a/packages/utils/src/composable/$prose.ts
+++ b/packages/utils/src/composable/$prose.ts
@@ -15,12 +15,16 @@ export type $Prose = MilkdownPlugin & {
   key: () => PluginKey | undefined
 }
 
-/// Create a milkdown wrapper for [prosemirror plugin](https://prosemirror.net/docs/ref/#state.Plugin).
-/// It takes a factory function which returns a [prosemirror plugin](https://prosemirror.net/docs/ref/#state.Plugin).
+/// Create a milkdown wrapper for
+/// [prosemirror plugin](https://prosemirror.net/docs/ref/#state.Plugin). It
+/// takes a factory function which returns a
+/// [prosemirror plugin](https://prosemirror.net/docs/ref/#state.Plugin).
 ///
 /// Additional property:
 /// - `plugin`: The prosemirror plugin created.
-/// - `key`: The [prosemirror plugin key](https://prosemirror.net/docs/ref/#state.PluginKey) of the plugin.
+/// - `key`: The
+///   [prosemirror plugin key](https://prosemirror.net/docs/ref/#state.PluginKey)
+///   of the plugin.
 export function $prose(prose: (ctx: Ctx) => Plugin): $Prose {
   let prosePlugin: Plugin | undefined
   const plugin: MilkdownPlugin = (ctx) => async () => {
@@ -38,11 +42,14 @@ export function $prose(prose: (ctx: Ctx) => Plugin): $Prose {
   return <$Prose>plugin
 }
 
-/// The async version for `$prose`. You can use `await` in the factory when creating the plugin.
+/// The async version for `$prose`. You can use `await` in the factory when
+/// creating the plugin.
 ///
 /// Additional property:
 /// - `plugin`: The prosemirror plugin created.
-/// - `key`: The [prosemirror plugin key](https://prosemirror.net/docs/ref/#state.PluginKey) of the plugin.
+/// - `key`: The
+///   [prosemirror plugin key](https://prosemirror.net/docs/ref/#state.PluginKey)
+///   of the plugin.
 /// - `timer`: The timer which will be resolved when the plugin is ready.
 export function $proseAsync(
   prose: (ctx: Ctx) => Promise<Plugin>,

--- a/packages/utils/src/composable/$shortcut.ts
+++ b/packages/utils/src/composable/$shortcut.ts
@@ -18,8 +18,8 @@ export type $Shortcut = MilkdownPlugin & {
   keymap: Keymap
 }
 
-/// Create a shortcut for the editor.
-/// It takes a factory function which returns a [prosemirror keymap](https://prosemirror.net/docs/ref/#keymap).
+/// Create a shortcut for the editor. It takes a factory function which returns
+/// a [prosemirror keymap](https://prosemirror.net/docs/ref/#keymap).
 ///
 /// Additional property:
 /// - `keymap`: The prosemirror keymap created.
@@ -39,7 +39,8 @@ export function $shortcut(shortcut: (ctx: Ctx) => Keymap): $Shortcut {
   return <$Shortcut>plugin
 }
 
-/// The async version for `$shortcut`. You can use `await` in the factory when creating the keymap.
+/// The async version for `$shortcut`. You can use `await` in the factory when
+/// creating the keymap.
 ///
 /// Additional property:
 /// - `keymap`: The prosemirror keymap created.

--- a/packages/utils/src/composable/$view.ts
+++ b/packages/utils/src/composable/$view.ts
@@ -32,10 +32,13 @@ export type GetConstructor<T extends $Node | $Mark> = T extends $Node
     ? MarkViewConstructor
     : NodeViewConstructor | MarkViewConstructor
 
-/// Create a [prosemirror node/mark view](https://prosemirror.net/docs/ref/#view.NodeView) plugin.
-/// It takes two arguments
+/// Create a
+/// [prosemirror node/mark view](https://prosemirror.net/docs/ref/#view.NodeView)
+/// plugin. It takes two arguments
 /// - `type`: The node/mark plugin that needs to add a view.
-/// - `view`: The factory that creates the view. It should return a function that returns a [node/mark view constructor](https://prosemirror.net/docs/ref/#view.NodeView).
+/// - `view`: The factory that creates the view. It should return a function
+///   that returns a
+///   [node/mark view constructor](https://prosemirror.net/docs/ref/#view.NodeView).
 ///
 /// Additional property:
 /// - `view`: The view created.
@@ -70,7 +73,8 @@ export function $view<
   return <$View<T, V>>plugin
 }
 
-/// The async version for `$view`. You can use `await` in the factory when creating the view.
+/// The async version for `$view`. You can use `await` in the factory when
+/// creating the view.
 ///
 /// Additional property:
 /// - `view`: The view created.

--- a/packages/utils/src/composable/composed/$mark-schema.ts
+++ b/packages/utils/src/composable/composed/$mark-schema.ts
@@ -25,9 +25,8 @@ export type $MarkSchema<T extends string> = [
   ) => $MarkSchema<T>
 }
 
-/// Create a plugin for mark schema.
-/// The first parameter is the id of the mark schema.
-/// The second parameter is the function that returns the mark schema.
+/// Create a plugin for mark schema. The first parameter is the id of the mark
+/// schema. The second parameter is the function that returns the mark schema.
 ///
 /// The function will return a plugin with additional properties:
 /// - `id`: The id of the mark schema.
@@ -36,7 +35,8 @@ export type $MarkSchema<T extends string> = [
 /// - `mark`: The mark schema plugin.
 /// - `schema`: The mark schema.
 /// - `key`: The key of slice which contains the mark schema factory.
-/// - `extendSchema`: A function witch will return a plugin that can extend the mark schema.
+/// - `extendSchema`: A function witch will return a plugin that can extend the
+///   mark schema.
 export function $markSchema<T extends string>(
   id: T,
   schema: GetMarkSchema

--- a/packages/utils/src/composable/composed/$node-schema.spec.ts
+++ b/packages/utils/src/composable/composed/$node-schema.spec.ts
@@ -232,7 +232,7 @@ test('should can register extended schema only', async () => {
   expect(extended2.node.schema.atom).toBe(true)
   expect(extended2.node.schema.defining).toBe(true)
 
-  // this schema is not registered, so it should be undefined
+  // An unregistered schema resolves to undefined.
   expect(extended.node.schema).toBe(undefined)
 
   const schema = editor.ctx.get(schemaCtx)

--- a/packages/utils/src/composable/composed/$node-schema.ts
+++ b/packages/utils/src/composable/composed/$node-schema.ts
@@ -25,9 +25,8 @@ export type $NodeSchema<T extends string> = [
   ) => $NodeSchema<T>
 }
 
-/// Create a plugin for node schema.
-/// The first parameter is the id of the node schema.
-/// The second parameter is the function that returns the node schema.
+/// Create a plugin for node schema. The first parameter is the id of the node
+/// schema. The second parameter is the function that returns the node schema.
 ///
 /// The function will return a plugin with additional properties:
 /// - `id`: The id of the node schema.
@@ -36,7 +35,8 @@ export type $NodeSchema<T extends string> = [
 /// - `node`: The node schema plugin.
 /// - `schema`: The node schema.
 /// - `key`: The key of slice which contains the node schema factory.
-/// - `extendSchema`: A function witch will return a plugin that can extend the node schema.
+/// - `extendSchema`: A function witch will return a plugin that can extend the
+///   node schema.
 export function $nodeSchema<T extends string>(
   id: T,
   schema: GetNodeSchema

--- a/packages/utils/src/composable/composed/$remark.ts
+++ b/packages/utils/src/composable/composed/$remark.ts
@@ -17,8 +17,10 @@ export type $Remark<Id extends string, Options> = [
   options: $Ctx<Options, Id>
 }
 
-/// Create a milkdown wrapper for [remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md).
-/// It takes a factory function which returns a [remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md).
+/// Create a milkdown wrapper for
+/// [remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md).
+/// It takes a factory function which returns a
+/// [remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md).
 ///
 /// Additional property:
 /// - `id`: The id of the remark plugin.

--- a/packages/utils/src/composable/composed/$use-keymap.ts
+++ b/packages/utils/src/composable/composed/$use-keymap.ts
@@ -37,10 +37,10 @@ export type $UserKeymap<N extends string, Key extends string> = [
   shortcuts: $Shortcut
 }
 
-/// Create a keymap which can be customized by user.
-/// It takes two arguments:
+/// Create a keymap which can be customized by user. It takes two arguments:
 /// - `name`: The name of the keymap.
-/// - `userKeymap`: The keymap config which contains the shortcuts and the command.
+/// - `userKeymap`: The keymap config which contains the shortcuts and the
+///   command.
 export function $useKeymap<N extends string, Key extends string>(
   name: N,
   userKeymap: UserKeymapConfig<Key>

--- a/packages/utils/src/macro/get-markdown.ts
+++ b/packages/utils/src/macro/get-markdown.ts
@@ -2,9 +2,9 @@ import type { Ctx } from '@milkdown/ctx'
 
 import { editorViewCtx, schemaCtx, serializerCtx } from '@milkdown/core'
 
-/// Get content of the editor as markdown string.
-/// If range is provided, it will return the markdown string of the range.
-/// If range is not provided, it will return the markdown string of the whole document.
+/// Get content of the editor as markdown string. If range is provided, it will
+/// return the markdown string of the range. If range is not provided, it will
+/// return the markdown string of the whole document.
 export function getMarkdown(range?: { from: number; to: number }) {
   return (ctx: Ctx): string => {
     const view = ctx.get(editorViewCtx)

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -11,12 +11,12 @@ const config: StorybookConfig = {
       },
     },
   },
-  // Storybook's vite builder doesn't honor `server.proxy` from the user
-  // vite.config.mts — it manages the dev server itself. The AI provider
-  // demos rely on these proxies to dodge CORS (browser → provider direct
-  // calls fail because OpenAI doesn't send ACAO headers and Anthropic's
-  // allow-list is finicky). Both Authorization and x-api-key headers
-  // are forwarded by Vite's http-proxy as-is.
+  // The Storybook vite builder manages the dev server itself and
+  // ignores `server.proxy` from the user vite.config.mts. The AI
+  // provider demos need these proxies to dodge CORS, because a direct
+  // browser call fails: OpenAI sends no ACAO header, and the Anthropic
+  // allow-list is strict. The Vite http-proxy forwards both the
+  // Authorization header and the x-api-key header unchanged.
   async viteFinal(viteConfig) {
     viteConfig.server = {
       ...viteConfig.server,

--- a/storybook/stories/crepe/setup.ts
+++ b/storybook/stories/crepe/setup.ts
@@ -16,10 +16,10 @@ export interface Args {
   enableTopBar: boolean
   enableAI: boolean
   language: 'EN' | 'JA'
-  /// AI demo only — selects which built-in provider to construct when
+  /// AI demo only. It selects the built-in provider to construct when
   /// the user enters a key in the BYOK banner.
   aiProvider: 'openai' | 'anthropic'
-  /// AI demo only — model id passed to the chosen provider.
+  /// AI demo only. The model id passed to the chosen provider.
   aiModel: string
 }
 
@@ -231,12 +231,11 @@ const aiDemoBannerStyle = `
 .byok-hint { font-size: 12px; color: #6b7280; font-style: italic; }
 `
 
-/// Per-provider fallback used when the `aiModel` arg is empty.
-/// Storybook controls can't react to `aiProvider` changes by also
-/// updating `aiModel`, so when no explicit model is set we pick a
-/// sensible default for the chosen provider — this prevents the
-/// demo from sending an OpenAI model id to Anthropic (or vice versa)
-/// after toggling the provider radio.
+/// The per-provider fallback for an empty `aiModel` arg. A Storybook
+/// control cannot update `aiModel` in reaction to an `aiProvider`
+/// change, so an unset model falls back to the default of the chosen
+/// provider. The demo then never sends an OpenAI model id to Anthropic
+/// after a toggle of the provider radio.
 export const DEFAULT_MODEL_FOR_PROVIDER: Record<Args['aiProvider'], string> = {
   openai: 'gpt-4o-mini',
   anthropic: 'claude-sonnet-4-5',
@@ -247,11 +246,12 @@ function resolveModel(args: Args): string {
 }
 
 function buildProvider(args: Args, apiKey: string): AIProvider {
-  // Route through the storybook dev server's vite proxy (configured in
-  // storybook/.storybook/main.ts via `viteFinal` — Storybook's vite
-  // builder doesn't honor `server.proxy` in the user vite.config.mts)
-  // to dodge CORS. The proxy is dev-only — the deployed static
-  // storybook build will get 404s here.
+  // The request routes through the vite proxy of the storybook dev
+  // server, which dodges CORS. `viteFinal` in
+  // storybook/.storybook/main.ts configures that proxy, because the
+  // Storybook vite builder ignores `server.proxy` in the user
+  // vite.config.mts. The proxy runs in dev only, so the deployed static
+  // storybook build gets a 404 here.
   const model = resolveModel(args)
   if (args.aiProvider === 'anthropic') {
     return createAnthropicProvider({


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Comments in this repo drifted into a hard-to-read style: em-dash-joined clauses, long multi-clause sentences, and comments that only restate the line below them. This PR writes down a standard and brings every existing comment in line with it.

- **The standard**, in `CONTRIBUTING.md` and `.claude/skills/review-code-style/SKILL.md`. Existence: a comment states what the code cannot show, and never narrates the next line. Style: [ASD-STE100](https://www.asd-ste100.org/) — one idea per sentence, 25 words or fewer, active voice, no em dash, no first person, wrapped at 80 columns to match `printWidth`.
- **121 comment lines** that joined clauses with an em dash are re-punctuated into separate sentences.
- **38 lines** dropped the first person; every comment line past 80 columns is re-wrapped.
- **28 comments** that only restate the next line are deleted.
- `///` docs keep every fact they carried, since `builddocs` publishes them into `docs/api`.

Worth a closer look:

- `packages/components/src/diff/merge-changes.ts` — two stacked comment blocks said the same thing, the second superseding the first; merged into one.
- `packages/crepe/src/core/slice.ts` — the `useCrepeFeatures` example was missing its closing code fence, so the generated API docs swallowed the entry after it.
- `packages/ctx/src/timer/clock.ts` — `has()` had its doc comment written with `//` instead of `///`, so it never reached the docs.
- `packages/plugins/preset-gfm/src/plugin/keep-table-align-plugin.ts` and the two footnote nodes — vague TODOs now name a concrete action.

## How did you test this change?

The change is comment-only, and that is machine-checked rather than eyeballed: every touched file was compiled with comments stripped (esbuild, `minify: true`) before and after, and each pair is byte-identical — 145/145 files, 0 with code changes.

On top of that:

- `pnpm test:lint` — pass
- `pnpm exec oxfmt --check .` — pass
- `pnpm test:unit` — pass, 55 files / 470 tests
- `pnpm build:tsc` — pass
- `pnpm --filter=@milkdown/docs run build` — pass; spot-checked `docs/lib/plugin-history.md` and `docs/lib/utils.md` to confirm the re-wrapped links still render
