### PR TITLE
fix(components): preserve pointer events on non-task list markers

### DIFF
--- a/packages/components/src/list-item-block/__tests__/list-item.marker-pointerdown.spec.tsx
+++ b/packages/components/src/list-item-block/__tests__/list-item.marker-pointerdown.spec.tsx
@@ -1,0 +1,84 @@
+import { render } from '@testing-library/vue'
+import { expect, test, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { ListItemBlockConfig } from '../config'
+
+import { ListItem } from '../component'
+
+// Only task checkboxes consume pointer events; other markers allow selection.
+
+const config: ListItemBlockConfig = {
+  renderLabel: ({ label, listType, checked }) => {
+    if (checked == null) return listType === 'bullet' ? '<svg />' : label
+    return checked ? '<svg data-checked />' : '<svg data-unchecked />'
+  },
+}
+
+function renderListItem(attrs: {
+  label?: string
+  listType?: string
+  checked?: boolean | null
+}) {
+  const setAttr = vi.fn()
+  const { container } = render(ListItem, {
+    props: {
+      label: ref(attrs.label ?? ''),
+      checked: ref(attrs.checked ?? null),
+      listType: ref(attrs.listType ?? 'bullet'),
+      readonly: ref(false),
+      selected: ref(false),
+      config,
+      setAttr,
+      onMount: () => {},
+    },
+  })
+  const label = container.querySelector('.label-wrapper .milkdown-icon')
+  expect(label).toBeTruthy()
+  const onPointerDown = vi.fn()
+  container.addEventListener('pointerdown', onPointerDown)
+  return { label: label!, setAttr, onPointerDown }
+}
+
+function pressAndReportCancellation(target: Element) {
+  const event = new Event('pointerdown', { bubbles: true, cancelable: true })
+  target.dispatchEvent(event)
+  return event.defaultPrevented
+}
+
+test('pressing a bullet marker leaves the event alone', () => {
+  const { label, setAttr, onPointerDown } = renderListItem({
+    listType: 'bullet',
+    checked: null,
+  })
+
+  expect(pressAndReportCancellation(label)).toBe(false)
+  expect(setAttr).not.toHaveBeenCalled()
+  expect(onPointerDown).toHaveBeenCalledOnce()
+})
+
+test('pressing an ordered marker leaves the event alone', () => {
+  const { label, setAttr, onPointerDown } = renderListItem({
+    listType: 'ordered',
+    label: '1.',
+    checked: null,
+  })
+
+  expect(pressAndReportCancellation(label)).toBe(false)
+  expect(setAttr).not.toHaveBeenCalled()
+  expect(onPointerDown).toHaveBeenCalledOnce()
+})
+
+test.each([false, true])(
+  'pressing a task checkbox (%s) consumes the event and toggles it',
+  (checked) => {
+    const { label, setAttr, onPointerDown } = renderListItem({
+      listType: 'bullet',
+      checked,
+    })
+
+    expect(pressAndReportCancellation(label)).toBe(true)
+    expect(setAttr).toHaveBeenCalledExactlyOnceWith('checked', !checked)
+    expect(onPointerDown).not.toHaveBeenCalled()
+  }
+)

--- a/packages/components/src/list-item-block/component.tsx
+++ b/packages/components/src/list-item-block/component.tsx
@@ -10,7 +10,8 @@ keepAlive(h)
 
 interface Attrs {
   label: string
-  checked: boolean
+  // Non-task items use the schema's null default.
+  checked: boolean | null
   listType: string
 }
 
@@ -77,10 +78,12 @@ export const ListItem = defineComponent<ListItemProps>({
     }
 
     const onClickLabel = (e: Event) => {
+      // Non-interactive markers must allow native selection handling.
+      if (checked.value == null) return
+
       e.stopPropagation()
       e.preventDefault()
 
-      if (checked.value == null) return
       setAttr('checked', !checked.value)
     }
 

--- a/packages/components/src/list-item-block/config.ts
+++ b/packages/components/src/list-item-block/config.ts
@@ -6,7 +6,7 @@ interface RenderLabelProps {
   label: string
   listType: string
   readonly?: boolean
-  checked?: boolean
+  checked?: boolean | null
 }
 
 export interface ListItemBlockConfig {


### PR DESCRIPTION
This PR was developed with Codex using GPT-6 Astra and went through several rounds of automated review. It resolves a real issue that I encountered while using this library.

- [x] I read the contributing guide.
- [x] I agree to follow the code of conduct.

## Summary

Bullet and ordered-list markers cancel pointer events despite having no checkbox to toggle. This PR leaves those events available for selection handling while preserving task-checkbox toggling.

## How did you test this change?

`pnpm test:unit --maxWorkers=2` passes all 474 tests. `pnpm build:tsc` and `pnpm test:lint --threads 2` pass. The new component tests cover propagation, cancellation and both checkbox states; the two non-task cases fail without the fix.
