### PR TITLE
fix: cancel resolved timer timeouts

### DIFF
--- a/packages/ctx/src/timer/timer.spec.ts
+++ b/packages/ctx/src/timer/timer.spec.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { TimerType } from './timer'
 
 describe('timing/timing', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
   it('createTimer', async () => {
     const timerType = new TimerType('timer')
     const map = new Map()
@@ -25,5 +30,25 @@ describe('timing/timing', () => {
     await expect(timer.start()).rejects.toStrictEqual(
       new Error('Timing timer timeout.')
     )
+  })
+
+  it('cancels the timeout after resolving', async () => {
+    vi.useFakeTimers()
+    const removeEventListener = vi.spyOn(globalThis, 'removeEventListener')
+    const timerType = new TimerType('timer', 10)
+    const map = new Map()
+    const timer = timerType.create(map)
+
+    const result = timer.start()
+    timer.done()
+
+    await expect(result).resolves.toBeUndefined()
+    expect(removeEventListener).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(removeEventListener).toHaveBeenCalledOnce()
+    expect(timer.status).toBe('resolved')
   })
 })

--- a/packages/ctx/src/timer/timer.ts
+++ b/packages/ctx/src/timer/timer.ts
@@ -12,6 +12,8 @@ export class Timer {
   /// @internal
   #listener: EventListener | null = null
   /// @internal
+  #timeout: ReturnType<typeof setTimeout> | null = null
+  /// @internal
   readonly #eventUniqId: symbol
   /// @internal
   #status: TimerStatus = 'pending'
@@ -69,12 +71,20 @@ export class Timer {
 
   /// @internal
   #removeListener = () => {
-    if (this.#listener) removeEventListener(this.type.name, this.#listener)
+    if (this.#listener) {
+      removeEventListener(this.type.name, this.#listener)
+      this.#listener = null
+    }
+
+    if (this.#timeout !== null) {
+      clearTimeout(this.#timeout)
+      this.#timeout = null
+    }
   }
 
   /// @internal
   #waitTimeout = (ifTimeout: () => void) => {
-    setTimeout(() => {
+    this.#timeout = setTimeout(() => {
       ifTimeout()
     }, this.type.timeout)
   }


### PR DESCRIPTION
This PR was developed with Codex using GPT-6 Astra and went through several rounds of automated review. It resolves a real issue that I encountered while using this library.

- [x] I read the contributing guide.
- [x] I agree to follow the code of conduct.

## Summary

Resolved context timers leave timeout callbacks queued until their deadlines. This PR cancels those callbacks during listener cleanup, releasing resources and preventing callbacks from running after teardown.

## How did you test this change?

`pnpm test:unit --maxWorkers=2` passes all 471 tests. `pnpm build:tsc` and `pnpm test:lint --threads 2` pass. The new fake-timer regression fails without the fix.
