### PR TITLE
fix(ctx): clear the timeout when a timer settles

### DIFF
--- a/.changeset/fix-timer-clears-its-timeout.md
+++ b/.changeset/fix-timer-clears-its-timeout.md
@@ -1,0 +1,5 @@
+---
+'@milkdown/ctx': patch
+---
+
+Clear a timer's timeout when the timer settles, so it cannot fire after an editor is destroyed.

--- a/packages/ctx/src/timer/timer.spec.ts
+++ b/packages/ctx/src/timer/timer.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { TimerType } from './timer'
 
@@ -25,5 +25,23 @@ describe('timing/timing', () => {
     await expect(timer.start()).rejects.toStrictEqual(
       new Error('Timing timer timeout.')
     )
+  })
+
+  it('clears its timeout once resolved', async () => {
+    // A resolved timer must not leave its rejection timeout armed. That
+    // callback calls the global removeEventListener. The call fails after a
+    // test environment tears the globals down.
+    vi.useFakeTimers()
+    try {
+      const timerType = new TimerType('timer', 3000)
+      const timer = timerType.create(new Map())
+      const started = timer.start()
+      timer.done()
+      await started
+
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/ctx/src/timer/timer.ts
+++ b/packages/ctx/src/timer/timer.ts
@@ -15,6 +15,8 @@ export class Timer {
   readonly #eventUniqId: symbol
   /// @internal
   #status: TimerStatus = 'pending'
+  /// @internal
+  #timeoutId: ReturnType<typeof setTimeout> | null = null
 
   /// @internal
   constructor(clock: TimerMap, type: TimerType) {
@@ -69,12 +71,17 @@ export class Timer {
 
   /// @internal
   #removeListener = () => {
+    if (this.#timeoutId !== null) {
+      clearTimeout(this.#timeoutId)
+      this.#timeoutId = null
+    }
     if (this.#listener) removeEventListener(this.type.name, this.#listener)
   }
 
   /// @internal
   #waitTimeout = (ifTimeout: () => void) => {
-    setTimeout(() => {
+    this.#timeoutId = setTimeout(() => {
+      this.#timeoutId = null
       ifTimeout()
     }, this.type.timeout)
   }


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

`Timer` arms a `setTimeout` when a slice starts to wait, and never clears it. The timer keeps that timeout for its full duration after it resolves, and the callback calls the global `removeEventListener`.

A test environment that tears the globals down before the callback runs turns that into `ReferenceError: removeEventListener is not defined`. The error belongs to no test, so vitest reports an unhandled error and exits non-zero with every test green:

```
 Test Files  30 passed (30)
      Tests  480 passed (480)
     Errors  1 error
ERROR: Job failed: exit code 1
```

```
Uncaught Exception
ReferenceError: removeEventListener is not defined
 ❯ Timer.#removeListener node_modules/@milkdown/ctx/src/timer/timer.ts:72:25
 ❯ node_modules/@milkdown/ctx/src/timer/timer.ts:51:14
 ❯ Timeout._onTimeout node_modules/@milkdown/ctx/src/timer/timer.ts:78:7
```

One editor arms about ten of these, one per timing slice, and each survives `editor.destroy()`. A suite that builds many editors leaves hundreds of live timeouts behind it, so whether a run ends cleanly depends on how the last file’s teardown races a 3s timer. It is also hard to attribute: the error points at whichever test file happened to be last, not at anything that file did.

The fix holds the timeout id and clears it in `#removeListener`, which already runs on both the resolve path and the reject path.

## How did you test this change?

`pnpm test:unit`, `pnpm test:lint` and `pnpm build:tsc` all pass on this branch (55 files, 471 tests).

A regression test in `packages/ctx/src/timer/timer.spec.ts` pins it: resolve a timer under fake timers, then assert `vi.getTimerCount()` is 0. It fails on `main` with `expected 1 to be +0`, and passes here.

Measured outside this repo too, in the app where it surfaced. Wrapping `setTimeout` so that callbacks which actually fire are counted, then waiting past the three seconds, gives **10 timeouts fired per editor after `editor.destroy()` returned** before the change, and **0** after it.

I did not add a test for the reject path. The timeout has already fired by then, so the assertion holds with or without this change.
